### PR TITLE
chore: add governance scaffolding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,35 @@
+# CODEOWNERS for claude-code-slack-channel
+#
+# GitHub assigns review requests to the owners listed here whenever a matching
+# path changes. The *last* matching rule wins — more specific paths near the
+# bottom override the catch-all at the top.
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+
+# Default: everything is owned by the sole maintainer.
+* @jeremylongshore
+
+# Security-critical runtime — the gate, the guards, the transport.
+# Any edit here needs a human read-through, not just a rubber-stamp.
+/lib.ts                         @jeremylongshore
+/server.ts                      @jeremylongshore
+/server.test.ts                 @jeremylongshore
+
+# Access control surface (allowlist, pairing codes, on-disk schema).
+/ACCESS.md                      @jeremylongshore
+/skills/access/                 @jeremylongshore
+/skills/configure/              @jeremylongshore
+
+# Security policy + threat model — changes must be intentional.
+/SECURITY.md                    @jeremylongshore
+/CLAUDE.md                      @jeremylongshore
+
+# CI + release automation. Workflow edits can bypass the whole test gate,
+# so they get reviewed as carefully as the runtime.
+/.github/                       @jeremylongshore
+/.github/workflows/             @jeremylongshore
+
+# Dependency manifests — a single bad upgrade is a supply-chain incident.
+/package.json                   @jeremylongshore
+/bun.lockb                      @jeremylongshore
+/package-lock.json              @jeremylongshore

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Something broke, crashed, or behaved weirdly. Not a security issue.
+title: "[bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug.
+
+        **If this is a security issue — a way to bypass the inbound gate, leak
+        tokens, reach Claude from an un-paired sender, or anything along those
+        lines — please close this form and use the private report link on the
+        previous page instead.** Public issues for security bugs help attackers,
+        not defenders.
+
+  - type: checkboxes
+    id: not-security
+    attributes:
+      label: Confirm this is not a security report
+      options:
+        - label: This bug is **not** a gate bypass, token leak, or other vulnerability. I understand security issues go through private reporting.
+          required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Short description of the actual behavior.
+      placeholder: "Slack DM from an allowlisted user didn't reach Claude — no error, just silence."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal recipe. Ideally something the maintainer can run without your Slack workspace.
+      placeholder: |
+        1. Start the server with `bun server.ts`
+        2. Send `...` from an allowlisted user
+        3. Observe `...`
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: "Output of `git rev-parse --short HEAD` or the release tag you're on."
+      placeholder: "v0.3.0 or abc1234"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime
+      options:
+        - Bun
+        - Node.js (tsx)
+        - Docker
+        - Other (note in Extra context)
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "macOS 14.5, Ubuntu 22.04, etc."
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste relevant server output. **Redact tokens, channel IDs, and user IDs.** If it's long, attach a file.
+      render: shell
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Extra context
+      description: Anything else — screenshots, suspected cause, related issues, workarounds.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability (private report)
+    url: https://github.com/jeremylongshore/claude-code-slack-channel/security/advisories/new
+    about: |
+      Gate bypasses, token leaks, prompt-injection escapes, outbound-gate
+      bypasses, or anything that could reach Claude from an un-paired sender.
+      Goes straight to the maintainer via GitHub's private advisory flow — do
+      not file a public issue.
+
+  - name: Security policy and threat model
+    url: https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/SECURITY.md
+    about: Scope, defense layers, and what counts as in-scope before you report.
+
+  - name: Question or idea
+    url: https://github.com/jeremylongshore/claude-code-slack-channel/discussions
+    about: |
+      Not sure it's a bug? Want to propose a new MCP tool or a different
+      access-control model? Open a discussion first so we can hash it out
+      before anyone writes code.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,102 @@
+<!--
+Thanks for the PR! A few quick notes before you hit submit:
+
+- Keep the diff focused. One idea per PR beats one big dump.
+- If you touched anything in the "Security impact" section below, expect extra
+  scrutiny — that's a feature, not friction.
+- Not sure whether something counts as security-sensitive? Check the boxes
+  anyway. Over-flagging is fine. Under-flagging is not.
+-->
+
+## What
+
+<!-- One or two sentences. What does this change do, from a user's perspective? -->
+
+## Why
+
+<!-- The motivation. Link the issue or discussion if there is one: "Fixes #123". -->
+
+## How
+
+<!-- Brief walkthrough of the approach. Call out anything non-obvious,
+     any tradeoffs, anything a reviewer would miss on a skim. -->
+
+---
+
+## Security impact
+
+Check every box that applies. If any of these are checked, the PR description
+**must** explain the threat-model reasoning — not just "tests pass."
+
+- [ ] Touches `gate()` / inbound gating logic in `lib.ts`
+- [ ] Touches `assertSendable()` / file exfiltration guard
+- [ ] Touches `assertOutboundAllowed()` / outbound gating logic
+- [ ] Changes the Socket Mode / MCP stdio transport in `server.ts`
+- [ ] Adds, removes, or modifies an MCP tool exposed to Claude
+- [ ] Touches token loading, `.env` handling, or `access.json` I/O
+- [ ] Changes the system-prompt hardening text
+- [ ] Adds a new runtime dependency (anything landing in `package.json`)
+- [ ] None of the above — this is a docs / test-only / cosmetic change
+
+<!-- If you checked anything above, answer these: -->
+<!-- - What's the new trust boundary (if any)? -->
+<!-- - What can an attacker-controlled message do after this change that it couldn't before? -->
+<!-- - What existing defense layer catches this if your new code has a bug? -->
+
+---
+
+## Test evidence
+
+Pick the tier that matches your change. One tier is enough — pick the strongest
+one that genuinely applies. Don't claim a tier you didn't meet.
+
+### Tier A — Automated test in the suite
+
+- [ ] I added or updated tests in `server.test.ts` (or a new `*.test.ts` file)
+- [ ] `bun test` passes locally
+- [ ] `bun run typecheck` passes locally
+- [ ] The test would fail without my fix (I verified by reverting the fix)
+
+<!-- Paste the relevant test name(s) or a short excerpt of the new assertion. -->
+
+### Tier B — Reproducible script CI can run
+
+Use this when the behavior is hard to unit-test (real Slack event shapes,
+real MCP handshake, file-system edge cases) but can still be exercised
+deterministically from a script.
+
+- [ ] Script lives at `scripts/<name>.ts` (or is inlined in the PR body)
+- [ ] Script is runnable with `bun run scripts/<name>.ts` with no secrets
+- [ ] Script exits non-zero on failure
+- [ ] Expected output is pasted below, verbatim
+
+<!-- ```
+$ bun run scripts/repro.ts
+... expected output ...
+``` -->
+
+### Tier C — Human evidence you ran yourself
+
+Use this only when the behavior truly cannot be automated (signals,
+real Slack handshakes, zombie-process checks). **You** run it, **you** post
+the evidence. The maintainer will not re-run it — if your evidence isn't
+convincing, you'll be asked for more, or the PR will be declined.
+
+- [ ] Exact command(s) you ran, copy-pasteable
+- [ ] Your actual terminal output pasted below (or a screen recording attached)
+- [ ] Environment: OS, Bun version, Claude Code version
+- [ ] Any required setup (tokens, workspace, channel) called out
+
+<!-- 1. ...
+     2. ...
+     3. Observed: ... -->
+
+---
+
+## Checklist
+
+- [ ] I read `CLAUDE.md` and `SECURITY.md` and the change is consistent with them
+- [ ] Pure logic went into `lib.ts`; stateful wiring stayed in `server.ts`
+- [ ] I did not add runtime dependencies beyond what's needed (the "four deps" rule)
+- [ ] Commit messages describe *why*, not just *what*
+- [ ] If this is a breaking change, `CHANGELOG.md` says so loudly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot configuration.
+#
+# Two ecosystems: npm (runtime + dev deps) and github-actions (workflow pins).
+# Grouping keeps @slack/* and @modelcontextprotocol/* updates as single PRs so
+# related-package bumps are reviewed together rather than as N isolated PRs.
+#
+# Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Chicago
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    assignees:
+      - jeremylongshore
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+      include: scope
+    groups:
+      slack:
+        patterns:
+          - "@slack/*"
+      mcp:
+        patterns:
+          - "@modelcontextprotocol/*"
+      # Non-major dev-tooling bumps (typescript, @types/*) go in one PR.
+      dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Chicago
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    assignees:
+      - jeremylongshore
+    commit-message:
+      prefix: chore(ci)
+      include: scope
+    groups:
+      actions-minor:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+name: CodeQL
+
+# Static analysis for the MCP server. This is a prompt-injection vector and
+# the gate/outbound/exfil guards in lib.ts are security-critical — CodeQL's
+# security-extended pack catches the JS/TS taint-flow and dangerous-sink
+# classes that could regress those guards.
+#
+# Source template: https://github.com/actions/starter-workflows/blob/main/code-scanning/codeql.yml
+# Action reference: https://github.com/github/codeql-action
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan catches newly-published queries against unchanged code.
+    - cron: '27 6 * * 1'
+
+# A push to main cancels an in-flight PR run for the same ref; PR runs from
+# different branches don't collide.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    permissions:
+      # Required to upload SARIF results to the Security tab.
+      security-events: write
+      # Required to fetch internal action metadata on private repos; harmless on public.
+      actions: read
+      # Minimum needed for checkout.
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended = default security queries + additional high-signal
+          # rules (taint flow, unsafe deserialization, regex DoS). Packed ruleset
+          # shipped by GitHub; no custom config file required.
+          queries: security-extended
+
+      # No build step: javascript-typescript uses the none build mode by default
+      # (CodeQL extracts source directly). Keeping autobuild would still work,
+      # but the explicit analyze call is faster and matches the starter-workflow.
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,63 @@
+name: Scorecard supply-chain security
+
+# OpenSSF Scorecard — scores the repo against ~20 supply-chain checks
+# (Token-Permissions, Pinned-Dependencies, Branch-Protection, Signed-Releases,
+# Dangerous-Workflow, etc.) and publishes findings to the Security tab.
+#
+# Source template: https://github.com/ossf/scorecard-action#installation
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '32 6 * * 1'
+  push:
+    branches: [main]
+
+# Top-level minimum; the job declares the extra writes it needs.
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to code-scanning.
+      security-events: write
+      # Required to read OIDC token for publishing results to scorecard.dev.
+      id-token: write
+      # Needed on private repos; harmless on public.
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes scores to the public scorecard.dev API. Set to false if
+          # the repo is private or the maintainer prefers not to publish.
+          publish_results: true
+
+      # Retained for debugging — surfaces the raw SARIF in the workflow run
+      # if Code Scanning rejects the upload.
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Adds the minimal governance layer this repo needs given it's a security-sensitive MCP prompt-injection surface with external contributors.

