### PR TITLE
chore(pr-template): add "re-read the full diff before merging" checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -100,3 +100,4 @@ convincing, you'll be asked for more, or the PR will be declined.
 - [ ] I did not add runtime dependencies beyond what's needed (the "four deps" rule)
 - [ ] Commit messages describe *why*, not just *what*
 - [ ] If this is a breaking change, `CHANGELOG.md` says so loudly
+- [ ] I re-read the full PR diff (not just the latest commit) before clicking merge


### PR DESCRIPTION
## Summary

Adds one line to the PR template checklist: _\"I re-read the full PR diff (not just the latest commit) before clicking merge.\"_

## Why

Solo-maintainer forcing function. Branch protection with `require_code_owner_reviews: true` is configuration theater when the CODEOWNER and the PR author are the same person — you can still click approve without actually reading. An explicit re-read checkbox puts the discipline where it lives: in a box the author has to tick, and reminds them the latest-commit diff isn't the full diff on a multi-commit PR.

No code changes. No test impact.

Jeremy made me do it
-claude