### PR TITLE
docs: fix dep count in CONTRIBUTING + fill CoC enforcement contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jeremy@intentsolutions.io. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ We welcome contributions to the Slack channel for Claude Code.
 ## Code Style
 
 - TypeScript strict mode
-- No external frameworks beyond the three declared dependencies
+- No external frameworks beyond the four declared runtime dependencies (`@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`)
 - Run `bun run typecheck` before submitting
 
 ## Testing


### PR DESCRIPTION
## Summary

Two small doc fixes flagged during the #27 audit:

- **`CONTRIBUTING.md`** said "three declared dependencies" — actual is four (zod was added in v0.2.0). Replaced with an explicit list so future drift is easier to catch.
- **`CODE_OF_CONDUCT.md`** enforcement contact was still the template placeholder `[INSERT CONTACT METHOD]`. Set to `jeremy@intentsolutions.io` to match SECURITY.md.

No code changes. Typecheck clean, 95/95 tests pass locally.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (95/95)
- [ ] CI green on PR

Jeremy made me do it
-claude