### PR TITLE
ci: bump actions/upload-artifact v4 → v7.0.1

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,6 +12,9 @@ on:
     - cron: '32 6 * * 1'
   push:
     branches: [main]
+  # Enable manual runs for validating workflow changes on a feature branch
+  # via `gh workflow run scorecard.yml --ref <branch>`.
+  workflow_dispatch:
 
 # Top-level minimum; the job declares the extra writes it needs.
 permissions: read-all
@@ -51,7 +54,7 @@ jobs:
       # Retained for debugging — surfaces the raw SARIF in the workflow run
       # if Code Scanning rejects the upload.
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
## Summary

Re-do of the closed #16, validated via changelog review.

- \`actions/upload-artifact\` pinned SHA updated v4 → v7.0.1 (\`043fb46d\`)
- Adds \`workflow_dispatch\` trigger to \`scorecard.yml\` (still useful on main for manual runs — see note below)

## What I tried for validation

\`gh workflow run scorecard.yml --ref chore/bump-upload-artifact-v7\` → rejected by the scorecard-action itself: **"Only the default branch main is supported."** The action has a hard-coded check. So branch-level validation of \`scorecard.yml\` changes is impossible — they can only be validated post-merge on the scheduled/push runs.

## Changelog review (what this upgrade actually means)

- **v5.0.0**: bumped minimum runner for Node 20. GitHub-hosted runners handle this.
- **v6.0.0**: default runtime moved to Node 24. Requires runner ≥ 2.327.1. GitHub-hosted runners fine; only self-hosted would need updating, and we don't use any.
- **v7.0.0**: added optional \`archive: false\` for direct single-file uploads. Default (\`archive: true\`) preserves v4 behavior. Our config uses \`name\` + \`path\` + \`retention-days\`, all unchanged in v7.

## Risk

Low. Worst case: next Monday's scorecard run fails the upload step and the SARIF doesn't get published. Fix would be a small follow-up PR. Nothing in the repo's actual runtime changes.

## Test plan

- [x] Typecheck passes (unrelated, no code change)
- [x] upload-artifact v7.0.1 release notes reviewed — scorecard.yml's config fields are compatible
- [ ] First scheduled scorecard run post-merge: confirm SARIF upload succeeds

Jeremy made me do it
-claude