### PR TITLE
feat: add permission relay support (by @SamSchimek) with block kit support for approvals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@anthropic/claude-channel-slack",
@@ -7,6 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@slack/socket-mode": "^2.0.0",
         "@slack/web-api": "^7.0.0",
+        "zod": "^3.24.0",
       },
       "devDependencies": {
         "@types/bun": "^1.0.0",
@@ -251,9 +253,11 @@
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@slack/socket-mode": "^2.0.0",
-    "@slack/web-api": "^7.0.0"
+    "@slack/web-api": "^7.0.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/bun": "^1.0.0",

--- a/server.ts
+++ b/server.ts
@@ -546,6 +546,28 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 // Permission relay — forward tool approval prompts to Slack
 // ---------------------------------------------------------------------------
 
+// Track pending permission request details for "See more" button expansion.
+// Each entry includes a timestamp for TTL-based cleanup (5-minute expiry).
+const PERM_TTL_MS = 5 * 60 * 1000
+const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; createdAt: number }>()
+
+function pruneStalePermissions(): void {
+  const cutoff = Date.now() - PERM_TTL_MS
+  for (const [id, entry] of pendingPermissions) {
+    if (entry.createdAt < cutoff) pendingPermissions.delete(id)
+  }
+}
+
+/** Escape Slack mrkdwn special characters to prevent injection. */
+function escMrkdwn(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+// Type assertion avoids TS2589 (excessively deep type instantiation) caused
+// by zod inference interacting with the MCP SDK's generic signature.
 const PermissionRequestSchema = z.object({
   method: z.literal('notifications/claude/channel/permission_request'),
   params: z.object({
@@ -554,27 +576,224 @@ const PermissionRequestSchema = z.object({
     description: z.string(),
     input_preview: z.string(),
   }),
-})
+}) as any
 
-mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }) => {
+// Claude Code generates request_id as exactly 5 lowercase letters from a-z
+// minus 'l'. Validate before using in action_ids (Slack limits to 255 chars).
+const VALID_REQUEST_ID = /^[a-km-z]{5}$/
+
+mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params: { request_id: string; tool_name: string; description: string; input_preview: string } }) => {
+  // Validate request_id format to prevent malformed action_ids
+  if (!VALID_REQUEST_ID.test(params.request_id)) return
+
   // Find where to post — last active channel, or first opted-in channel
   const access = getAccess()
   const targetChannel = lastActiveChannel || Object.keys(access.channels || {})[0]
   if (!targetChannel) return
 
+  // Outbound gate: only post to channels that have been validated
+  try {
+    assertOutboundAllowed(targetChannel)
+  } catch {
+    return
+  }
+
+  pruneStalePermissions()
+  pendingPermissions.set(params.request_id, {
+    tool_name: params.tool_name,
+    description: params.description,
+    input_preview: params.input_preview,
+    createdAt: Date.now(),
+  })
+
+  const safeTool = escMrkdwn(params.tool_name)
+  const safeDesc = escMrkdwn(params.description)
+
+  // Post Block Kit message with interactive buttons
   await web.chat.postMessage({
     channel: targetChannel,
-    text:
-      `🟡 *${params.tool_name}*: ${params.description}\n` +
-      `Reply \`y ${params.request_id}\` or \`n ${params.request_id}\``,
+    // Fallback text for notifications and clients that don't support blocks
+    text: `Claude wants to run ${safeTool}: ${safeDesc} — reply \`y ${params.request_id}\` or \`n ${params.request_id}\``,
     thread_ts: lastActiveThread,
     unfurl_links: false,
     unfurl_media: false,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `🟡 *Claude wants to run \`${safeTool}\`*\n${safeDesc}`,
+        },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '✅ Allow' },
+            style: 'primary',
+            action_id: `perm:allow:${params.request_id}`,
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '❌ Deny' },
+            style: 'danger',
+            action_id: `perm:deny:${params.request_id}`,
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '🔍 Details' },
+            action_id: `perm:more:${params.request_id}`,
+          },
+        ],
+      },
+    ],
   })
 })
 
