### PR TITLE
feat(hardening): SENDABLE_ROOTS fail-fast + PolicyRule test coverage (ccsc-a9z, ccsc-d3w)

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -182,6 +182,12 @@ SLACK_SENDABLE_ROOTS=/Users/you/projects/report-outputs:/tmp/claude-artifacts
 ```
 
 - Paths must be absolute; relative entries are silently dropped.
+- **Every configured path must exist and be readable at server startup.** The
+  server fails fast (`process.exit(1)` with a message listing each bad path)
+  if any entry cannot be `realpath`-resolved — missing directory, broken
+  symlink, or permission denied. Fix the path or remove it from `.env` and
+  restart. This closes a TOCTOU window where a post-boot symlink could flip
+  a previously-inaccessible root into a structurally different check.
 - Symlinks are followed via `realpath` before the allowlist check, so
   symlinking a secret file into an allowed root will not bypass the guard.
 - The guard also applies a **basename denylist** that rejects common secret

--- a/lib.ts
+++ b/lib.ts
@@ -498,6 +498,47 @@ export function parseSendableRoots(raw: string | undefined): string[] {
   return out
 }
 
+/** Fail-fast validator for SLACK_SENDABLE_ROOTS at server boot (ccsc-a9z).
+ *
+ *  Throws with a detailed message listing every root that could not be
+ *  realpath-resolved — missing directory, broken symlink, no-permission,
+ *  etc. Intended to run once at startup before the Slack socket is open
+ *  so a misconfigured state dir is a loud failure, not a silent degradation.
+ *
+ *  **Why this exists.** `assertSendable` has a defensive silent-fallback
+ *  (`realpath → catch → resolve`) on per-call root resolution. That
+ *  fallback meant a root path that did not exist at runtime would
+ *  silently be treated as a *lexical* path — so an attacker who could
+ *  create a symlink at the configured location *after* server start
+ *  could turn a previously inaccessible root into one with a structurally
+ *  different (non-canonicalized) check. Validating at boot ensures every
+ *  configured root is real + resolvable before any request arrives; the
+ *  silent fallback then becomes dead code for any in-production call.
+ *
+ *  Called from `server.ts` bootstrap. Empty input is a no-op — the
+ *  default allowlist (INBOX_DIR only) needs no extra validation.
+ */
+export function validateSendableRoots(roots: readonly string[]): void {
+  const errors: string[] = []
+  for (const r of roots) {
+    try {
+      realpathSync(resolve(r))
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException)?.code
+      const msg = code ?? (e instanceof Error ? e.message : 'inaccessible')
+      errors.push(`${r}: ${msg}`)
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `SLACK_SENDABLE_ROOTS contains ${errors.length} inaccessible path(s):\n` +
+        `  - ${errors.join('\n  - ')}\n\n` +
+        'Every configured root must exist and be readable at server startup. ' +
+        'Fix the path (or remove it from SLACK_SENDABLE_ROOTS in .env) before restarting.',
+    )
+  }
+}
+
 /**
  * Throws if `filePath` is not safe to hand to the Slack file-upload API.
  *

--- a/server.test.ts
+++ b/server.test.ts
@@ -3,6 +3,7 @@ import {
   gate,
   assertSendable,
   parseSendableRoots,
+  validateSendableRoots,
   assertOutboundAllowed,
   isSlackFileUrl,
   chunkText,
@@ -1625,5 +1626,249 @@ describe('session persistence across restart', () => {
 
     expect(loadedOld.ownerId).toBe('U_A')
     expect(loadedNew.ownerId).toBe('U_B')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateSendableRoots — ccsc-a9z boot-time fail-fast
+//
+// Every configured SLACK_SENDABLE_ROOTS entry must exist and realpath-resolve
+// at server startup. Silently degrading to lexical resolution (the previous
+// behavior in assertSendable) created a TOCTOU window where a post-boot
+// symlink could flip a previously-inaccessible root into a structurally
+// different check. This test suite locks the fail-fast contract.
+// ---------------------------------------------------------------------------
+
+describe('validateSendableRoots', () => {
+  let rawRoot: string
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'validateRoots-'))
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  test('empty input is a no-op', () => {
+    expect(() => validateSendableRoots([])).not.toThrow()
+  })
+
+  test('passes when every root exists', () => {
+    const a = mkdtempSync(join(tmpdir(), 'validateRoots-a-'))
+    const b = mkdtempSync(join(tmpdir(), 'validateRoots-b-'))
+    try {
+      expect(() => validateSendableRoots([a, b])).not.toThrow()
+    } finally {
+      rmSync(a, { recursive: true, force: true })
+      rmSync(b, { recursive: true, force: true })
+    }
+  })
+
+  test('throws with a detailed message listing each missing path', () => {
+    const missing = join(rawRoot, 'does-not-exist')
+    expect(() => validateSendableRoots([missing])).toThrow(/1 inaccessible path/)
+    expect(() => validateSendableRoots([missing])).toThrow(missing)
+  })
+
+  test('reports every missing root in the same error (not just the first)', () => {
+    const missingA = join(rawRoot, 'missing-a')
+    const missingB = join(rawRoot, 'missing-b')
+    try {
+      validateSendableRoots([missingA, missingB])
+      throw new Error('should have thrown')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      expect(msg).toContain('2 inaccessible path')
+      expect(msg).toContain(missingA)
+      expect(msg).toContain(missingB)
+    }
+  })
+
+  test('mixed valid + invalid: throws, naming only the invalid ones', () => {
+    const good = mkdtempSync(join(tmpdir(), 'validateRoots-good-'))
+    const bad = join(rawRoot, 'nope')
+    try {
+      validateSendableRoots([good, bad])
+      throw new Error('should have thrown')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      expect(msg).toContain('1 inaccessible path')
+      expect(msg).toContain(bad)
+      expect(msg).not.toContain(`${good}:`)
+    } finally {
+      rmSync(good, { recursive: true, force: true })
+    }
+  })
+
+  test('error message instructs the operator how to recover', () => {
+    const missing = join(rawRoot, 'gone')
+    try {
+      validateSendableRoots([missing])
+      throw new Error('should have thrown')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      // Operator-facing guidance must be present so the .env change is obvious.
+      expect(msg).toMatch(/exist and be readable/)
+      expect(msg).toMatch(/SLACK_SENDABLE_ROOTS/)
+      expect(msg).toMatch(/\.env/)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PolicyRule Zod schema — ccsc-d3w follow-up test coverage for ccsc-v1b.1
+//
+// Exercises every branch of MatchSpec + the discriminated union's per-effect
+// shapes. Locks the 24h ttlMs ceiling and documents the intentional
+// deferral of id-uniqueness to the loader (ccsc-v1b.3's evaluator caller).
+// ---------------------------------------------------------------------------
+
+describe('PolicyRule schema (29-A.1)', () => {
+  // Imports done dynamically so this suite is independent of the other
+  // policy-engine test blocks that may land in later epics.
+  const loadPolicyModule = async () => await import('./policy.ts')
+
+  // ── MatchSpec refinement: at least one constrained field ──────────────
+
+  test('MatchSpec rejects zero-field match', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'auto_approve',
+        match: {},
+      }),
+    ).toThrow(/at least one field/)
+  })
+
+  test('MatchSpec rejects argEquals: {} (empty object counts as zero fields)', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'auto_approve',
+        match: { argEquals: {} },
+      }),
+    ).toThrow(/at least one field/)
+  })
+
+  test('MatchSpec accepts a single-field constraint', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'auto_approve',
+        match: { tool: 'reply' },
+      }),
+    ).not.toThrow()
+  })
+
+  // ── Channel ID regex ──────────────────────────────────────────────────
+
+  test('MatchSpec accepts valid Slack channel IDs starting with C or D', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    for (const channel of ['C0123456789', 'D0123456789', 'CABCDEF1234']) {
+      expect(() =>
+        PolicyRule.parse({
+          id: 'r1',
+          effect: 'auto_approve',
+          match: { channel },
+        }),
+      ).not.toThrow()
+    }
+  })
+
+  test('MatchSpec rejects channel IDs not starting with C or D', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'auto_approve',
+        match: { channel: 'G0123456789' },
+      }),
+    ).toThrow()
+  })
+
+  // ── Discriminated union variance ──────────────────────────────────────
+
+  test('DenyRule requires a non-empty reason', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'deny',
+        match: { tool: 'upload_file' },
+      }),
+    ).toThrow()
+
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'deny',
+        match: { tool: 'upload_file' },
+        reason: 'blocks sensitive uploads',
+      }),
+    ).not.toThrow()
+  })
+
+  test('RequireApprovalRule accepts a default ttlMs of 5 minutes', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    const parsed = PolicyRule.parse({
+      id: 'r1',
+      effect: 'require_approval',
+      match: { tool: 'upload_file' },
+    }) as { effect: 'require_approval'; ttlMs: number }
+    expect(parsed.ttlMs).toBe(5 * 60 * 1000)
+  })
+
+  test('RequireApprovalRule accepts ttlMs up to 24h', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'require_approval',
+        match: { tool: 'upload_file' },
+        ttlMs: 24 * 60 * 60 * 1000,
+      }),
+    ).not.toThrow()
+  })
+
+  test('RequireApprovalRule rejects ttlMs > 24h', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'require_approval',
+        match: { tool: 'upload_file' },
+        ttlMs: 24 * 60 * 60 * 1000 + 1,
+      }),
+    ).toThrow()
+  })
+
+  // ── Defaults ──────────────────────────────────────────────────────────
+
+  test('priority defaults to 100 when omitted', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    const parsed = PolicyRule.parse({
+      id: 'r1',
+      effect: 'auto_approve',
+      match: { tool: 'reply' },
+    }) as { priority: number }
+    expect(parsed.priority).toBe(100)
+  })
+
+  // ── Loader-deferred invariants ────────────────────────────────────────
+
+  test('parsePolicyRules does NOT enforce id uniqueness (deferred to loader per design doc)', async () => {
+    // The doc specifies id-uniqueness is a load-time error. parsePolicyRules
+    // deliberately does not enforce it — the loader (29-A.5) will. This
+    // test locks the deferred behavior so a future refactor that quietly
+    // adds the check (and breaks the loader's error ordering) is loud.
+    const { parsePolicyRules } = await loadPolicyModule()
+    const rules = parsePolicyRules([
+      { id: 'dupe', effect: 'auto_approve', match: { tool: 'reply' } },
+      { id: 'dupe', effect: 'deny', match: { tool: 'reply' }, reason: 'x' },
+    ])
+    expect(rules).toHaveLength(2)
   })
 })

--- a/server.ts
+++ b/server.ts
@@ -33,6 +33,7 @@ import {
   generateCode as _generateCode,
   assertSendable as libAssertSendable,
   parseSendableRoots,
+  validateSendableRoots,
   assertOutboundAllowed as libAssertOutboundAllowed,
   isSlackFileUrl,
   chunkText,
@@ -62,7 +63,18 @@ const DEFAULT_CHUNK_LIMIT = 4000
 // File-exfil allowlist: additional roots beyond INBOX_DIR from which the
 // reply tool may attach files. Colon-separated absolute paths. Default empty
 // (only INBOX_DIR is sendable). See ACCESS.md for details.
+//
+// Boot-time fail-fast (ccsc-a9z): every configured root must exist and be
+// readable at startup. A missing root used to degrade silently to lexical
+// resolution in assertSendable — a TOCTOU window where an attacker could
+// plant a symlink post-boot. Validating here closes that window.
 const SENDABLE_ROOTS = parseSendableRoots(process.env['SLACK_SENDABLE_ROOTS'])
+try {
+  validateSendableRoots(SENDABLE_ROOTS)
+} catch (err) {
+  console.error(`[slack] ${err instanceof Error ? err.message : String(err)}`)
+  process.exit(1)
+}
 
 // ---------------------------------------------------------------------------
 // Bootstrap — tokens & state directory


### PR DESCRIPTION
## Summary

Two P1 debt items consolidated — both small, independent, same release train.

- **`ccsc-a9z`** — SLACK_SENDABLE_ROOTS fail-fast at server boot
- **`ccsc-d3w`** — Follow-up test coverage for PolicyRule Zod schema (29-A.1)

## ccsc-a9z: Why

`assertSendable` used `realpath → catch → resolve` as a defensive fallback: if a configured root didn't exist at runtime, it degraded to a lexically-resolved path. That left a TOCTOU window — an attacker who could plant a symlink at the configured location *after* server boot would flip a previously-inaccessible root into a structurally different check.

### What changes

- **`validateSendableRoots(roots)`** in `lib.ts` — realpath-probes every configured root; throws with a detailed message listing each bad path (`<path>: <errno>`). Empty input is a no-op.
- **`server.ts` bootstrap** calls it right after `parseSendableRoots`. On failure, prints the message and `process.exit(1)` before the Slack socket opens.
- The `assertSendable` fallback stays in place (defense-in-depth; test hermeticity) but is now dead code for any production call because boot has already validated.
- **`ACCESS.md`** "Adding additional roots" section updated with the fail-fast behavior and operator recovery instructions.

## ccsc-d3w: What's tested (11 new assertions)

- MatchSpec: zero-field rejected, `argEquals: {}` rejected, single-field OK.
- Channel regex: `C`/`D` prefix accepted, `G` rejected.
- `DenyRule` requires a non-empty `reason`.
- `RequireApprovalRule`: default `ttlMs = 5min`, accepts 24h exactly, rejects 24h + 1ms.
- `priority` defaults to 100 when omitted.
- `parsePolicyRules` does **NOT** enforce id uniqueness — locks the deferred-to-loader behavior so a future refactor that quietly adds the check (and breaks the loader's error ordering) is loud.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — **159 pass / 0 fail / 334 expects** (+17 new)

## Runtime impact

- Server now exits(1) on misconfigured `SENDABLE_ROOTS` instead of booting into a degraded state. No behavior change for an empty or correctly-configured `SENDABLE_ROOTS`.
- PolicyRule schema tests are pure additions; no production code changed.

Jeremy made me do it
-claude