### PR TITLE
docs: document allowBotIds cross-bot delivery (follow-up to #33)

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -11,7 +11,8 @@ The Slack channel uses `~/.claude/channels/slack/access.json` to control who can
   "channels": {
     "C12345678": {
       "requireMention": true,
-      "allowFrom": ["U12345678"]
+      "allowFrom": ["U12345678"],
+      "allowBotIds": []
     }
   },
   "pending": {
@@ -66,6 +67,30 @@ Map of channel IDs to policies. Only channels listed here are monitored.
 
 - `requireMention`: If true, only messages that @mention the bot are delivered
 - `allowFrom`: If non-empty, only these user IDs are delivered from this channel
+- `allowBotIds`: Opt-in list of bot user IDs allowed to deliver messages in this channel. Absent or empty (default) = all bot messages dropped. See "Multi-agent coordination" below.
+
+### Multi-agent coordination (`allowBotIds`)
+
+By default, every message with a `bot_id` is dropped at the gate to prevent bot-loop amplification and unintended interactions with third-party integrations (Zapier, PagerDuty, GitHub, etc.). Channels that need to host multiple cooperating agents — for example, an ops-monitor bot and an engineering bot coordinating in an `#incidents` channel — opt in by listing specific bot user IDs in `allowBotIds`.
+
+```json
+"channels": {
+  "C_INCIDENTS": {
+    "requireMention": false,
+    "allowFrom": ["U_OPS_BOT", "U_ENG_BOT", "U_HUMAN"],
+    "allowBotIds": ["U_OPS_BOT", "U_ENG_BOT"]
+  }
+}
+```
+
+Only bot user IDs explicitly listed in `allowBotIds` can deliver bot messages. Every other bot is dropped. Additional invariants enforced at the gate:
+
+- **Self-echo** from this bot is always filtered — even if its own user ID appears in `allowBotIds`. Filtering matches on `bot_id`, `bot_profile.app_id`, or `user === botUserId` to cover payload variants (including `as_user=false` posts and multi-workspace installs).
+- **Permission-reply-shaped messages** from peer bots (`y abcde`, `no xyzwq`) are dropped at the gate before reaching the permission relay. Peer bots cannot approve tool calls regardless of `allowBotIds` membership — the permission relay additionally requires the approver to be in the top-level `allowFrom`.
+- **`requireMention` and `allowFrom`** still apply. `allowBotIds` only gets a peer-bot message past the default `bot_id` drop; the usual channel gating runs afterward.
+- **DMs** are unaffected. `allowBotIds` is channel-scoped; bot messages in DM channels are always dropped.
+
+> **Security note:** Only add bot user IDs you operate or trust. A peer bot's messages reach Claude with the same effective trust as human messages, and a compromised peer bot can attempt prompt injection. The system prompt treats peer-bot content as untrusted, but that's a last-line defense — the first line is you being deliberate about what's in `allowBotIds`. Cross-bot delivery requires explicit opt-in precisely so operators have to think about this tradeoff before enabling it.
 
 ### `pending`
 Active pairing codes. Auto-pruned on every gate check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Per-channel `allowBotIds` for opt-in cross-bot message delivery (#33) — @CaseyMargell. Default-safe: absent or empty `allowBotIds` preserves the prior "all bot messages dropped" behavior for every existing install. Self-echo detection uses a triple-check against `bot_id`, `bot_profile.app_id`, and `user === botUserId` to cover Slack payload variants (including `as_user=false` posts and multi-workspace installs). Permission-reply-shaped peer-bot messages (`y abcde`, `no xyzwq`) are dropped at the gate. Peer bots still cannot approve permission prompts — that path is gated on the top-level `allowFrom`. See [ACCESS.md](ACCESS.md) for schema and security tradeoffs.
+- System prompt now warns Claude that peer-bot messages carry the same prompt-injection risk as human messages and may be coordinated by an attacker who controls the peer bot's session (#33).
+- Audit log line on every delivered bot message (`[slack] bot message delivered`) — diagnostics for multi-agent flows (#33).
+
+### Changed
+- Gemini PR review workflow switched from `pull_request` to `pull_request_target` so fork PRs receive AI review (#34). Workflow is read-only by design: checks out the PR head SHA but never executes any code from it, and the run-gemini-cli action is restricted to read-only shell tools.
+- `PERMISSION_REPLY_RE` moved from `server.ts` to `lib.ts` so the gate can drop permission-reply-shaped peer-bot text. No behavior change for human permission replies (#33).
+
+### Fixed
+- Docs: corrected runtime dependency count in `CONTRIBUTING.md` (was "three", actually four including `zod`) and filled the `CODE_OF_CONDUCT.md` enforcement contact placeholder with `jeremy@intentsolutions.io` (#28).
+
 ## [0.3.1] - 2026-04-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,10 @@ CI runs typecheck + tests on every push to main and every PR (`.github/workflows
 
 This is a prompt injection vector. Five defense layers:
 
-1. **Inbound gate** (`gate()`) — drops ungated messages before MCP notification
+1. **Inbound gate** (`gate()`) — drops ungated messages before MCP notification. Bot messages dropped by default; per-channel `allowBotIds` opts specific peer bots in. Self-echo detection matches on `bot_id` / `bot_profile.app_id` / `user === botUserId` to cover payload variants. `PERMISSION_REPLY_RE` is checked at the gate so peer bots cannot inject permission-reply text.
 2. **Outbound gate** (`assertOutboundAllowed()`) — replies only to delivered channels
 3. **File exfiltration guard** (`assertSendable()`) — blocks sending state dir files
-4. **System prompt hardening** — instructions tell Claude to refuse pairing/access from messages
+4. **System prompt hardening** — instructions tell Claude to refuse pairing/access from messages. Peer-bot messages are flagged as carrying the same prompt-injection risk as human messages.
 5. **Token security** — `.env` chmod 0o600, atomic writes, never logged
 
 Any change to `gate()`, `assertSendable()`, or `assertOutboundAllowed()` is security-critical.

--- a/README.md
+++ b/README.md
@@ -99,13 +99,33 @@ See [ACCESS.md](ACCESS.md) for the full schema.
 /slack-channel:access status                 # Show current config
 ```
 
+### Multi-agent coordination
+
+Channels can opt in to cross-bot message delivery by listing trusted bot user IDs in `allowBotIds`. Useful when multiple Claude Code instances (or other bots you operate) need to coordinate in a shared channel — e.g., an ops-monitor agent and an engineering agent in `#incidents`. Default is no cross-bot delivery: every bot message is dropped at the gate. See [ACCESS.md](ACCESS.md) for the full schema and security tradeoffs.
+
+Example `access.json` entry:
+
+```json
+{
+  "channels": {
+    "C_INCIDENTS": {
+      "requireMention": false,
+      "allowFrom": ["U_OPS_BOT", "U_ENG_BOT", "U_HUMAN"],
+      "allowBotIds": ["U_OPS_BOT", "U_ENG_BOT"]
+    }
+  }
+}
+```
+
+Self-echoes from this bot are always filtered regardless of `allowBotIds`. Peer bots cannot approve permission prompts — the permission relay gates on the top-level `allowFrom`, not the channel policy.
+
 ## Security
 
 - **Sender gating**: Every inbound message hits a gate. Ungated messages are silently dropped before reaching Claude.
 - **Outbound gate**: Replies only work to channels that passed the inbound gate.
 - **File exfiltration guard**: Cannot send `.env`, `access.json`, or other state files through the reply tool.
 - **Prompt injection defense**: System instructions explicitly tell Claude to refuse pairing/access requests from Slack messages.
-- **Bot filtering**: All `bot_id` messages are dropped (prevents bot-to-bot loops).
+- **Bot filtering**: `bot_id` messages are dropped by default. Channels that host multiple cooperating agents can opt in to specific peers via `allowBotIds`; self-echoes are always filtered via `bot_id` / `bot_profile.app_id` / `user` triple-check.
 - **Link unfurling disabled**: All outbound messages set `unfurl_links: false, unfurl_media: false`.
 - **Token security**: `.env` is `chmod 0o600`, never logged, never in tool results.
 - **Static mode**: Set `SLACK_ACCESS_MODE=static` to freeze access at boot (no runtime mutation).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,10 +24,10 @@ You should receive a response within 48 hours. We will work with you to understa
 
 This plugin is a **prompt injection vector** — anyone who can send a message that reaches the Claude Code session can potentially manipulate Claude. The security architecture has multiple defense layers:
 
-1. **Inbound gate**: Drops all messages from non-allowlisted senders before they reach MCP
+1. **Inbound gate**: Drops all messages from non-allowlisted senders before they reach MCP. Bot messages are dropped by default; channels opt in to specific peer bots via per-channel `allowBotIds` (see [ACCESS.md](ACCESS.md)). Self-echo filtering matches on `bot_id`, `bot_profile.app_id`, and `user === botUserId` to cover payload variants.
 2. **Outbound gate**: Restricts replies to channels that passed the inbound gate
 3. **File exfiltration guard**: Blocks sending state directory files (`.env`, `access.json`)
-4. **System prompt hardening**: Instructs Claude to refuse pairing/access manipulation from messages
+4. **System prompt hardening**: Instructs Claude to refuse pairing/access manipulation from messages. Peer-bot messages are explicitly flagged as carrying the same prompt-injection risk as human messages.
 5. **Token security**: All secrets are `chmod 0o600`, never logged, atomic writes
 
 See the threat model in the project plan for the full analysis.
@@ -39,7 +39,7 @@ In scope:
 - Token exfiltration (secrets sent via reply tool or leaked in tool results)
 - State tampering (access.json modified by message content)
 - Outbound gate bypass (reply sent to arbitrary channel)
-- Bot-to-bot amplification
+- Bot-to-bot amplification — including self-echo bypass, cross-bot delivery without explicit `allowBotIds` opt-in, and permission-relay escalation via peer-bot messages
 
 Out of scope:
 - Slack platform vulnerabilities (report to Slack)


### PR DESCRIPTION
## Summary

Follow-up to @CaseyMargell's #33, which landed the `allowBotIds` feature. Per the scope agreement on #27 (comment [4274625065](https://github.com/jeremylongshore/claude-code-slack-channel/issues/27#issuecomment-4274625065)), the doc updates were excluded from Casey's PR and promised as a follow-up. This is that follow-up.

Covers all five files called out in the review scope.

## Changes

| File | What changed |
|------|--------------|
| `ACCESS.md` | Added `allowBotIds` to the schema JSON example. Added field description alongside `requireMention` and `allowFrom`. New \"Multi-agent coordination (`allowBotIds`)\" section covering the default-safe drop, the self-echo triple-check (`bot_id` / `bot_profile.app_id` / `user`), the `PERMISSION_REPLY_RE` gate guard, `requireMention` + `allowFrom` interaction, DM invariant, and a security callout about only listing trusted bots. |
| `README.md` | New \"Multi-agent coordination\" subsection under Access Control with an `access.json` example. Bot-filtering security bullet rewritten — no longer \"all bot_id messages are dropped,\" now \"dropped by default with per-channel opt-in.\" |
| `CHANGELOG.md` | `[Unreleased]` entries for #33 (allowBotIds), #34 (Gemini `pull_request_target`), and #28 (CONTRIBUTING/CoC fixes). |
| `SECURITY.md` | Inbound gate description updated to mention `allowBotIds` and the self-echo triple-check. System-prompt hardening bullet updated to reflect the peer-bot injection warning. In-scope list extended: \"Bot-to-bot amplification — including self-echo bypass, cross-bot delivery without explicit `allowBotIds` opt-in, and permission-relay escalation via peer-bot messages.\" |
| `CLAUDE.md` | Security Architecture layer 1 (Inbound gate) expanded to document `allowBotIds`, self-echo triple-check, and `PERMISSION_REPLY_RE` gate guard. Layer 4 (System prompt hardening) mentions the peer-bot risk. |

## Not included here

- **No version bump.** Per the plan this goes through `/release`, not a docs PR. CHANGELOG is staged under `[Unreleased]` ready for the release skill to promote to `[0.4.0]`.
- **No code changes.** Everything Casey shipped in #33 is already on main and correct.

## Test plan

- [x] `bun run typecheck` — clean (no code changed)
- [x] `bun test` — 104/104 pass
- [ ] CI green on PR
- [ ] Manual: skim `ACCESS.md` renders cleanly on GitHub

Jeremy made me do it
-claude