### PR TITLE
ci(gemini): switch to pull_request_target so fork PRs get AI review

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,16 +1,20 @@
 # Gemini AI Code Review
 #
-# Template for all wild-* repos.
 # Requires these GitHub repo variables (set via scripts/gcp-setup.sh):
 #   WIF_PROVIDER, WIF_SERVICE_ACCOUNT, GCP_PROJECT_ID,
 #   GOOGLE_CLOUD_LOCATION, GOOGLE_GENAI_USE_VERTEXAI
 #
-# Copy this file to .github/workflows/gemini-review.yml in each wild-* repo.
+# Uses pull_request_target so WIF auth works on fork PRs. This workflow
+# is read-only by design: it checks out the PR head SHA but never executes
+# any code from it (no install, no build, no test). The run-gemini-cli
+# action reads the diff via the GitHub API and is restricted to read-only
+# shell tools (cat, echo, grep, head, tail). A malicious fork cannot
+# compromise the runner credentials through code Gemini only reads.
 
 name: Gemini Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened]
 
@@ -27,6 +31,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          # Check out the PR head SHA explicitly (pull_request_target
+          # defaults to base branch). Using the SHA (not ref) prevents
+          # TOCTOU if the PR is force-pushed mid-run.
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: google-github-actions/run-gemini-cli@9dbec29a20fab3f35017a40ad0eb798a257d4d51 # v0
         with:


### PR DESCRIPTION
## Summary

Switches the Gemini code review workflow from `pull_request` to `pull_request_target` so it runs successfully on fork PRs. Problem surfaced on @CaseyMargell's PR #33, where Gemini silently failed at the WIF auth step because GitHub does not propagate OIDC tokens with the base-repo `repository` claim on fork PRs — the token carried `CaseyMargell/...` and the WIF attribute condition rejected it.

## Why this is safe

The standard caution with `pull_request_target` is \"fork executes arbitrary code with your secrets.\" That only applies when a subsequent step **runs** code from the checked-out tree (install/build/test scripts, preinstall hooks, etc). This workflow does **none** of that:

1. `actions/checkout` just clones the tree — no code execution
2. `google-github-actions/run-gemini-cli` reads the diff via the GitHub API and is already restricted to read-only shell tools (`cat`, `echo`, `grep`, `head`, `tail`) per the existing `settings` block

A malicious fork PR cannot compromise the WIF credentials through code that is only being read.

## Change

- Trigger: `pull_request` → `pull_request_target`
- Checkout: explicit `ref: \${{ github.event.pull_request.head.sha }}` (pull_request_target defaults to base branch; we want the PR's code for Gemini to see). Using the SHA (not branch ref) prevents TOCTOU if the PR is force-pushed mid-run.
- Inline header comment added documenting the fork-safety invariant.

## Test plan

- [x] Workflow YAML validates locally (diff applied cleanly)
- [ ] CI green on this PR (internal branch, should pass as before)
- [ ] After merge, force a re-run on Casey's #33 (close/reopen) — Gemini review should succeed

## Aftermath

Once merged, Casey's PR #33 and any future fork PR will get Gemini review alongside the existing human review, Typecheck, CodeQL, and javascript-typescript analysis checks. No label gate or trusted-author allowlist; defense-in-depth relies on the read-only workflow invariant documented in the header.

If the threat posture changes (e.g. drive-by fork PRs from unknown contributors become common), adding a `MEMBER || allowlisted-author` condition is a small follow-up.

Jeremy made me do it
-claude