### PR TITLE
fix: dedupe duplicate event delivery from message + app_mention

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -454,3 +454,51 @@ function isMentioned(event: Record<string, unknown>, botUserId: string): boolean
   const text = (event['text'] as string | undefined) || ''
   return text.includes(`<@${botUserId}>`)
 }
+
+// ---------------------------------------------------------------------------
+// Event deduplication
+// ---------------------------------------------------------------------------
+
+/** How long a seen (channel, ts) pair stays in the dedup cache. */
+export const EVENT_DEDUP_TTL_MS = 60_000
+
+/**
+ * Detect and record a duplicate Slack event.
+ *
+ * Slack subscribes bots to both `message` and `app_mention` events. A channel
+ * message that @-mentions the bot arrives via BOTH subscriptions, so the
+ * server's handler runs twice for the same Slack message. This also protects
+ * against Slack's own event redelivery when an ack is slow or missed.
+ *
+ * Dedup key is (channel, ts) — Slack's own unique identifier for a message.
+ *
+ * Mutates `seen` in place: prunes expired entries on every call, then
+ * records this event with expiry at `now + ttlMs`. Returns true when the
+ * event was already recorded within the window (caller should skip).
+ * Events without both channel and ts can't be deduped and are treated as
+ * first-time (returns false).
+ */
+export function isDuplicateEvent(
+  event: Record<string, unknown>,
+  seen: Map<string, number>,
+  now: number,
+  ttlMs: number,
+): boolean {
+  // Prune expired on every check. Cheap in practice — TTL is short and
+  // the Map only holds a few minutes of event history.
+  for (const [key, expiresAt] of seen) {
+    if (expiresAt <= now) seen.delete(key)
+  }
+
+  const channel = event['channel']
+  const ts = event['ts']
+  if (typeof channel !== 'string' || typeof ts !== 'string') {
+    return false
+  }
+
+  const key = `${channel}:${ts}`
+  if (seen.has(key)) return true
+
+  seen.set(key, now + ttlMs)
+  return false
+}