-// Regex for permission replies: "yes abcde" or "no abcde"
-// ID alphabet is lowercase a-z minus 'l', /i tolerates phone autocorrect
+// Handle Block Kit button interactions (delivered via Socket Mode)
+socket.on('interactive', async ({ body, ack }: { body: any; ack: () => Promise<void> }) => {
+  try {
+    await ack()
+    if (body?.type !== 'block_actions' || !body.actions?.length) return
+
+    const action = body.actions[0]
+    const actionId: string = action.action_id || ''
+    const match = actionId.match(/^perm:(allow|deny|more):(.+)$/)
+    if (!match) return
+
+    const [, verb, requestId] = match
+    const userId: string = body.user?.id || ''
+
+    // Only allowlisted users (session owner) can respond to permission prompts
+    const access = getAccess()
+    if (!access.allowFrom.includes(userId)) {
+      // Ephemeral message visible only to the clicking user
+      try {
+        await web.chat.postEphemeral({
+          channel: body.channel?.id || '',
+          user: userId,
+          text: 'Only the session owner can approve or deny tool calls.',
+        })
+      } catch { /* non-critical */ }
+      return
+    }
+
+    const channelId: string = body.channel?.id || ''
+    const messageTs: string = body.message?.ts || ''
+
+    if (verb === 'more') {
+      // Expand details — update the message to include input_preview
+      const details = pendingPermissions.get(requestId)
+      if (!details || !channelId || !messageTs) return
+
+      // Use plain_text to prevent mrkdwn injection from tool input.
+      // Truncate to stay within Slack's 3000-char text object limit.
+      const MAX_PREVIEW = 2900
+      const previewText = details.input_preview
+        ? details.input_preview.length > MAX_PREVIEW
+          ? details.input_preview.slice(0, MAX_PREVIEW) + '…'
+          : details.input_preview
+        : 'No preview available'
+
+      const safeTool = escMrkdwn(details.tool_name)
+      const safeDesc = escMrkdwn(details.description)
+
+      try {
+        await web.chat.update({
+          channel: channelId,
+          ts: messageTs,
+          text: `Claude wants to run ${safeTool}: ${safeDesc}`,
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `🟡 *Claude wants to run \`${safeTool}\`*\n${safeDesc}`,
+              },
+            },
+            {
+              type: 'context',
+              elements: [{ type: 'plain_text', text: previewText }],
+            },
+            {
+              type: 'actions',
+              elements: [
+                {
+                  type: 'button',
+                  text: { type: 'plain_text', text: '✅ Allow' },
+                  style: 'primary',
+                  action_id: `perm:allow:${requestId}`,
+                },
+                {
+                  type: 'button',
+                  text: { type: 'plain_text', text: '❌ Deny' },
+                  style: 'danger',
+                  action_id: `perm:deny:${requestId}`,
+                },
+              ],
+            },
+          ],
+        })
+      } catch { /* non-critical — Slack API rejection won't block the session */ }
+      return
+    }
+
+    // Allow or Deny — send verdict to Claude Code
+    const details = pendingPermissions.get(requestId)
+    if (!details) {
+      // Already resolved (by button or text reply) — update message and bail
+      if (channelId && messageTs) {
+        try {
+          await web.chat.update({
+            channel: channelId,
+            ts: messageTs,
+            text: 'Already resolved',
+            blocks: [{ type: 'section', text: { type: 'mrkdwn', text: '⚪ Already resolved' } }],
+          })
+        } catch { /* non-critical */ }
+      }
+      return
+    }
+
+    const behavior = verb === 'allow' ? 'allow' : 'deny'
+    const verdict = behavior === 'allow' ? 'allowed' : 'denied'
+    const safeTool = escMrkdwn(details.tool_name)
+    pendingPermissions.delete(requestId)
+
+    await mcp.notification({
+      method: 'notifications/claude/channel/permission',
+      params: { request_id: requestId, behavior },
+    })
+
+    // Update message to show outcome (remove buttons)
+    if (channelId && messageTs) {
+      const emoji = behavior === 'allow' ? '✅' : '❌'
+      try {
+        await web.chat.update({
+          channel: channelId,
+          ts: messageTs,
+          text: `${emoji} ${safeTool} — ${verdict}`,
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `${emoji} *\`${safeTool}\`* — ${verdict} by <@${userId}>`,
+              },
+            },
+          ],
+        })
+      } catch { /* non-critical */ }
+    }
+  } catch (err) {
+    console.error('[slack] Error handling interactive event:', err)
+  }
+})
+
+// Regex for text-based permission replies: "yes abcde" or "no abcde"
+// Claude Code generates request_id as exactly 5 lowercase letters from a-z
+// minus 'l'. The /i flag tolerates phone autocorrect capitalization.
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 
 // ---------------------------------------------------------------------------
