### PR TITLE
feat(lib): loadSession + migrator + restart integration (closes sub-epics z78.12 and z78.13)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -10,7 +10,7 @@
 
 import { resolve, sep, basename, join } from 'path'
 import { realpathSync, mkdirSync } from 'fs'
-import { writeFile, chmod, rename, unlink } from 'fs/promises'
+import { writeFile, chmod, rename, unlink, readFile } from 'fs/promises'
 
 // ---------------------------------------------------------------------------
 // Constants (re-exported so server.ts and tests share the same values)
@@ -257,6 +257,46 @@ export async function saveSession(path: string, session: Session): Promise<void>
     }
     throw err
   }
+}
+
+/** Read and parse a session file, fail-closed on any containment breach.
+ *
+ *  Contract (000-docs/session-state-machine.md §47-68, §232-239):
+ *
+ *  - `path` is assumed to be the output of `sessionPath()` from a prior
+ *    turn. Between save and load, an adversary with local access could
+ *    replace the file with a symlink pointing outside the state root.
+ *    `loadSession` catches that by realpath-ing both the root and the
+ *    path and verifying root-prefix containment.
+ *  - Both `root` and `path` are realpath-resolved up front. Any
+ *    resolution failure (ENOENT on a missing file, loop, permission)
+ *    propagates to the caller — the supervisor treats that as a
+ *    `Quarantined` transition per the state machine.
+ *  - JSON.parse errors propagate unchanged. No silent recovery;
+ *    malformed session files are loud failures.
+ *
+ *  This function does NOT schema-validate the parsed object against the
+ *  `Session` shape. The writer (saveSession) is trusted to produce valid
+ *  content; runtime schema validation is a separate concern (a Zod
+ *  schema for Session would live with the type).
+ *
+ *  **Fail-closed posture.** Any throw here should drop the event (the
+ *  supervisor Quarantines the key); it must never degrade to a partial
+ *  load or a synthesized empty session.
+ */
+export async function loadSession(root: string, path: string): Promise<Session> {
+  const resolvedRoot = realpathSync.native(resolve(root))
+  // realpath on the file itself — throws ENOENT if missing, which is
+  // the caller's signal to create a fresh session. Also collapses any
+  // symlinks at `path` to their true target.
+  const resolvedFile = realpathSync.native(path)
+  if (!isUnderRoot(resolvedFile, resolvedRoot)) {
+    throw new Error(
+      `loadSession: resolved path escapes state root: ${JSON.stringify(path)}`,
+    )
+  }
+  const raw = await readFile(resolvedFile, 'utf8')
+  return JSON.parse(raw) as Session
 }
 
 // ---------------------------------------------------------------------------

--- a/lib.ts
+++ b/lib.ts
@@ -9,7 +9,7 @@
  */
 
 import { resolve, sep, basename, join } from 'path'
-import { realpathSync, mkdirSync } from 'fs'
+import { realpathSync, mkdirSync, readdirSync, statSync, existsSync } from 'fs'
 import { writeFile, chmod, rename, unlink, readFile } from 'fs/promises'
 
 // ---------------------------------------------------------------------------
@@ -297,6 +297,100 @@ export async function loadSession(root: string, path: string): Promise<Session> 
   }
   const raw = await readFile(resolvedFile, 'utf8')
   return JSON.parse(raw) as Session
