### PR TITLE
ci: enable Gemini PR review (wild ecosystem)

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,54 @@
+# Gemini AI Code Review
+#
+# Template for all wild-* repos.
+# Requires these GitHub repo variables (set via scripts/gcp-setup.sh):
+#   WIF_PROVIDER, WIF_SERVICE_ACCOUNT, GCP_PROJECT_ID,
+#   GOOGLE_CLOUD_LOCATION, GOOGLE_GENAI_USE_VERTEXAI
+#
+# Copy this file to .github/workflows/gemini-review.yml in each wild-* repo.
+
+name: Gemini Code Review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write   # Required for WIF
+
+jobs:
+  gemini-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: google-github-actions/run-gemini-cli@v0
+        with:
+          gcp_workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          gcp_service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
+          gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+          gcp_location: ${{ vars.GOOGLE_CLOUD_LOCATION }}
+          use_vertex_ai: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
+          gemini_model: gemini-2.5-pro
+          settings: |
+            {
+              "tools": {
+                "includeTools": [
+                  "add_comment_to_pending_review",
+                  "pull_request_read",
+                  "pull_request_review_write"
+                ],
+                "core": [
+                  "run_shell_command(cat)",
+                  "run_shell_command(echo)",
+                  "run_shell_command(grep)",
+                  "run_shell_command(head)",
+                  "run_shell_command(tail)"
+                ]
+              }
+            }


### PR DESCRIPTION
## Summary

Enables Gemini AI code review on every PR to main.

- Adds `.github/workflows/gemini-review.yml` (copied from shared wild-ecosystem template)
- Uses the existing shared `wild-ecosystem` GCP project, WIF pool, and service account — no new infra
- Five repo variables already set: `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`, `GCP_PROJECT_ID`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`
- Runs on `pull_request: [opened, synchronize, reopened]` against main

## Why

Solo-maintained security-sensitive repo — Gemini gives a tireless first-pass reviewer on every PR. Shared wild-ecosystem GCP so this repo costs nothing extra to stand up.

## Test plan

- [x] Typecheck CI passes on this branch
- [ ] After merge: open any PR and confirm Gemini posts a review within ~2 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)