### PR TITLE
chore(security): harden workflows + Dockerfile per Scorecard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,21 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -23,11 +23,12 @@ jobs:
   gemini-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: google-github-actions/run-gemini-cli@v0
+      - uses: google-github-actions/run-gemini-cli@9dbec29a20fab3f35017a40ad0eb798a257d4d51 # v0
         with:
           gcp_workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           gcp_service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}

--- a/.github/workflows/notify-marketplace.yml
+++ b/.github/workflows/notify-marketplace.yml
@@ -8,9 +8,12 @@ on:
       - '.github/**'
       - '000-docs/**'
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Trigger marketplace sync
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1-slim
+FROM oven/bun:1-slim@sha256:d3c7094c144dd3975d183a4dbc4ec0a764223995bff73290d983edb47043a75f
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Closes the actionable Scorecard alerts: Token-Permissions (#2, #3) and Pinned-Dependencies (#5, #7, #8, #17, #18).

## Why

OpenSSF Scorecard flagged loose workflow permissions (default write-all) and unpinned action references (`@v6`, `@v2`, `@v0` — mutable). Pinning to commit SHAs and scoping permissions to exactly what each workflow needs closes the supply-chain attack vector where a compromised tag/release could silently upgrade.

## How

**Action pins (SHA + version comment):**
- `actions/checkout@de0fac2` (v6.0.2)
- `oven-sh/setup-bun@0c5077e` (v2.2.0)
- `google-github-actions/run-gemini-cli@9dbec29` (v0)

**Permissions:**
- `ci.yml`: `permissions: {}` at top, `contents: read` at job level, `persist-credentials: false` on checkout
- `notify-marketplace.yml`: `permissions: {}` everywhere — only uses `curl` with a secret, no GITHUB_TOKEN needed
- `gemini-review.yml`: already had correct permissions, just added `persist-credentials: false`

**Dockerfile:**
- `oven/bun:1-slim@sha256:d3c7094c...` (pinned by image index digest)

## Separately dismissed (not part of this PR)

- **#15, #16 (CodeQL http↔file):** intended behavior of `download_attachment` tool. Network→file path gated by `isSlackFileUrl()` host allowlist; filesystem write gated by `assertSendable()` (allowlist roots + symlink resolution). Safe by design.
- **#9–#14 Scorecard metadata:** OSS-Fuzz enrollment, CII badge, multi-reviewer Code-Review, Maintained activity signal. Not fixable via code on a solo-maintainer repo.

---

## Security impact

- [x] Touches token loading, `.env` handling, or `access.json` I/O

(Technically no runtime changes — only CI/CD supply chain. But this is the supply chain that builds/tests the code that loads tokens, so it belongs in scope.)

### Threat model notes
- **New trust boundary:** none — scope contracted (permissions narrowed, tags replaced with immutable SHAs)
- **Attacker-controlled message:** unchanged — runtime is identical
- **Existing defense layer if code has a bug:** Dependabot (github-actions ecosystem) will re-bump SHAs as new releases come out

## Test evidence

### Tier B — Reproducible script CI can run

- [x] CI itself is the validation — if the workflows run green on this PR, the pins resolve and permissions are sufficient
- [x] Dockerfile pin verified: `docker buildx imagetools inspect oven/bun:1-slim` returned matching digest

## Checklist

- [x] I read `CLAUDE.md` and `SECURITY.md` and the change is consistent with them
- [x] Commit messages describe *why*, not just *what*

Jeremy made me do it
-claude