### PR TITLE
feat(lib): sessionPath contract stub + failing spec tests (ccsc-z78.3)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -123,6 +123,24 @@ export interface Session {
   data: Record<string, unknown>
 }
 
+/** Construct the on-disk path for a session file.
+ *
+ *  Contract per 000-docs/session-state-machine.md §47-68:
+ *    <root>/sessions/<channel>/<thread>.json
+ *
+ *  Implementation lands in ccsc-z78.4 with three safety rules:
+ *    1. Validate every component against /^[A-Za-z0-9._-]+$/.
+ *    2. Resolve parent via fs.realpathSync.native and verify the state
+ *       root is still a prefix (CWE-22 symlink smuggling).
+ *    3. Create sessions/<channel>/ with mode 0o700 on first use.
+ *
+ *  Stub until then so the boundary type is exported and ccsc-z78.3's
+ *  failing spec test has a symbol to reference.
+ */
+export function sessionPath(_root: string, _key: SessionKey): string {
+  throw new Error('sessionPath not implemented (ccsc-z78.4)')
+}
+
 // ---------------------------------------------------------------------------
 // Access helpers
 // ---------------------------------------------------------------------------

--- a/server.test.ts
+++ b/server.test.ts
@@ -12,6 +12,7 @@ import {
   pruneExpired,
   generateCode,
   isDuplicateEvent,
+  sessionPath,
   EVENT_DEDUP_TTL_MS,
   PERMISSION_REPLY_RE,
   MAX_PENDING,
@@ -19,6 +20,7 @@ import {
   PAIRING_EXPIRY_MS,
   type Access,
   type GateOptions,
+  type SessionKey,
 } from './lib.ts'
 import {
   mkdtempSync,
@@ -1013,5 +1015,58 @@ describe('isDuplicateEvent', () => {
     expect(isDuplicateEvent(event, seen, 1000, 60000)).toBe(false)
     // `app_mention` subscription fires shortly after with the same event
     expect(isDuplicateEvent(event, seen, 1050, 60000)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sessionPath — ccsc-z78.3 failing test (spec-first)
+//
+// Locks the thread-scoped layout from 000-docs/session-state-machine.md §47-68
+// before any implementation lands. Skipped tests below are the red side of
+// the TDD cycle; ccsc-z78.4 un-skips and implements sessionPath() to go
+// green. Do not delete these assertions without updating the design doc.
+// ---------------------------------------------------------------------------
+
+describe('sessionPath', () => {
+  const key = (channel: string, thread: string): SessionKey => ({ channel, thread })
+
+  test('stub throws until ccsc-z78.4 lands — locks the export contract', () => {
+    // Active gate so ccsc-z78.4 cannot quietly rename, remove, or change
+    // the signature of this symbol without a visible test failure.
+    expect(() => sessionPath('/tmp/state', key('C0000000001', '1700000000.000100'))).toThrow(
+      /not implemented/,
+    )
+  })
+
+  test.skip('two threads in one channel produce two distinct file paths', () => {
+    // ccsc-z78.4 un-skips. The bug this epic fixes: a flat
+    // <root>/sessions/<channel>.json layout cannot represent two
+    // parallel threads in one channel. The path must encode `thread`.
+    const root = '/tmp/state-root'
+    const p1 = sessionPath(root, key('C_CHAN', 'T1700000000.000100'))
+    const p2 = sessionPath(root, key('C_CHAN', 'T1700000000.000200'))
+
+    expect(p1).not.toBe(p2)
+    expect(p1.endsWith('/T1700000000.000100.json')).toBe(true)
+    expect(p2.endsWith('/T1700000000.000200.json')).toBe(true)
+
+    // Both live under the same per-channel directory.
+    const dir1 = p1.slice(0, p1.lastIndexOf('/'))
+    const dir2 = p2.slice(0, p2.lastIndexOf('/'))
+    expect(dir1).toBe(dir2)
+    expect(dir1.endsWith('/sessions/C_CHAN')).toBe(true)
+  })
+
+  test.skip('different channels produce paths under different per-channel dirs', () => {
+    // ccsc-z78.4 un-skips. Sibling threads may collide in filename
+    // (same thread_ts across channels is improbable but legal); the
+    // per-channel parent directory keeps them isolated.
+    const root = '/tmp/state-root'
+    const p1 = sessionPath(root, key('C_AAA', '1700000000.000100'))
+    const p2 = sessionPath(root, key('C_BBB', '1700000000.000100'))
+
+    expect(p1).not.toBe(p2)
+    expect(p1.includes('/sessions/C_AAA/')).toBe(true)
+    expect(p2.includes('/sessions/C_BBB/')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

TDD red-phase for Epic 32-A (ccsc-z78). Closes **ccsc-z78.3**.

Locks the `sessionPath(root, key)` boundary from [`000-docs/session-state-machine.md` §47-68](./000-docs/session-state-machine.md) **before** the implementation arrives in `ccsc-z78.4`.

## What's in this PR

- **`lib.ts`** — exported `sessionPath()` stub that throws `'not implemented (ccsc-z78.4)'`. JSDoc on the stub cites the three safety rules `.4` must uphold (component regex `/^[A-Za-z0-9._-]+$/`, realpath parent containment, 0o700 dir creation).
- **`server.test.ts`** — a new `describe('sessionPath')` block with:
  - One active test pinning the stub contract (it must exist and throw).
  - Two `test.skip` spec tests encoding the invariants that flip to green in `.4`:
    1. Two threads in one channel produce distinct paths ending in `<thread>.json`, sharing a `/sessions/<channel>/` parent directory.
    2. Different channels produce paths under different per-channel dirs.

No runtime or behavior change — `sessionPath()` has no callers yet.

## Why skip, not red?

Landing an actually-failing test on main would break the required `Typecheck + test` status check for every downstream PR until `.4` lands. The skipped tests are the spec — they're a contract `.4` commits to making pass. The active stub-contract test prevents silent signature drift in the meantime.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 105 pass / 2 skip / 0 fail / 241 expects
- [ ] `.4` author un-skips both `test.skip` blocks and implements the body; expected final state after `.4`: 108 pass / 0 skip.

## Related

- Parent epic: `ccsc-z78` — "Give each Slack thread its own session file on disk"
- Next in sequence: `ccsc-z78.4` — implement `sessionPath()` with the three safety rules.
- Frozen design doc: `000-docs/session-state-machine.md`

Jeremy made me do it
-claude