### PR TITLE
docs: update CLAUDE.md line counts and dependency count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Slack channel for the Claude Code — two-way chat bridge via Socket Mode + MCP 
 
 ## Architecture
 
-Two-file MCP server: `server.ts` (stateful runtime, ~630 lines) and `lib.ts` (pure functions, ~260 lines). Three dependencies: `@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`. No frameworks.
+Two-file MCP server: `server.ts` (stateful runtime, ~1000 lines) and `lib.ts` (pure functions, ~460 lines). Four runtime dependencies: `@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`. No frameworks.
 
 ```
 Slack workspace → Socket Mode WebSocket → server.ts → MCP stdio → Claude Code
@@ -71,4 +71,4 @@ All state lives in `~/.claude/channels/slack/`:
 - Matches `anthropics/claude-plugins-official` patterns (file structure, naming, skills)
 - Bun primary runtime, Node.js/Docker as alternatives
 - TypeScript strict mode
-- No external frameworks beyond the three declared dependencies
+- No external frameworks beyond the four declared runtime dependencies


### PR DESCRIPTION
## What

Updates CLAUDE.md to reflect current codebase metrics.

## Why

Documentation accuracy — line counts and dependency count were stale.

## How

- server.ts: ~630 → ~1000 lines
- lib.ts: ~260 → ~460 lines  
- Dependencies: 3 → 4 (added zod)

---

## Security impact

- [x] None of the above — this is a docs / test-only / cosmetic change

---

## Test evidence

### Tier A — Automated test in the suite

- [x] `bun run typecheck` passes locally

---

## Checklist

- [x] I read `CLAUDE.md` and `SECURITY.md` and the change is consistent with them
- [x] Commit messages describe *why*, not just *what*

Jeremy made me do it
-claude