### PR TITLE
docs(32-A): ACCESS.md state-layout + CLAUDE.md cross-links (closes sub-epic z78.14, finishes Epic 32-A)

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -115,6 +115,53 @@ How to split long messages: `"newline"` (paragraph-aware, default) or `"length"`
 - Corrupt files are moved aside and replaced with defaults
 - In static mode (`SLACK_ACCESS_MODE=static`), the file is read once at boot and never mutated
 
+## State directory layout
+
+All plugin state lives under `~/.claude/channels/slack/`. Files are mode `0o600`, directories `0o700` — owner-only access. The plugin is single-writer per state directory; running two plugin instances against the same directory is undefined behavior.
+
+```
+~/.claude/channels/slack/
+├── .env                        # tokens (xoxb / xapp), SLACK_SENDABLE_ROOTS, SLACK_ACCESS_MODE   (0o600)
+├── access.json                 # this file — allowlist, pairing codes, per-channel policy        (0o600)
+├── inbox/                      # downloaded attachments, auto-allowed for re-share via `reply`   (0o700)
+└── sessions/                   # per-thread conversation state (v0.5.0+)                          (0o700)
+    ├── .migrated               # sentinel: migrator has run; future boots skip the scan          (0o600)
+    ├── C0123456789/            # one directory per Slack channel ID
+    │   ├── default.json        #   migrated flat pre-0.5.0 session, if the channel had one       (0o600)
+    │   ├── 1700000000.000100.json   # one file per thread_ts                                     (0o600)
+    │   └── 1700000500.000200.json   #                                                            (0o600)
+    └── D0987654321/            # DMs use the same per-channel layout (channel ID starts with D)
+        └── 1700000100.000300.json
+```
+
+### How thread-scoping works
+
+A **session** is the unit of conversation state. One session corresponds to one Slack thread — **not** one channel. Two parallel threads in the same channel get two independent sessions and never observe each other's state.
+
+- `channel` — Slack channel ID, e.g. `C0123456789` (channel) or `D0123456789` (DM).
+- `thread` — `thread_ts` from the Slack event. For top-level (non-threaded) messages, the plugin synthesises `thread = ts` of the root message, so the first reply anchors the thread naturally.
+
+Session files are **self-describing**: each JSON file duplicates the `(channel, thread)` key inside the file body. A moved or copied session file stays traceable under forensic inspection.
+
+### Migration from v0.4.x
+
+Pre-0.5.0, the plugin kept one file per channel at `sessions/<channel>.json`. The migrator runs once at boot:
+
+- Finds each `sessions/*.json` that is a regular file.
+- Creates `sessions/<channel>/` at mode `0o700`.
+- Moves the legacy file to `sessions/<channel>/default.json` (atomic rename; mode preserved).
+- Drops `sessions/.migrated` so subsequent boots no-op.
+
+Existing conversations that predate thread-scoping surface as the `default` thread and continue without context loss. If the migrator encounters a partial prior migration (per-channel dir already exists), it leaves the legacy file in place and surfaces the conflict rather than clobber.
+
+### Safety invariants
+
+- **Realpath-guarded joins.** Every path is validated against `/^[A-Za-z0-9._-]+$/` and additionally rejected if the component is exactly `.` or `..` (both match the regex but would escape the `sessions/` layer via `path.join`). After the per-channel directory is created, `realpath` resolves it and the plugin verifies the state root is still a prefix — catches symlink-based smuggling (CWE-22).
+- **Atomic writes.** Every session save is `writeFile(<path>.tmp.<pid>, {flag: 'wx', mode: 0o600})` → `chmod 0o600` → `rename`. Readers never observe a partial file; the `wx` flag makes a stale `.tmp.*` from a crashed prior writer a loud failure rather than a silent overwrite.
+- **Fail-closed loader.** `loadSession` realpaths the file before reading; any containment breach or malformed JSON throws and the supervisor Quarantines the session. No silent degradation to an empty session.
+
+Full design reference: [`000-docs/session-state-machine.md`](000-docs/session-state-machine.md).
+
 ## File attachments — sendable roots
 
 The `reply` tool can attach files to Slack messages, but only files whose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ This is a prompt injection vector. Five defense layers:
 
 1. **Inbound gate** (`gate()`) — drops ungated messages before MCP notification. Bot messages dropped by default; per-channel `allowBotIds` opts specific peer bots in. Self-echo detection matches on `bot_id` / `bot_profile.app_id` / `user === botUserId` to cover payload variants. `PERMISSION_REPLY_RE` is checked at the gate so peer bots cannot inject permission-reply text.
 2. **Outbound gate** (`assertOutboundAllowed()`) — replies only to delivered channels