@@ -617,14 +836,30 @@ async function handleMessage(event: unknown): Promise<void> {
       const msgText = ((ev['text'] as string) || '').trim()
       const permMatch = PERMISSION_REPLY_RE.exec(msgText)
       if (permMatch) {
+        const requestId = permMatch[2].toLowerCase()
+
+        // Skip if already resolved (e.g. by a button click)
+        if (!pendingPermissions.has(requestId)) {
+          // Still ack so the user knows the message was seen
+          try {
+            await web.reactions.add({
+              channel: channelId,
+              timestamp: ev['ts'] as string,
+              name: 'heavy_multiplication_x',
+            })
+          } catch { /* non-critical */ }
+          return
+        }
+
+        pendingPermissions.delete(requestId)
         await mcp.notification({
           method: 'notifications/claude/channel/permission',
           params: {
-            request_id: permMatch[2].toLowerCase(),
+            request_id: requestId,
             behavior: permMatch[1].toLowerCase().startsWith('y') ? 'allow' : 'deny',
           },
         })
-        // Ack with a reaction so Sam knows it was processed
+        // Ack with a reaction so the sender knows it was processed
         try {
           await web.reactions.add({
             channel: channelId,

--- a/server.ts
+++ b/server.ts
@@ -14,6 +14,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
 import { SocketModeClient } from '@slack/socket-mode'
 import { WebClient } from '@slack/web-api'
 import { homedir } from 'os'
@@ -176,6 +177,10 @@ function assertSendable(filePath: string): void {
 // Track channels that passed inbound gate (session-lifetime cache)
 const deliveredChannels = new Set<string>()
 
+// Track last active channel/thread for permission relay
+let lastActiveChannel = ''
+let lastActiveThread: string | undefined
+
 function assertOutboundAllowed(chatId: string): void {
   libAssertOutboundAllowed(chatId, getAccess(), deliveredChannels)
 }
@@ -223,7 +228,10 @@ const mcp = new Server(
   { name: 'slack', version: '0.1.0' },
   {
     capabilities: {
-      experimental: { 'claude/channel': {} },
+      experimental: {
+        'claude/channel': {},
+        'claude/channel/permission': {},
+      },
       tools: {},
     },
     instructions: [
@@ -535,6 +543,41 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 })
 
 // ---------------------------------------------------------------------------
+// Permission relay — forward tool approval prompts to Slack
+// ---------------------------------------------------------------------------
+
+const PermissionRequestSchema = z.object({
+  method: z.literal('notifications/claude/channel/permission_request'),
+  params: z.object({
+    request_id: z.string(),
+    tool_name: z.string(),
+    description: z.string(),
+    input_preview: z.string(),
+  }),
+})
+
+mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }) => {
+  // Find where to post — last active channel, or first opted-in channel
+  const access = getAccess()
+  const targetChannel = lastActiveChannel || Object.keys(access.channels || {})[0]
+  if (!targetChannel) return
+
+  await web.chat.postMessage({
+    channel: targetChannel,
+    text:
+      `🟡 *${params.tool_name}*: ${params.description}\n` +
+      `Reply \`y ${params.request_id}\` or \`n ${params.request_id}\``,
+    thread_ts: lastActiveThread,
+    unfurl_links: false,
+    unfurl_media: false,
+  })
+})
+
+// Regex for permission replies: "yes abcde" or "no abcde"
+// ID alphabet is lowercase a-z minus 'l', /i tolerates phone autocorrect
+const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
+
+// ---------------------------------------------------------------------------
 // Inbound message handler
 // ---------------------------------------------------------------------------
 
@@ -563,7 +606,34 @@ async function handleMessage(event: unknown): Promise<void> {
 
     case 'deliver': {
       // Track this channel as delivered (for outbound gate)
-      deliveredChannels.add(ev['channel'] as string)
+      const channelId = ev['channel'] as string
+      deliveredChannels.add(channelId)
+
+      // Track last active channel for permission relay
+      lastActiveChannel = channelId
+      lastActiveThread = ev['thread_ts'] as string | undefined
+
+      // Check for permission reply before normal delivery
+      const msgText = ((ev['text'] as string) || '').trim()
+      const permMatch = PERMISSION_REPLY_RE.exec(msgText)
+      if (permMatch) {
+        await mcp.notification({
+          method: 'notifications/claude/channel/permission',
+          params: {
+            request_id: permMatch[2].toLowerCase(),
+            behavior: permMatch[1].toLowerCase().startsWith('y') ? 'allow' : 'deny',
+          },
+        })
+        // Ack with a reaction so Sam knows it was processed
+        try {
+          await web.reactions.add({
+            channel: channelId,
+            timestamp: ev['ts'] as string,
+            name: 'white_check_mark',
+          })
+        } catch { /* non-critical */ }
+        return // Don't forward as chat
+      }
 
       const access = result.access!
       const userName = await resolveUserName(ev['user'] as string)


### PR DESCRIPTION
# Summary

Extends the permission relay from #3 with Slack Block Kit interactive buttons, so users can tap Allow/Deny on their phone instead of typing y abcde.

Built on top of @SamSchimek's #3 — includes his permission relay commit as the base.

# Block Kit buttons

 - Allow (green), Deny (red), Details buttons rendered via Block Kit
 - Details expands input_preview as plain_text to prevent mrkdwn injection
 - Messages update in-place to show outcome and remove buttons
 - Non-owner button clicks get ephemeral rejection: "Only the session owner can approve or deny tool calls"

# Security hardening (addresses qodo review on #3)

 - Outbound gate enforced on permission relay messages (#3 review item 1)
 - zod added as explicit dependency (#3 review item 2)
 - request_id format validated before use in action_id fields
 - tool_name / description escaped to prevent mrkdwn injection
 - Duplicate verdict guard on both button and text paths

# Other fixes

 - Fix TS2589 type recursion between zod and MCP SDK generics (typecheck now passes)
 - Fix "denyed" → "denied" typo
 - Add try/catch on interactive handler (matches message/app_mention pattern)
 - TTL-based cleanup for pendingPermissions map (5-min expiry)

# Slack App requirement

Interactivity must be enabled in app settings for buttons to work. Socket Mode delivers interaction payloads — no public URL needed.

# Known limitation

When a permission prompt is resolved from the terminal (not via Slack), the Block Kit buttons remain in Slack. Clicking them shows "Already resolved." A permission_resolved notification in the channels protocol would fix this, but that's an upstream change -- in Claude Code.

# Test plan

- bun test — 52 tests pass, no regressions
- bun run typecheck — passes clean
- End-to-end: permission prompt renders buttons in Slack
- Allow button delivers verdict, message updates
- Deny button delivers verdict, message updates
- Details button expands input_preview as plain_text
- Non-owner click shows ephemeral rejection
- Text-based y/n <code> fallback works
- Terminal approval works in parallel with Slack buttons
- Duplicate click shows "Already resolved"

 Co-Authored-By: Sam Schimek sam@backyard.chat
 Co-Authored-By: Claude Opus 4.6 (1M context) noreply@anthropic.com