### PR TITLE
feat(lib): SessionKey type for thread-scoped sessions (32-A.1)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -65,6 +65,25 @@ export interface GateResult {
   isResend?: boolean
 }
 
+/** Identity of a thread-scoped session. See 000-docs/session-state-machine.md.
+ *
+ *  Sessions are keyed by (channel, thread) so two parallel threads in the
+ *  same Slack channel do not observe each other's state. Both fields are
+ *  strings that arrive from the Slack event payload — never constructed
+ *  from message content.
+ *
+ *  For top-level (non-threaded) messages the supervisor synthesises
+ *  `thread = event.ts` at session-activation time so this type stays
+ *  total (no null case to handle downstream). That synthesis happens in
+ *  server.ts, not here. */
+export interface SessionKey {
+  /** Slack channel ID, e.g. `C0123456789` or `D0123456789` (DM). */
+  channel: string
+  /** Slack thread_ts, e.g. `1711000000.000100`. For top-level messages the
+   *  supervisor uses the message `ts` as the thread value. */
+  thread: string
+}
+
 // ---------------------------------------------------------------------------
 // Access helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `SessionKey` to `lib.ts` as the identity primitive for the thread-scoped session boundary. Pure type, no runtime behavior — implementation lands in 32-A.4 (`sessionPath`) and 32-A.5 (atomic writer). Closes bead **ccsc-z78.1**.

## Shape

```ts
export interface SessionKey {
  channel: string   // Slack channel ID (C... or D...)
  thread:  string   // Slack thread_ts, or ts of root message for non-threaded events
}
```

## Design notes

- **No null on `thread`.** The session supervisor synthesises `thread = event.ts` for top-level messages at activation time, so the type stays total and downstream code doesn't need `thread ?? event.ts` sprinkled everywhere.
- Matches the shape locked in by [`000-docs/session-state-machine.md`](../000-docs/session-state-machine.md) (the design-in-public contract for 32-A). This diverges slightly from the bead's draft signature (`{ channelId, threadTs: string | null }`) in favour of the spec doc.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 104 pass / 0 fail (no behavior change, expected)
- [ ] Re-read the full diff before merging

Jeremy made me do it
-claude