- `CODEOWNERS` — path-scoped ownership; security-critical files (lib.ts, server.ts, access paths) get their own lines so future changes can't slip in unnoticed
- `PULL_REQUEST_TEMPLATE` — three-tier test evidence model (A automated / B reproducible script / C human evidence the contributor posts) + security-impact checkboxes mapped 1:1 to the five defense layers in SECURITY.md
- `ISSUE_TEMPLATE/` — bug_report form + config.yml with blank issues disabled and a top-of-form redirect to GHSA private reporting so accidental public disclosure gets harder
- `dependabot.yml` — weekly npm + github-actions updates, grouped by vendor (@slack/*, @modelcontextprotocol/*) so related bumps land as one PR
- `codeql.yml` — security-extended queries, SHA-pinned actions, weekly cron + PR trigger
- `scorecard.yml` — weekly OpenSSF Scorecard run, SARIF uploaded to the security tab

Actions pinned to SHAs (Scorecard Pinned-Dependencies check). All templates adapted from anthropics/anthropic-sdk-typescript, slackapi/bolt-js, modelcontextprotocol/typescript-sdk, vercel/next.js, and cli/cli — not invented.

## Test plan

- [x] Typecheck passes (no runtime code touched)
- [ ] After merge: first Scorecard run appears in Actions tab
- [ ] After merge: first Dependabot PR lands next Monday
- [ ] After merge: CodeQL initial scan completes on the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)