-3. **File exfiltration guard** (`assertSendable()`) — blocks sending state dir files
+3. **File exfiltration guard** (`assertSendable()`) — blocks sending state dir files (`.env`, `access.json`, `sessions/`, future `audit.log`). State-dir layout and per-thread session files are specified in [`000-docs/session-state-machine.md`](000-docs/session-state-machine.md) (Epic 32-A).
 4. **System prompt hardening** — instructions tell Claude to refuse pairing/access from messages. Peer-bot messages are flagged as carrying the same prompt-injection risk as human messages.
 5. **Token security** — `.env` chmod 0o600, atomic writes, never logged
 
@@ -95,10 +95,11 @@ Any change to `gate()`, `assertSendable()`, or `assertOutboundAllowed()` is secu
 
 ## State
 
-All state lives in `~/.claude/channels/slack/`:
+All state lives in `~/.claude/channels/slack/` (files `0o600`, directories `0o700`, single-writer):
 - `.env` — tokens (0o600)
 - `access.json` — allowlist + pairing codes (0o600, atomic writes)
 - `inbox/` — downloaded attachments
+- `sessions/<channel>/<thread>.json` — per-thread conversation state (v0.5.0+). Migrated flat pre-0.5.0 files surface as the `default` thread. See [`000-docs/session-state-machine.md`](000-docs/session-state-machine.md) for the layout spec, lifecycle state machine, and supervisor contract; operator-facing docs in [`ACCESS.md`](ACCESS.md#state-directory-layout).
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Bundles the last two docs leaves of Epic 32-A — **closes sub-epic `ccsc-z78.14`**, and (once merged) **closes the parent epic `ccsc-z78`**.

- `ccsc-z78.9` — ACCESS.md state-layout section
- `ccsc-z78.10` — CLAUDE.md cross-links into the state-machine doc

## ACCESS.md changes (z78.9)

New section `## State directory layout` between `## Security` and `## File attachments`:
- Full tree view of `~/.claude/channels/slack/` with mode annotations (files `0o600`, dirs `0o700`, single-writer).
- Thread-scoping explanation (one session = one thread, not one channel; `thread_ts` from Slack, synthesized from `ts` for top-level messages).
- v0.4.x → v0.5.0 migration behavior, including `default` thread naming and partial-migration skip.
- Three safety invariants: realpath-guarded joins (with the explicit `.`/`..` rejection), atomic writes, fail-closed loader.
- Cross-link to `000-docs/session-state-machine.md` for deep reading.

## CLAUDE.md changes (z78.10)

- **Security Architecture layer 3** (file exfiltration guard) now names `sessions/` explicitly and links out to the state-machine doc.
- **State section** gets a new bullet for `sessions/<channel>/<thread>.json` with the migrator's `default` thread note, cross-linking both the design doc and the new ACCESS.md section.

## Test plan

No code changes — pure docs.
- [x] `bun run typecheck` — clean
- [x] `bun test` — 142 pass / 0 fail / 307 expects
- [x] Internal links verified by grep (all target sections exist)

## Epic 32-A status after merge

```
ccsc-z78 — Give each Slack thread its own session file on disk  ✅ closing
├── z78.11 — Session identity and file-shape types               ✅ done (.1, .2)
├── z78.12 — Safe path joining and atomic reads and writes       ✅ done (.3, .4, .5, .6)
├── z78.13 — Move old flat session files into the new layout     ✅ done (.7, .8)
└── z78.14 — Update ACCESS.md and cross-link the state machine   ✅ done (.9, .10)  ← this PR
```

10 leaves total, all shipped. Runtime wiring follows in Epic 32-B (session supervisor).

Jeremy made me do it
-claude