### PR TITLE
docs: sync README + GitHub Pages to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1] - 2026-04-15
 
 ### Fixed
-- MCP server now terminates cleanly on client disconnect (#7) — @maui-99
-- Deduplicated event delivery from `message` + `app_mention` dual-fire (#8) — @maui-99
+- MCP server now terminates cleanly on client disconnect (#7) — @jinsung-kang
+- Deduplicated event delivery from `message` + `app_mention` dual-fire (#8) — @CaseyMargell
 
 ### Changed
 - **Governance**: Added CODEOWNERS, PR template, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md (#10)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# Slack Channel for the Claude Code
+# claude-code-slack-channel v0.3.1
 
 Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channels, just like you'd chat in the terminal.
 
 [![CI](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml/badge.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jeremylongshore/claude-code-slack-channel/badge)](https://scorecard.dev/viewer/?uri=github.com/jeremylongshore/claude-code-slack-channel)
+
+**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.3.1)
 
 > **Research Preview** — Channels require Claude Code v2.1.80+ and `claude.ai` login.
 
@@ -54,7 +57,7 @@ Pick your runtime:
 #### Option A: Bun (recommended)
 
 ```bash
-cd slack && bun install
+bun install
 # Current (claude-code-plugins marketplace):
 claude --channels plugin:slack-channel@claude-code-plugins
 # Future (after upstream approval):
@@ -64,7 +67,7 @@ claude --channels plugin:slack-channel@claude-code-plugins
 #### Option B: Node.js / npx
 
 ```bash
-cd slack && npm install
+npm install
 # In .mcp.json, change command to: "npx", args: ["tsx", "server.ts"]
 claude --channels plugin:slack-channel@claude-code-plugins
 ```
@@ -72,7 +75,7 @@ claude --channels plugin:slack-channel@claude-code-plugins
 #### Option C: Docker
 
 ```bash
-cd slack && docker build -t claude-slack-channel .
+docker build -t claude-slack-channel .
 # In .mcp.json, change command to: "docker", args: ["run", "--rm", "-i", "-v", "~/.claude/channels/slack:/state", "claude-slack-channel"]
 claude --channels plugin:slack-channel@claude-code-plugins
 ```
@@ -120,8 +123,10 @@ claude --dangerously-load-development-channels server:slack
 
 ## Contributors
 
-- [@jeremylongshore](https://github.com/jeremylongshore) — author
-- [@maui-99](https://github.com/maui-99) — security hardening (v0.3.0)
+- [@jeremylongshore](https://github.com/jeremylongshore) — author, maintainer
+- [@maui-99](https://github.com/maui-99) — security hardening review (v0.3.0)
+- [@jinsung-kang](https://github.com/jinsung-kang) — clean shutdown on client disconnect (v0.3.1)
+- [@CaseyMargell](https://github.com/CaseyMargell) — event deduplication fix (v0.3.1)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,14 @@
-# claude-code-slack-channel v0.1.0
+# claude-code-slack-channel v0.3.1
 
-Two-way Slack channel for the Claude Code — chat from Slack DMs and channels, just like the terminal.
+Two-way Slack channel for the Claude Code — chat from Slack DMs and channels, approve tool calls from your phone.
 
-Uses Socket Mode (outbound WebSocket, no public URL) to bridge Slack messages into a running Claude Code session via MCP stdio. Five defense layers prevent prompt injection, token exfiltration, and unauthorized access. Three runtime options: Bun, Node.js, Docker.
+A `claude/channel` implementation for Slack. Uses Socket Mode (outbound WebSocket, no public URL) to bridge Slack messages into a running Claude Code session via MCP stdio. Permission relay with Block Kit buttons lets you approve or deny Claude Code tool calls remotely. Seven defense layers prevent prompt injection, token exfiltration, and unauthorized access. Three runtime options: Bun, Node.js, Docker.
 
 [![CI](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml/badge.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jeremylongshore/claude-code-slack-channel/badge)](https://scorecard.dev/viewer/?uri=github.com/jeremylongshore/claude-code-slack-channel)
 
-**Links:** [GitHub](https://github.com/jeremylongshore/claude-code-slack-channel) · [Pages](https://jeremylongshore.github.io/claude-code-slack-channel/)
+**Links:** [GitHub](https://github.com/jeremylongshore/claude-code-slack-channel) · [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.3.1)
 
 ---
 
@@ -15,27 +16,25 @@ Uses Socket Mode (outbound WebSocket, no public URL) to bridge Slack messages in
 
 ### The Problem
 
-If you're using Claude Code, you're chained to the terminal. Step away from your desk and the conversation stops. Your phone has Slack — but Slack can't talk to your Claude session.
+If you're using Claude Code, you're chained to the terminal. Step away from your desk and the conversation stops — worse, Claude may be waiting for permission to run a tool, and you can't approve it from your phone. Your phone has Slack, but Slack can't talk to your Claude session.
 
-Anthropic shipped channels for Telegram, Discord, and a localhost demo (fakechat), but nothing for Slack — the tool most teams already live in. The existing Slack plugin in the official repo is a tool server: Claude can post to Slack, but Slack can't talk back. It's one-way.
-
-Meanwhile, the channel protocol (`claude/channel`) is documented in the [Anthropic channels reference](https://docs.anthropic.com/en/docs/claude-code/channels) but no community Slack channel exists yet. If you want to DM your Claude session from Slack, nothing exists to do it.
+Anthropic shipped channels for Telegram and Discord, but not yet for Slack — the tool most teams already live in. The channel protocol (`claude/channel`) is documented and ready for community implementations. Slack is the obvious next channel — and this project fills that gap, including the permission relay protocol for remote tool approvals.
 
 ### The Solution
 
-A single-file MCP server (~850 lines TypeScript) that connects Slack to Claude Code bidirectionally. Inbound messages arrive via Socket Mode (Slack's outbound WebSocket — no public URL, no webhook endpoint, works behind any firewall). Outbound replies go through the Slack Web API. Everything runs locally as a subprocess of Claude Code.
+A two-file MCP server (~1000 lines in `server.ts` for stateful wiring, ~460 lines in `lib.ts` for pure functions) that connects Slack to Claude Code bidirectionally. Inbound messages arrive via Socket Mode (Slack's outbound WebSocket — no public URL, works behind any firewall). Outbound replies go through the Slack Web API. **Permission prompts** render as Block Kit messages with Allow/Deny/Details buttons — tap your phone to approve a tool call from anywhere.
 
-The architecture mirrors the official Discord channel exactly — same gate/pairing/allowlist pattern — adapted for Slack's APIs (timestamps as message IDs, mrkdwn instead of Markdown, dual tokens, `files.uploadV2`). Security is defense-in-depth: inbound gate drops ungated messages before MCP, outbound gate restricts replies, file exfiltration guard blocks state directory leaks, and system prompt hardening tells Claude to refuse manipulation attempts from messages.
+Security is defense-in-depth: inbound gate drops ungated messages before MCP, outbound gate restricts replies, file exfiltration guard blocks state directory leaks, owner-only approval ensures only the session owner can approve tool calls, and system prompt hardening tells Claude to refuse manipulation attempts from messages.
 
 ### Who / What / Where / When / Why
 
 | Aspect | Details |
 |--------|---------|
 | **Who** | Developers using Claude Code who collaborate via Slack |
-| **What** | MCP channel server — pushes Slack events into Claude Code sessions, replies back |
+| **What** | MCP channel server — pushes Slack events into Claude Code sessions, replies back, relays permission prompts |
 | **Where** | Runs locally (your machine), connects to Slack via Socket Mode WebSocket |
-| **When** | AFK coding — review PRs from your phone, check build status from the couch, pair with Claude from any device with Slack |
-| **Why** | Only Slack channel for Claude Code. No public URL needed. Five security layers. Matches official plugin patterns exactly. |
+| **When** | AFK coding — approve tool calls from your phone, review PRs from the couch, pair with Claude from any device with Slack |
+| **Why** | Only Slack channel for Claude Code. Permission relay with Block Kit. No public URL. Seven security layers. |
 
 ### Stack
 
@@ -44,14 +43,17 @@ The architecture mirrors the official Discord channel exactly — same gate/pair
 | Runtime | Bun / Node.js / Docker | Flexible execution — pick your preference |
 | Protocol | MCP (stdio) | Standard Claude Code channel transport |
 | Connection | @slack/socket-mode v2 | Outbound WebSocket to Slack — no public URL |
-| API | @slack/web-api v7 | Send messages, upload files, add reactions |
-| Security | Custom gate + allowlist | 5-layer defense: inbound gate, outbound gate, exfiltration guard, prompt hardening, token security |
+| API | @slack/web-api v7 | Send messages, upload files, add reactions, Block Kit interactions |
+| Validation | zod v3 | Schema validation for permission relay protocol |
+| Security | Custom gate + allowlist | 7-layer defense: inbound gate, outbound gate, owner-only approval, exfiltration guard, symlink resolution, mrkdwn escaping, token lockdown |
 
 ### Key Differentiators
-1. **No public URL** — Socket Mode means outbound-only WebSocket, works behind firewalls and NAT
-2. **Defense-in-depth security** — 5 layers: inbound gate, outbound gate, file exfiltration guard, prompt injection hardening, token lockdown
-3. **Three runtime options** — Bun (fastest), Node.js/npx (universal), Docker (isolated)
-4. **Upstream-ready** — matches `anthropics/claude-plugins-official` patterns exactly (MIT, same file structure, same conventions as Discord/Telegram)
+
+1. **Permission relay** — Approve/deny Claude Code tool calls remotely via Slack (Block Kit buttons or text fallback)
+2. **No public URL** — Socket Mode means outbound-only WebSocket, works behind firewalls and NAT
+3. **Defense-in-depth security** — 7 layers hardened via community security review (v0.3.0)
+4. **Three runtime options** — Bun (fastest), Node.js/npx (universal), Docker (isolated)
+5. **Upstream-ready** — matches `anthropics/claude-plugins-official` patterns exactly (MIT, same structure as Discord/Telegram)
 
 ---
 
@@ -59,11 +61,11 @@ The architecture mirrors the official Discord channel exactly — same gate/pair
 
 ### Executive Summary
 
-claude-code-slack-channel is a fully built, single-file MCP server that bridges Slack workspaces to Claude Code sessions. The entire implementation lives in `server.ts` (844 lines) with two skill files for configuration and access management. It uses three dependencies (`@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`) — no frameworks, no middleware, no build step for Bun.
+claude-code-slack-channel is a production-oriented MCP server that bridges Slack workspaces to Claude Code sessions. The implementation is split across `server.ts` (~1000 lines of stateful runtime wiring) and `lib.ts` (~460 lines of pure, testable functions). Two skill files handle configuration and access management. Four dependencies (`@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`) — no frameworks, no middleware, no build step for Bun.
 
-The security architecture is the most substantial part of the design. Every inbound message passes through a gate function that checks sender identity against an allowlist before anything reaches the MCP notification layer. Outbound messages are similarly gated. State files (tokens, access config) are locked to 0o600 permissions with atomic writes. The system prompt explicitly warns Claude about prompt injection patterns.
+**v0.3.1** is a patch release with two community bug fixes: clean MCP server shutdown on client disconnect (#7 — @jinsung-kang) and deduplication of dual-fire events when a message is both a `message` and `app_mention` (#8 — @CaseyMargell). The release also lands governance scaffolding (CODEOWNERS, SECURITY.md, CONTRIBUTING.md), Gemini PR review, CodeQL, and OpenSSF Scorecard.
 
-This is v0.1.0 — feature-complete for the core use case (DM chat + channel monitoring) but pre-release. CI pipeline is configured and passing. No test suite yet. The immediate next step is real-world testing against a Slack workspace, then PR to `anthropics/claude-plugins-official`.
+**v0.3.0** hardened the security model via a seven-vulnerability review from @maui-99: restrictive file sendable policy with symlink resolution, outbound gate enforcement on all reply paths, display-name sanitization against prompt injection, atomic `access.json` writes with 0o600, Slack file URL validation, and frozen-lockfile dependency pinning. The test suite grew from 52 to 86 tests in v0.3.0, then to 95 tests in v0.3.1.
 
 ### Technology Stack
 
@@ -72,122 +74,76 @@ This is v0.1.0 — feature-complete for the core use case (DM chat + channel mon
 | Runtime | Bun | 1.x | Primary execution runtime (also supports Node.js via tsx) |
 | Protocol | @modelcontextprotocol/sdk | 1.27.x | MCP server + stdio transport |
 | Connection | @slack/socket-mode | 2.0.x | Outbound WebSocket to Slack (no public URL) |
-| API | @slack/web-api | 7.15.x | Slack REST API (messages, files, reactions) |
+| API | @slack/web-api | 7.15.x | Slack REST API (messages, files, reactions, interactions) |
+| Validation | zod | 3.25.x | Schema validation for permission relay |
 | Language | TypeScript | 5.9.x | Strict mode, type-checked |
 | Container | Docker (oven/bun:1-slim) | — | Optional isolated runtime |
 
 ### Architecture
 
 ```
-┌────────────────────────────┐
-│     Slack Workspace        │
-│   (cloud, api.slack.com)   │
-└────────────┬───────────────┘
-             │ WebSocket (Socket Mode)
-             │ outbound from local machine
-┌────────────▼───────────────┐
-│       server.ts            │
-│                            │
-│  ┌──────────────────────┐  │
-│  │  Socket Mode Client  │  │  ← receives events
-│  └──────────┬───────────┘  │
-│             │              │
-│  ┌──────────▼───────────┐  │
-│  │     gate()           │  │  ← drops ungated messages
-│  │  (inbound security)  │  │
-│  └──────────┬───────────┘  │
-│             │ deliver      │
-│  ┌──────────▼───────────┐  │
-│  │   MCP Notification   │──┼──→ Claude Code session (stdio)
-│  └──────────────────────┘  │
-│                            │
-│  ┌──────────────────────┐  │
-│  │   Tools (reply, etc) │←─┼── Claude calls tools
-│  │  + outbound gate     │  │
-│  │  + assertSendable()  │  │
-│  └──────────┬───────────┘  │
-│             │              │
-│  ┌──────────▼───────────┐  │
-│  │   Web API Client     │  │  ← sends messages back
-│  └──────────┬───────────┘  │
-└─────────────┼──────────────┘
-              │ HTTPS
-┌─────────────▼──────────────┐
-│     Slack Workspace        │
-└────────────────────────────┘
+Slack workspace (cloud)
+    ↕ WebSocket (Socket Mode — outbound only, no public URL)
+server.ts + lib.ts (local MCP server, spawned by Claude Code)
+    ↕ stdio (MCP transport)
+Claude Code session
 ```
 
-### Key Tradeoffs
+Socket Mode means **no public URL needed** — works behind firewalls, NAT, anywhere.
 
-| Decision | Chosen | Over | Why | Revisit When |
-|----------|--------|------|-----|--------------|
-| Connection | Socket Mode | Webhooks | No public URL needed, works behind NAT/firewalls | Never — this is a hard requirement for local-only |
-| Framework | Raw SDK | @slack/bolt | Fewer deps, smaller surface, direct event control | If event routing gets complex (10+ event types) |
-| State | JSON file | SQLite/DB | Zero deps, simple read/write, atomic via rename | If access lists exceed ~1000 entries |
-| Architecture | Single file | Multi-module | Matches official plugins pattern, easy to review | If server exceeds ~1500 lines |
-| Auth | Dual token (bot + app) | OAuth flow | Socket Mode requires app-level token; simplest setup | If distributing as installable Slack app |
+### Security Model
 
-Socket Mode over webhooks is the defining choice. It means the server is local-only — no DNS, no TLS cert, no port forwarding. The tradeoff is that Socket Mode requires an app-level token with `connections:write`, which is an extra setup step. Worth it for the security posture.
+| Layer | Function | Implementation |
+|-------|----------|----------------|
+| Inbound Gate | Drop unauthorized messages | `gate()` checks `allowFrom` and channel opt-in |
+| Outbound Gate | Restrict reply targets | `assertOutboundAllowed()` checks delivered channels |
+| Owner-Only Approval | Only session owner can approve tools | Button + text paths verify `access.allowFrom` |
+| File Exfiltration Guard | Block state file uploads | `assertSendable()`: allowlist roots + basename/parent denylist + symlink resolution |
+| mrkdwn Escaping | Prevent Slack injection | `escMrkdwn()` neutralizes `<`, `>`, `&` and sanitizes display names |
+| Slack URL Validation | Block token exfiltration via crafted URLs | `isSlackFileUrl()` validates host allowlist |
+| Token Security | Protect credentials | 0o600 permissions, atomic writes, never logged |
 
-### Directory Structure
+### Quality Metrics
 
-```
-claude-code-slack-channel/
-├── .claude-plugin/
-│   └── manifest.json      # Plugin metadata (name, version, description)
-├── skills/
-│   ├── configure.md       # /slack-channel:configure — token setup
-│   └── access.md          # /slack-channel:access — pairing, allowlist, channels
-├── server.ts              # MCP server — all logic (844 lines)
-├── package.json           # 3 runtime deps, 2 dev deps
-├── .mcp.json              # MCP server registration (bun server.ts)
-├── Dockerfile             # Optional Docker runtime
-├── tsconfig.json          # TypeScript strict config
-├── ACCESS.md              # Access control schema docs
-├── README.md              # Setup guide + security overview
-├── CONTRIBUTING.md        # Contribution guidelines
-├── SECURITY.md            # Vulnerability reporting
-├── CHANGELOG.md           # Keep a Changelog format
-├── CODE_OF_CONDUCT.md     # Contributor Covenant 2.1
-└── LICENSE                # MIT
-```
-
-### Deployment & Operations
-
-| Capability | Command | Notes |
-|------------|---------|-------|
-| Install deps | `bun install` | Or `npm install` for Node.js |
-| Typecheck | `bun run typecheck` | `tsc --noEmit` — strict mode |
-| Run (Bun) | `bun server.ts` | Primary runtime |
-| Run (Node) | `npx tsx server.ts` | Fallback runtime |
-| Run (Docker) | `docker build -t claude-slack-channel . && docker run --rm -i -v ~/.claude/channels/slack:/state claude-slack-channel` | Isolated runtime |
-| Launch channel | `claude --channels plugin:slack-channel@claude-code-plugins` | Current marketplace |
-| Dev mode | `claude --dangerously-load-development-channels server:slack` | Bypasses plugin allowlist |
-| Configure | `/slack-channel:configure xoxb-... xapp-...` | Writes tokens to ~/.claude/channels/slack/.env |
-| Pair user | `/slack-channel:access pair <code>` | Approves pending pairing code |
+| Metric | Value |
+|--------|-------|
+| Test Coverage | 95 tests, security-critical functions |
+| TypeScript | Strict mode, zero errors |
+| Dependencies | 4 production deps |
+| Lines of Code | ~1460 total (server.ts ~1000 + lib.ts ~460) |
+| CI | GitHub Actions — typecheck, test, CodeQL, Gemini review, OpenSSF Scorecard |
+| Default DM Policy | `allowlist` (restrictive) — explicit user approval required |
 
 ### Current State Assessment
 
-#### What's Working
-- Full MCP server implementation with `claude/channel` capability (844 lines, type-checked)
-- 5 tools: reply (with chunking), react, edit_message, fetch_messages, download_attachment
-- Complete security architecture: inbound gate, outbound gate, file exfiltration guard, prompt hardening, token security
+**What's Working**
+- Full MCP server with `claude/channel` + `claude/channel/permission` capabilities
+- 7 tools: `reply`, `react`, `edit_message`, `fetch_messages`, `download_attachment`, permission approval paths
+- Complete security architecture: 7 defense layers, all unit-tested
 - Pairing flow with 6-char codes, 1-hour expiry, max 3 pending, max 2 replies
-- Channel opt-in with mention requirement and per-channel allowlists
-- Static mode for restricted deployments
+- Channel opt-in with optional mention requirement and per-channel allowlists
+- Static mode for restricted deployments (`SLACK_ACCESS_MODE=static`)
 - Three runtime options (Bun, Node.js, Docker)
-- Clean typecheck (`tsc --noEmit` passes)
+- Clean typecheck, 95 passing tests
+- Governance: CODEOWNERS, SECURITY.md, PR template, branch protection, Dependabot
 
-#### Roadmap
-- Live Slack workspace integration testing (Socket Mode, event flow, file upload)
-- Lint/format config (biome or eslint) before upstream PR
-- Expanded test coverage for edge cases
+**Roadmap**
+- Dedup cache scaling improvements (tracked in #11)
+- Expanded test coverage for rare edge cases
+- Upstream PR to `anthropics/claude-plugins-official`
 
 ### Quick Reference
 
-- **Repo:** https://github.com/jeremylongshore/claude-code-slack-channel
-- **CI:** Passing (GitHub Actions — Bun typecheck)
+- **Repo:** [github.com/jeremylongshore/claude-code-slack-channel](https://github.com/jeremylongshore/claude-code-slack-channel)
+- **CI:** Passing (GitHub Actions — typecheck, test, CodeQL, Gemini review, Scorecard)
 - **License:** MIT
-- **Last Release:** v0.1.0 (2026-03-20)
-- **Test Coverage:** Unit tests for security-critical functions (gate, assertSendable, assertOutboundAllowed)
+- **Latest Release:** [v0.3.1](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.3.1) (2026-04-15)
+- **Test Coverage:** 95 tests covering security-critical functions
 - **Docs:** [Anthropic Channels Reference](https://docs.anthropic.com/en/docs/claude-code/channels) · [Plugin Spec](https://docs.anthropic.com/en/docs/claude-code/plugins)
+
+### Contributors
+
+- [@jeremylongshore](https://github.com/jeremylongshore) — author, maintainer
+- [@maui-99](https://github.com/maui-99) — security hardening review (v0.3.0, 7 vulnerabilities closed)
+- [@jinsung-kang](https://github.com/jinsung-kang) — clean shutdown on client disconnect (v0.3.1, #7)
+- [@CaseyMargell](https://github.com/CaseyMargell) — event deduplication fix (v0.3.1, #8)


### PR DESCRIPTION
## What

Syncs README.md and docs/index.md (GitHub Pages) to v0.3.1 state. Gist one-pager also updated out-of-band.

## Why

`/validate-consistency` flagged critical drift:
- **docs/index.md** stuck at v0.1.0 — wrong version, "no test suite", "844 lines", etc.
- **README.md** missing version in title, missing Links line, stale contributors
- **Gist** pinned to v0.3.0 (already fixed via `gh gist edit`)

## How

README:
- Title now includes version (`v0.3.1`) per gist-auditor template
- Added `**Links:**` line with Gist/Pages/Release-notes
- Added OpenSSF Scorecard badge
- Dropped stale `cd slack &&` (repo is flat, no `slack/` subdir)
- Credited @jinsung-kang (#7) and @CaseyMargell (#8) for v0.3.1

docs/index.md:
- Full rewrite mirroring the gist one-pager (consistent messaging across public surfaces)
- All metrics synced to v0.3.1 (95 tests, ~1460 LOC, 4 deps, governance, Scorecard)

---

## Security impact

- [x] None of the above — this is a docs / test-only / cosmetic change

## Test evidence

- [x] `bun run typecheck` passes locally
- [x] `bun test` passes (95 tests)

Jeremy made me do it
-claude