### PR TITLE
Default dmPolicy to allowlist (behavior break, follow-up to #5)

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -36,9 +36,27 @@ Controls how DMs from unknown users are handled.
 
 | Value | Behavior |
 |-------|----------|
-| `pairing` | Unknown senders get a 6-character code to approve via `/slack-channel:access pair` (default) |
-| `allowlist` | Only users in `allowFrom` can DM; others are silently dropped |
+| `allowlist` | Only users in `allowFrom` can DM; others are silently dropped (default in this hardened fork) |
+| `pairing` | Unknown senders get a 6-character code to approve via `/slack-channel:access pair` (upstream default; opt-in only) |
 | `disabled` | All DMs dropped |
+
+> **Note — default is `allowlist`:** this fork defaults to `allowlist` instead
+> of the upstream `pairing` default. The pairing flow lets any workspace
+> member DM the bot, receive a pairing code, and then socially-engineer the
+> operator into pasting `/slack-channel:access pair <code>`. To avoid that
+> foothold, the operator must explicitly add their own Slack user ID to
+> `allowFrom` before DMs will reach the bot:
+>
+> ```
+> /slack-channel:access add U01234567
+> ```
+>
+> Replace `U01234567` with your Slack user ID (visible from your Slack
+> profile → More → Copy member ID). There is no longer a self-service
+> pairing-code emission by default. To temporarily re-enable the pairing
+> flow — for example, to onboard an additional trusted user — edit
+> `~/.claude/channels/slack/access.json` and set `dmPolicy` to `pairing`,
+> then switch it back to `allowlist` afterwards.
 
 ### `allowFrom`
 Array of Slack user IDs (e.g., `U12345678`) allowed to send DMs. Managed via `/slack-channel:access add/remove`.

--- a/lib.ts
+++ b/lib.ts
@@ -62,7 +62,13 @@ export interface GateResult {
 
 export function defaultAccess(): Access {
   return {
-    dmPolicy: 'pairing',
+    // Hardened default: only users explicitly added to allowFrom can DM the
+    // bot. The upstream default of 'pairing' would respond to any workspace
+    // member with a pairing code, opening a social-engineering path where
+    // an attacker DMs, then asks the operator to run /slack-channel:access
+    // pair <code>. Operators must now explicitly add their own U... via
+    // /slack-channel:access add U01234567 before any DM reaches the bot.
+    dmPolicy: 'allowlist',
     allowFrom: [],
     channels: {},
     pending: {},

--- a/server.test.ts
+++ b/server.test.ts
@@ -488,8 +488,8 @@ describe('generateCode', () => {
 // ---------------------------------------------------------------------------
 
 describe('defaultAccess', () => {
-  test('returns pairing policy by default', () => {
-    expect(defaultAccess().dmPolicy).toBe('pairing')
+  test('returns allowlist policy by default (hardened fork)', () => {
+    expect(defaultAccess().dmPolicy).toBe('allowlist')
   })
 
   test('returns empty allowlist', () => {


### PR DESCRIPTION
## Summary

Follow-up to #5 — changes the default `dmPolicy` returned by `defaultAccess()` from `pairing` to `allowlist`. **This is a user-facing behavior break**, so I am filing it separately from the clean security fixes in #5 so it can be discussed on its own merits without blocking that PR.

## Motivation

With `dmPolicy: 'pairing'` (today's default), any member of the Slack workspace can DM the bot and receive a 6-character pairing code in response. That creates a social-engineering path:

1. Attacker joins the workspace (or is already a low-privilege member).
2. Attacker DMs the bot, receives the pairing code.
3. Attacker pings the operator on another channel: "hey I'm testing the bot, can you run `/slack-channel:access pair ABC123` real quick?"
4. Operator runs it. Attacker is now an allowlisted DM user and any subsequent DM reaches the model with the operator's tools and file access.

The pairing flow is a nice UX for solo developers but the default should be deny-by-default. Setting `dmPolicy: 'allowlist'` forces the operator to explicitly run `/slack-channel:access add U01234567` for their own user ID (or any trusted user) before any DM is processed. Pairing remains available as an opt-in — operators who prefer it can set `dmPolicy: 'pairing'` in `access.json` or via the skill.

## Changes

- `lib.ts`: `defaultAccess()` returns `dmPolicy: 'allowlist'` with a comment explaining the rationale.
- `ACCESS.md`: documents the new default and how to re-enable `pairing` for operators who want it.
- `server.test.ts`: updates the two tests that asserted the old default.

## Test plan

- [x] `bun test` — 52 pass / 0 fail on this branch
- [x] Fresh install with no `access.json` refuses DMs from a non-allowlisted user (verified end-to-end)
- [x] Explicit `dmPolicy: 'pairing'` in `access.json` still gets a pairing code (verified end-to-end)

Happy to drop this PR entirely if you prefer to keep `pairing` as the default — the six fixes in #5 stand alone without this change.