### PR TITLE
docs: correct v0.3.1 contributor credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1] - 2026-04-15
 
 ### Fixed
-- MCP server now terminates cleanly on client disconnect (#7) — @maui-99
-- Deduplicated event delivery from `message` + `app_mention` dual-fire (#8) — @maui-99
+- MCP server now terminates cleanly on client disconnect (#7) — @jinsung-kang
+- Deduplicated event delivery from `message` + `app_mention` dual-fire (#8) — @CaseyMargell
 
 ### Changed
 - **Governance**: Added CODEOWNERS, PR template, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md (#10)


### PR DESCRIPTION
## What

Fixes contributor attribution in CHANGELOG.md for v0.3.1.

## Why

Release notes credited @maui-99 for #7 and #8, but those PRs were authored by:
- #7 — @jinsung-kang
- #8 — @CaseyMargell

@maui-99 contributed the security hardening work that shipped in v0.3.0, not v0.3.1.

## How

Updated CHANGELOG entries with correct handles.

---

## Security impact

- [x] None of the above — this is a docs / test-only / cosmetic change

Jeremy made me do it
-claude