+}
+
+/** Filename used as the thread-slot for migrated pre-0.5.0 session files.
+ *  Sessions whose original files used the flat per-channel layout surface
+ *  as this synthetic "default" thread after migration. */
+export const MIGRATED_DEFAULT_THREAD = 'default'
+
+/** Sentinel the migrator drops after a successful pass so subsequent
+ *  boots skip the scan. Lives inside sessions/ next to the per-channel
+ *  dirs — that's the tree being migrated, so the marker travels with it
+ *  if an operator ever moves or backs up the state root. */
+const MIGRATED_MARKER = '.migrated'
+
+/** One-shot migrator from the v0.4.x flat layout
+ *    sessions/<channel>.json
+ *  to the v0.5.0 thread-scoped layout
+ *    sessions/<channel>/<thread>.json
+ *
+ *  The legacy file becomes the `default` thread (constant above) so
+ *  existing conversations continue across the upgrade without context
+ *  loss (see 000-docs/session-state-machine.md §71-81).
+ *
+ *  Semantics:
+ *    - Idempotent. A successful pass drops `sessions/.migrated`; later
+ *      calls no-op.
+ *    - If `sessions/` does not exist (fresh install), drops the marker
+ *      anyway so v0.5.0 never re-scans.
+ *    - If the per-channel directory already exists from a partial prior
+ *      migration, skips that channel rather than clobbering.
+ *    - Component validation on every channel name — a malformed legacy
+ *      file (`.` / `..` / path separators) is skipped and reported.
+ *    - Preserves file mode because `rename` does not touch it. The
+ *      legacy writer used 0o600; the post-migration file keeps 0o600.
+ *
+ *  Called by `server.ts` at bootstrap, before any session activity. Not
+ *  safe to call while the supervisor is running (races with active
+ *  writers). Designed for boot-time only.
+ */
+export async function migrateFlatSessions(
+  root: string,
+): Promise<{ migrated: string[]; skipped: string[]; alreadyDone: boolean }> {
+  const resolvedRoot = realpathSync.native(resolve(root))
+  const sessionsDir = join(resolvedRoot, 'sessions')
+
+  // No sessions dir at all — fresh install. Create it and drop the
+  // marker so v0.5.0 boots never re-scan.
+  if (!existsSync(sessionsDir)) {
+    mkdirSync(sessionsDir, { recursive: true, mode: 0o700 })
+    await writeFile(join(sessionsDir, MIGRATED_MARKER), '', { mode: 0o600 })
+    return { migrated: [], skipped: [], alreadyDone: false }
+  }
+
+  // Idempotence: marker present → we're done.
+  if (existsSync(join(sessionsDir, MIGRATED_MARKER))) {
+    return { migrated: [], skipped: [], alreadyDone: true }
+  }
+
+  const migrated: string[] = []
+  const skipped: string[] = []
+
+  for (const entry of readdirSync(sessionsDir)) {
+    // Only legacy flat files: sessions/*.json that is a regular file.
+    if (!entry.endsWith('.json')) continue
+    const full = join(sessionsDir, entry)
+    const st = statSync(full)
+    if (!st.isFile()) continue
+
+    const channel = entry.slice(0, -'.json'.length)
+
+    // Defense-in-depth: a legacy file could have any name. Reject
+    // anything we wouldn't accept in the new layout.
+    if (!isValidSessionComponent(channel)) {
+      skipped.push(entry)
+      continue
+    }
+
+    const channelDir = join(sessionsDir, channel)
+    const target = join(channelDir, `${MIGRATED_DEFAULT_THREAD}.json`)
+
+    // If the per-channel dir already exists from a partial prior
+    // migration (interrupted boot, manual poking), skip rather than
+    // clobber. Operator decides what to do with the stray legacy file.
+    if (existsSync(channelDir)) {
+      skipped.push(entry)
+      continue
+    }
+
+    mkdirSync(channelDir, { recursive: true, mode: 0o700 })
+    await rename(full, target)
+    migrated.push(channel)
+  }
+
+  await writeFile(join(sessionsDir, MIGRATED_MARKER), '', { mode: 0o600 })
+  return { migrated, skipped, alreadyDone: false }
 }
 
 // ---------------------------------------------------------------------------

