### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-15
+
+### Fixed
+- MCP server now terminates cleanly on client disconnect (#7) — @maui-99
+- Deduplicated event delivery from `message` + `app_mention` dual-fire (#8) — @maui-99
+
+### Changed
+- **Governance**: Added CODEOWNERS, PR template, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md (#10)
+- **CI**: Enabled Gemini PR review, CodeQL, OpenSSF Scorecard (#9, #10)
+- **CI**: Bumped actions/checkout v4→v6, codeql-action v3→v4, upload-artifact to v7 (#14, #17, #21)
+- **Dependabot**: Removed npm ecosystem (bun.lockb incompatibility), kept github-actions only (#20)
+- **Docs**: Updated CLAUDE.md line counts and dependency count (#22)
+- **Docs**: Added contributors section to README
+
 ## [0.3.0] - 2026-04-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-channel-slack",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Slack channel for Claude Code — two-way chat via Socket Mode",
   "type": "module",
   "bin": "./server.ts",


### PR DESCRIPTION
## What

Release v0.3.1 — patch release with two bug fixes and governance scaffolding.

## Why

Community contributions from @maui-99 ready for release, plus CI/governance improvements.

## How

- CHANGELOG.md: added [0.3.1] section with all changes since v0.3.0
- package.json: bumped version 0.3.0 → 0.3.1

---

## Security impact

- [x] None of the above — this is a docs / test-only / cosmetic change

---

## Test evidence

### Tier A — Automated test in the suite

- [x] `bun test` passes locally (95 tests)
- [x] `bun run typecheck` passes locally

---

## Checklist

- [x] I read `CLAUDE.md` and `SECURITY.md` and the change is consistent with them
- [x] Commit messages describe *why*, not just *what*

## Release Notes (v0.3.1)

### Fixed
- MCP server now terminates cleanly on client disconnect (#7) — @maui-99
- Deduplicated event delivery from `message` + `app_mention` dual-fire (#8) — @maui-99

### Changed
- **Governance**: Added CODEOWNERS, PR template, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md (#10)
- **CI**: Enabled Gemini PR review, CodeQL, OpenSSF Scorecard (#9, #10)
- **CI**: Bumped actions/checkout v4→v6, codeql-action v3→v4, upload-artifact to v7 (#14, #17, #21)
- **Dependabot**: Removed npm ecosystem (bun.lockb incompatibility), kept github-actions only (#20)
- **Docs**: Updated CLAUDE.md line counts and dependency count (#22)
- **Docs**: Added contributors section to README

Jeremy made me do it
-claude