### PR TITLE
chore(policy): fix priority comment drift + gitignore local Claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ bun.lockb
 .dolt/
 *.db
 .beads-credential-key
+
+# Claude Code local settings (per-machine / per-user)
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/policy.ts
+++ b/policy.ts
@@ -67,8 +67,10 @@ const RuleBase = {
    *  messages. Two rules with the same id is a load-time error. */
   id: z.string().min(1).max(120),
 
-  /** Authored order of evaluation; lower first. Equal priorities tie-break
-   *  by the rule's position in the array the loader saw. */
+  /** Tie-breaker within effect when two rules would otherwise be
+   *  equivalent. Primary ordering is authored array position (first-
+   *  applicable, see 000-docs/policy-evaluation-flow.md §Combining).
+   *  Lower `priority` wins the tie. */
   priority: z.number().int().default(100),
 
   match: MatchSpec,


### PR DESCRIPTION
## Summary

Stop-the-line housekeeping surfaced by a deep review before claiming new policy-engine beads:

1. **`policy.ts:72` priority comment contradicted the frozen doc.** Comment said priority was the primary sort key with array position as tie-break. Doc (`000-docs/policy-evaluation-flow.md` §80-81, §89-93) says the opposite — array position is primary (first-applicable combining), `priority` is a within-effect tie-breaker. Left uncorrected, the 29-A.3 `evaluate()` implementer would have built on the wrong contract.
2. **Gitignore Claude Code local settings** — `.claude/settings.local.json` and `.claude/scheduled_tasks.lock` are per-user/per-machine runtime state.

## Scope

- Comment-only change on `policy.ts`. Schema and runtime behavior unchanged.
- `.gitignore` additions only.
- Typecheck: clean (`tsc --noEmit`).
- Tests: 104 pass, 0 fail.

## Related follow-up beads filed

- `ccsc-d3w` — P1 — Test coverage for PolicyRule Zod schema (depends on ccsc-v1b.1)
- `ccsc-a9z` — P1 — Fail-fast on missing SLACK_SENDABLE_ROOTS (lib.ts:284-286 silent fallback)
- `ccsc-t7j` — P2 — 30-A.15 `--verify-audit-log` CLI subcommand (doc referenced, no bead existed)

`ccsc-v1b.2` description also rewritten in beads to match the doc — `PolicyDecision` has three kinds (`allow | deny | require`), not four (the bead had conflated `PolicyRule.effect` with `PolicyDecision.kind` and invented a `prompt` variant).

## Test plan

- [x] `bun run typecheck`
- [x] `bun test`
- [ ] Reviewer spot-checks that the comment matches doc §80-81 and §89-93

Jeremy made me do it
-claude