--- a/server.test.ts
+++ b/server.test.ts
@@ -15,6 +15,8 @@ import {
   sessionPath,
   saveSession,
   loadSession,
+  migrateFlatSessions,
+  MIGRATED_DEFAULT_THREAD,
   EVENT_DEDUP_TTL_MS,
   PERMISSION_REPLY_RE,
   MAX_PENDING,
@@ -1401,5 +1403,227 @@ describe('loadSession', () => {
     expect(loadedB.ownerId).toBe('U_B')
     expect(loadedA.key.thread).toBe('TA.0')
     expect(loadedB.key.thread).toBe('TB.0')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// migrateFlatSessions — 000-docs/session-state-machine.md §71-81
+//
+// One-shot boot-time migration from flat pre-0.5.0 layout
+// (sessions/<channel>.json) to thread-scoped layout
+// (sessions/<channel>/default.json). Idempotent via .migrated marker.
+// ---------------------------------------------------------------------------
+
+describe('migrateFlatSessions', () => {
+  let rawRoot: string
+  let tmpRoot: string
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'migrate-'))
+    tmpRoot = realpathSync.native(rawRoot)
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  const writeLegacy = (channel: string, payload: unknown): void => {
+    const sessionsDir = join(tmpRoot, 'sessions')
+    mkdirSync(sessionsDir, { recursive: true, mode: 0o700 })
+    writeFileSync(join(sessionsDir, `${channel}.json`), JSON.stringify(payload), {
+      mode: 0o600,
+    })
+  }
+
+  test('migrates a single legacy file to <channel>/default.json', async () => {
+    const legacyBody = { v: 1, legacy: 'pre-0.5.0 content' }
+    writeLegacy('C_LEG', legacyBody)
+
+    const result = await migrateFlatSessions(tmpRoot)
+
+    expect(result.migrated).toEqual(['C_LEG'])
+    expect(result.alreadyDone).toBe(false)
+
+    const newPath = join(tmpRoot, 'sessions', 'C_LEG', `${MIGRATED_DEFAULT_THREAD}.json`)
+    expect(existsSync(newPath)).toBe(true)
+    expect(JSON.parse(readFileSync(newPath, 'utf8'))).toEqual(legacyBody)
+
+    // Legacy flat file removed.
+    expect(existsSync(join(tmpRoot, 'sessions', 'C_LEG.json'))).toBe(false)
+  })
+
+  test('preserves file mode 0o600 across rename', async () => {
+    writeLegacy('C_MODE', { v: 1 })
+    await migrateFlatSessions(tmpRoot)
+
+    const newPath = join(tmpRoot, 'sessions', 'C_MODE', `${MIGRATED_DEFAULT_THREAD}.json`)
+    const st = statSync(newPath)
+    expect(st.mode & 0o777).toBe(0o600)
+  })
+
+  test('is idempotent — second call is a no-op', async () => {
+    writeLegacy('C_IDEM', { v: 1 })
+    const first = await migrateFlatSessions(tmpRoot)
+    expect(first.migrated).toEqual(['C_IDEM'])
+
+    const second = await migrateFlatSessions(tmpRoot)
+    expect(second.alreadyDone).toBe(true)
+    expect(second.migrated).toEqual([])
+  })
+
+  test('drops marker even on fresh-install (sessions/ did not exist)', async () => {
+    const result = await migrateFlatSessions(tmpRoot)
+    expect(result.migrated).toEqual([])
+    expect(result.alreadyDone).toBe(false)
+    expect(existsSync(join(tmpRoot, 'sessions', '.migrated'))).toBe(true)
+  })
+
+  test('skips legacy filenames with invalid components (defense in depth)', async () => {
+    mkdirSync(join(tmpRoot, 'sessions'), { recursive: true, mode: 0o700 })
+    // ".." is a legacy filename that would migrate to sessions/../default.json
+    // — exactly the lexical-escape we added a guard for in sessionPath.
+    writeFileSync(join(tmpRoot, 'sessions', '...json'), 'x')
+
+    const result = await migrateFlatSessions(tmpRoot)
+    expect(result.migrated).toEqual([])
+    // The entry "...json" has channel "..", rejected by isValidSessionComponent.
+    expect(result.skipped).toEqual(['...json'])
+  })
+
+  test('skips channels whose target per-channel dir already exists', async () => {
+    // Partial prior migration: the new-layout dir was created but the
+    // legacy file was not yet removed. Don't clobber — operator triage.
+    writeLegacy('C_PART', { v: 1 })
+    mkdirSync(join(tmpRoot, 'sessions', 'C_PART'), { recursive: true, mode: 0o700 })
+
+    const result = await migrateFlatSessions(tmpRoot)
+    expect(result.migrated).toEqual([])
+    expect(result.skipped).toEqual(['C_PART.json'])
+    // Legacy file left in place so the operator can see both.
+    expect(existsSync(join(tmpRoot, 'sessions', 'C_PART.json'))).toBe(true)
+  })
+
+  test('migrates multiple channels in one pass', async () => {
+    writeLegacy('C_A', { v: 1, owner: 'a' })
+    writeLegacy('C_B', { v: 1, owner: 'b' })
+    writeLegacy('C_C', { v: 1, owner: 'c' })
+
+    const result = await migrateFlatSessions(tmpRoot)
+    expect(result.migrated.sort()).toEqual(['C_A', 'C_B', 'C_C'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration — ccsc-z78.8: state survives process restart under both
+// layouts. Composes migrateFlatSessions, sessionPath, saveSession, and
+// loadSession to prove the full boot → work → restart → resume flow.
+// ---------------------------------------------------------------------------
+
+describe('session persistence across restart', () => {
+  let rawRoot: string
+  let tmpRoot: string
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'restart-'))
+    tmpRoot = realpathSync.native(rawRoot)
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  test('legacy layout → migrate → restart → load returns original content', async () => {
+    // Simulate a v0.4.x state dir with a flat session file.
+    const legacyPayload: Session = {
+      v: 1,
+      key: { channel: 'C_OLD', thread: MIGRATED_DEFAULT_THREAD },
+      createdAt: 1_700_000_000_000,
+      lastActiveAt: 1_700_000_500_000,
+      ownerId: 'U_PREUPGRADE',
+      data: { history: ['q1', 'a1', 'q2'] },
+    }
+    const sessionsDir = join(tmpRoot, 'sessions')
+    mkdirSync(sessionsDir, { recursive: true, mode: 0o700 })
+    writeFileSync(join(sessionsDir, 'C_OLD.json'), JSON.stringify(legacyPayload), {
+      mode: 0o600,
+    })
+
+    // Boot v0.5.0: migrator runs once.
+    await migrateFlatSessions(tmpRoot)
+
+    // "Restart": later boot recomputes path from key, loadSession reads.
+    const key: SessionKey = { channel: 'C_OLD', thread: MIGRATED_DEFAULT_THREAD }
+    const p = sessionPath(tmpRoot, key)
+    const loaded = await loadSession(tmpRoot, p)
+
+    expect(loaded).toEqual(legacyPayload)
+  })
+
+  test('new layout → save → restart → load returns original content', async () => {
+    const key: SessionKey = { channel: 'C_NEW', thread: '1700000000.000100' }
+    const s: Session = {
+      v: 1,
+      key,
+      createdAt: 1_700_000_000_000,
+      lastActiveAt: 1_700_000_100_000,
+      ownerId: 'U_OWNER',
+      data: { turns: ['one', 'two'] },
+    }
+
+    // Boot 1: ensure state dir, migrate (no-op), save the session.
+    await migrateFlatSessions(tmpRoot)
+    const p1 = sessionPath(tmpRoot, key)
+    await saveSession(p1, s)
+
+    // Boot 2: migrate is idempotent, sessionPath returns the same path
+    // (it just re-mkdirs the per-channel dir), load returns the session.
+    const migrated2 = await migrateFlatSessions(tmpRoot)
+    expect(migrated2.alreadyDone).toBe(true)
+
+    const p2 = sessionPath(tmpRoot, key)
+    expect(p2).toBe(p1)
+    const loaded = await loadSession(tmpRoot, p2)
+    expect(loaded).toEqual(s)
+  })
+
+  test('mixed: legacy file for one channel + new-layout file for another, both survive', async () => {
+    // Channel A: legacy file.
+    const legacy: Session = {
+      v: 1,
+      key: { channel: 'C_MIX_OLD', thread: MIGRATED_DEFAULT_THREAD },
+      createdAt: 1_700_000_000_000,
+      lastActiveAt: 1_700_000_000_000,
+      ownerId: 'U_A',
+      data: {},
+    }
+    const sessionsDir = join(tmpRoot, 'sessions')
+    mkdirSync(sessionsDir, { recursive: true, mode: 0o700 })
+    writeFileSync(join(sessionsDir, 'C_MIX_OLD.json'), JSON.stringify(legacy), {
+      mode: 0o600,
+    })
+
+    // Run migrator — legacy file becomes new-layout.
+    await migrateFlatSessions(tmpRoot)
+
+    // Channel B: new-layout save (post-migration).
+    const newKey: SessionKey = { channel: 'C_MIX_NEW', thread: 'T1.0' }
+    const newSession: Session = {
+      v: 1,
+      key: newKey,
+      createdAt: 1_700_000_100_000,
+      lastActiveAt: 1_700_000_100_000,
+      ownerId: 'U_B',
+      data: {},
+    }
+    const pNew = sessionPath(tmpRoot, newKey)
+    await saveSession(pNew, newSession)
+
+    // Restart: both survive.
+    const loadedOld = await loadSession(
+      tmpRoot,
+      sessionPath(tmpRoot, { channel: 'C_MIX_OLD', thread: MIGRATED_DEFAULT_THREAD }),
+    )
+    const loadedNew = await loadSession(tmpRoot, sessionPath(tmpRoot, newKey))
+
+    expect(loadedOld.ownerId).toBe('U_A')
+    expect(loadedNew.ownerId).toBe('U_B')
   })
 })

--- a/server.test.ts
+++ b/server.test.ts
@@ -14,6 +14,7 @@ import {
   isDuplicateEvent,
   sessionPath,
   saveSession,
+  loadSession,
   EVENT_DEDUP_TTL_MS,
   PERMISSION_REPLY_RE,
   MAX_PENDING,
@@ -1285,5 +1286,120 @@ describe('saveSession', () => {
     const loaded = JSON.parse(readFileSync(p, 'utf8')) as Session
     expect(loaded.key.channel).toBe('C_ID')
     expect(loaded.key.thread).toBe('1700000000.000100')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadSession — realpath-guarded reader
+//
+// Entry point to on-disk state after a supervisor restart. Trusts nothing:
+// realpaths both root and target, verifies containment, fail-closed on any
+// resolution error. See 000-docs/session-state-machine.md §232-239 for the
+// restart-recovery contract this reader serves.
+// ---------------------------------------------------------------------------
+
+describe('loadSession', () => {
+  let rawRoot: string
+  let tmpRoot: string
+
+  const makeSession = (channel: string, thread: string): Session => ({
+    v: 1,
+    key: { channel, thread },
+    createdAt: 1_700_000_000_000,
+    lastActiveAt: 1_700_000_001_000,
+    ownerId: 'U_OWNER',
+    data: { turns: ['hello', 'world'] },
+  })
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'loadSession-'))
+    tmpRoot = realpathSync.native(rawRoot)
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  test('round-trips with saveSession — load returns the saved object', async () => {
+    const key = { channel: 'C_RT', thread: '1700000000.000100' }
+    const p = sessionPath(tmpRoot, key)
+    const s = makeSession(key.channel, key.thread)
+
+    await saveSession(p, s)
+    const loaded = await loadSession(tmpRoot, p)
+
+    expect(loaded).toEqual(s)
+  })
+
+  test('throws ENOENT when file is missing', async () => {
+    const p = sessionPath(tmpRoot, { channel: 'C_MISS', thread: 'T1.0' })
+    // sessionPath created the per-channel dir but no file yet.
+    await expect(loadSession(tmpRoot, p)).rejects.toThrow()
+  })
+
+  test('rejects symlink at session file pointing outside the state root', async () => {
+    // Simulate an attacker who swaps the session file for a symlink
+    // to an arbitrary path after save. loadSession realpaths and
+    // checks the resolved target is still under the state root.
+    const outside = mkdtempSync(join(tmpdir(), 'loadSession-escape-'))
+    const victimFile = join(outside, 'victim.json')
+    writeFileSync(victimFile, JSON.stringify(makeSession('C_EVIL', 'T1.0')))
+
+    try {
+      const p = sessionPath(tmpRoot, { channel: 'C_EVIL', thread: 'T1.0' })
+      // Place a symlink at the session-file path pointing outside root.
+      symlinkSync(victimFile, p)
+
+      await expect(loadSession(tmpRoot, p)).rejects.toThrow(/escapes state root/)
+    } finally {
+      rmSync(outside, { recursive: true, force: true })
+    }
+  })
+
+  test('throws on malformed JSON — no silent recovery', async () => {
+    const p = sessionPath(tmpRoot, { channel: 'C_BAD', thread: 'T1.0' })
+    writeFileSync(p, '{not valid json', { mode: 0o600 })
+
+    await expect(loadSession(tmpRoot, p)).rejects.toThrow()
+  })
+
+  test('round-trip preserves nested data field contents', async () => {
+    const key = { channel: 'C_NEST', thread: 'T1.0' }
+    const p = sessionPath(tmpRoot, key)
+    const s = makeSession(key.channel, key.thread)
+    s.data = {
+      turns: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi back' },
+      ],
+      counters: { messages: 2, replies: 1 },
+    }
+
+    await saveSession(p, s)
+    const loaded = await loadSession(tmpRoot, p)
+
+    expect(loaded.data).toEqual(s.data)
+  })
+
+  test('two threads in one channel round-trip independently', async () => {
+    // Locks the core session-isolation invariant end-to-end: save thread A,
+    // save thread B, load both, neither sees the other's state.
+    const pA = sessionPath(tmpRoot, { channel: 'C_ISO', thread: 'TA.0' })
+    const pB = sessionPath(tmpRoot, { channel: 'C_ISO', thread: 'TB.0' })
+
+    const sA = makeSession('C_ISO', 'TA.0')
+    sA.ownerId = 'U_A'
+    const sB = makeSession('C_ISO', 'TB.0')
+    sB.ownerId = 'U_B'
+
+    await saveSession(pA, sA)
+    await saveSession(pB, sB)
+
+    const loadedA = await loadSession(tmpRoot, pA)
+    const loadedB = await loadSession(tmpRoot, pB)
+
+    expect(loadedA.ownerId).toBe('U_A')
+    expect(loadedB.ownerId).toBe('U_B')
+    expect(loadedA.key.thread).toBe('TA.0')
+    expect(loadedB.key.thread).toBe('TB.0')
   })
 })


### PR DESCRIPTION
## Summary

Bundles three leaves that together finish the file-level I/O story for Epic 32-A:

- **`ccsc-z78.6`** — `loadSession(root, path)` with realpath-guarded read
- **`ccsc-z78.7`** — `migrateFlatSessions(root)` one-shot boot migrator
- **`ccsc-z78.8`** — restart integration tests composing all four primitives

Closes the two remaining child sub-epics:
- `ccsc-z78.12` — *Safe path joining and atomic reads and writes* (was: .3 ✅, .4 ✅, .5 ✅, .6 ✅)
- `ccsc-z78.13` — *Move old flat session files into the new layout* (was: .7 ✅, .8 ✅)

Only the docs sub-epic (`ccsc-z78.14` — .9 ACCESS.md + .10 CLAUDE.md cross-link) remains before Epic 32-A can close.

## What's in the PR

### `loadSession(root, path): Promise<Session>`
Entry point to on-disk state after a supervisor restart. Zero-trust posture:
- `realpathSync.native` on both `root` and `path`.
- `isUnderRoot` check on the resolved file (rejects a symlink swapped in post-save).
- ENOENT / loop / permission → throw (supervisor Quarantines on any failure).
- JSON.parse errors propagate unchanged.
- Does **not** schema-validate the parsed object — the writer is trusted; runtime schema validation is a separate concern.

### `migrateFlatSessions(root)`
Boot-time migration from `sessions/<channel>.json` → `sessions/<channel>/default.json` (doc §71-81).
- Idempotent via `sessions/.migrated` sentinel.
- Fresh install also drops the marker (no re-scan on future boots).
- Component validation (`isValidSessionComponent`) — a legacy `..json` filename is rejected, not migrated to `sessions/..`.
- Partial-prior-migration detection: if `sessions/<channel>/` already exists, skip rather than clobber.
- `rename` preserves 0o600 mode.
- Exports `MIGRATED_DEFAULT_THREAD = 'default'` so consumers don't re-stringify.

### Restart integration tests (the ccsc-z78.8 spec)
Compose migrate + sessionPath + save + load to prove:
1. Legacy round-trip: flat file → migrate → restart → load.
2. New-layout round-trip: save → restart (idempotent migrate no-ops) → load.
3. Mixed coexistence: legacy for one channel + new-layout for another, both survive.

## Test plan — 10 new tests

| Group | Tests |
|---|---|
| `loadSession` | round-trip, ENOENT, symlink-escape rejection, malformed JSON, nested data preservation, two-threads-in-one-channel independence |
| `migrateFlatSessions` | single-file migration, mode 0o600 preservation, idempotence, fresh-install marker, invalid-component rejection, partial-migration skip, multi-channel one-pass |
| restart integration | legacy round-trip, new-layout round-trip, mixed layouts coexist |

**142 pass / 0 fail / 307 expects. Typecheck clean.**

## Runtime safety

**None of this is wired into `server.ts` yet.** Migrator is boot-time-only and intended to run before any session activity; that call site lands with Epic 32-B (supervisor integration). Loader/saver have zero call sites today. Shipping the primitives + their contract so the supervisor can consume them cleanly.

## Why bundled

Per request to reduce PR sprawl. These three leaves are one coherent story (read/write/migrate) and share tests (the restart integration test literally cannot exist without all three primitives). Splitting them would duplicate test scaffolding across three PRs for no architectural benefit.

Jeremy made me do it
-claude