--- a/server.test.ts
+++ b/server.test.ts
@@ -11,6 +11,8 @@ import {
   defaultAccess,
   pruneExpired,
   generateCode,
+  isDuplicateEvent,
+  EVENT_DEDUP_TTL_MS,
   MAX_PENDING,
   MAX_PAIRING_REPLIES,
   PAIRING_EXPIRY_MS,
@@ -796,5 +798,88 @@ describe('defaultAccess', () => {
 
   test('returns empty pending', () => {
     expect(defaultAccess().pending).toEqual({})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isDuplicateEvent()
+// ---------------------------------------------------------------------------
+
+describe('isDuplicateEvent', () => {
+  test('returns false and records the event on first seen', () => {
+    const seen = new Map<string, number>()
+    const result = isDuplicateEvent(
+      { channel: 'C1', ts: '1700000000.000100' },
+      seen,
+      1000,
+      EVENT_DEDUP_TTL_MS,
+    )
+    expect(result).toBe(false)
+    expect(seen.size).toBe(1)
+  })
+
+  test('returns true for repeat within TTL window', () => {
+    const seen = new Map<string, number>()
+    isDuplicateEvent({ channel: 'C1', ts: '1.0' }, seen, 1000, 60000)
+    const second = isDuplicateEvent({ channel: 'C1', ts: '1.0' }, seen, 2000, 60000)
+    expect(second).toBe(true)
+  })
+
+  test('returns false for same event after TTL expires', () => {
+    const seen = new Map<string, number>()
+    isDuplicateEvent({ channel: 'C1', ts: '1.0' }, seen, 1000, 60000)
+    const later = isDuplicateEvent({ channel: 'C1', ts: '1.0' }, seen, 62000, 60000)
+    expect(later).toBe(false)
+  })
+
+  test('distinguishes same ts across different channels', () => {
+    const seen = new Map<string, number>()
+    isDuplicateEvent({ channel: 'C1', ts: '1.0' }, seen, 1000, 60000)
+    const other = isDuplicateEvent({ channel: 'C2', ts: '1.0' }, seen, 1000, 60000)
+    expect(other).toBe(false)
+  })
+
+  test('distinguishes different ts within the same channel', () => {
+    const seen = new Map<string, number>()
+    isDuplicateEvent({ channel: 'C1', ts: '1.0' }, seen, 1000, 60000)
+    const other = isDuplicateEvent({ channel: 'C1', ts: '2.0' }, seen, 1000, 60000)
+    expect(other).toBe(false)
+  })
+
+  test('treats missing channel as undedupable (returns false, no record)', () => {
+    const seen = new Map<string, number>()
+    const result = isDuplicateEvent({ ts: '1.0' }, seen, 1000, 60000)
+    expect(result).toBe(false)
+    expect(seen.size).toBe(0)
+  })
+
+  test('treats missing ts as undedupable (returns false, no record)', () => {
+    const seen = new Map<string, number>()
+    const result = isDuplicateEvent({ channel: 'C1' }, seen, 1000, 60000)
+    expect(result).toBe(false)
+    expect(seen.size).toBe(0)
+  })
+
+  test('prunes expired entries when checking new events', () => {
+    const seen = new Map<string, number>()
+    isDuplicateEvent({ channel: 'C1', ts: '1.0' }, seen, 1000, 60000)
+    isDuplicateEvent({ channel: 'C1', ts: '2.0' }, seen, 62000, 60000)
+    expect(seen.size).toBe(1)
+    expect(seen.has('C1:1.0')).toBe(false)
+    expect(seen.has('C1:2.0')).toBe(true)
+  })
+
+  test('covers the intended scenario: message + app_mention duplicate delivery', () => {
+    const seen = new Map<string, number>()
+    const event = {
+      channel: 'C_INCIDENTS',
+      ts: '1700000000.000100',
+      user: 'U_SENDER',
+      text: 'hey <@U_BOT> please look',
+    }
+    // `message` subscription fires first
+    expect(isDuplicateEvent(event, seen, 1000, 60000)).toBe(false)
+    // `app_mention` subscription fires shortly after with the same event
+    expect(isDuplicateEvent(event, seen, 1050, 60000)).toBe(true)
   })
 })

--- a/server.ts
+++ b/server.ts
@@ -39,6 +39,8 @@ import {
   sanitizeFilename,
   sanitizeDisplayName,
   gate as libGate,
+  isDuplicateEvent,
+  EVENT_DEDUP_TTL_MS,
   type Access,
   type GateResult,
 } from './lib.ts'
@@ -188,6 +190,10 @@ function assertSendable(filePath: string): void {
 
 // Track channels that passed inbound gate (session-lifetime cache)
 const deliveredChannels = new Set<string>()
+
+// Dedupe events across `message` and `app_mention` subscriptions. Keyed on
+// (channel, ts). See isDuplicateEvent in lib.ts for rationale.
+const seenEvents = new Map<string, number>()
 
 // Track last active channel/thread for permission relay
 let lastActiveChannel = ''
@@ -829,9 +835,13 @@ const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 // ---------------------------------------------------------------------------
 
 async function handleMessage(event: unknown): Promise<void> {
-  const result = await gate(event)
-
   const ev = event as Record<string, unknown>
+
+  // Skip duplicates (message + app_mention fire for the same @-mentioned
+  // channel message; Slack also occasionally redelivers on slow acks).
+  if (isDuplicateEvent(ev, seenEvents, Date.now(), EVENT_DEDUP_TTL_MS)) return
+
+  const result = await gate(event)
 
   switch (result.action) {
     case 'drop':


### PR DESCRIPTION
## Summary

The server subscribes to both `message` and `app_mention` events (`server.ts:966,977`), routing both through `handleMessage`. In Slack's Events API, `app_mention` isn't a replacement for `message` — it's an *additional* event that fires alongside a regular `message` event when the bot is @-mentioned. Result: for any @-mentioned channel message, `handleMessage` runs twice, causing doubled inference, doubled replies, and doubled token cost.

Slack's own event redelivery (on slow acks) causes the same symptom.

## Repro

1. Add the bot to a channel and opt that channel in under `access.json` with `requireMention: false`
2. Post a message from Slack that @-mentions the bot
3. Observe: `handleMessage` processes the event twice; two replies get posted

The comment at `server.ts:976` ("used in channels with requireMention") suggests the `app_mention` subscription was thought necessary when `requireMention` is true. It isn't — the regular `message` event carries the mention text and `isMentioned()` reads that directly, so `app_mention` is redundant for bots that are members of the channel.

## Approach

Adds `isDuplicateEvent()` to `lib.ts` as a pure function, matching the lib/server split described in `CLAUDE.md`. Keyed on `(channel, ts)` — Slack's unique identifier for a message. The cache is caller-supplied (a `Map`), so the function stays pure and is directly testable. Prunes expired entries on every check; TTL is 60s.

Wired into `handleMessage` at the top so both subscriptions share one process-lifetime cache.

Considered alternative: delete the `app_mention` handler outright. Not taken because dedup also defends against Slack's own event redelivery, which happens occasionally even with only one subscription. Happy to switch to the delete-the-handler approach if you prefer fewer moving parts — it would be a smaller diff.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 95 pass, 0 fail (86 existing + 9 new)
- [x] New tests cover: first-seen, repeat-within-TTL, repeat-after-TTL, cross-channel independence, same-channel different-ts independence, undedupable events (missing channel or ts), TTL-based pruning, and the exact message+app_mention dual-delivery scenario this PR addresses

## Notes

Happy to split into "lib function" + "server wiring" commits, swap to the alternative approach above, or drop any part of this if the shape doesn't fit. Filed as one commit for reviewability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)