### PR TITLE
feat(policy): PolicyDecision tagged union + path canonicalization (closes sub-epic v1b.10)

### DIFF
--- a/policy.ts
+++ b/policy.ts
@@ -18,6 +18,8 @@
  */
 
 import { z } from 'zod'
+import { realpathSync } from 'fs'
+import { resolve, sep } from 'path'
 
 // ---------------------------------------------------------------------------
 // MatchSpec — which tool calls a rule applies to.
@@ -131,4 +133,99 @@ export function parsePolicyRule(raw: unknown): PolicyRule {
  *  shadow detection so both errors are reported together. */
 export function parsePolicyRules(raw: unknown): PolicyRule[] {
   return z.array(PolicyRule).parse(raw)
+}
+
+// ---------------------------------------------------------------------------
+// PolicyDecision — output of evaluate(). See 000-docs/policy-evaluation-flow.md §27-30.
+// ---------------------------------------------------------------------------
+
+/** The decision returned by `evaluate()`. Three kinds — a deliberately
+ *  narrow surface. `allow` is the happy path; `deny` refuses with a
+ *  reason surfaced to Claude; `require` pauses until a human approver
+ *  responds on Slack within `ttlMs`.
+ *
+ *  Not confused with `PolicyRule.effect` (the *input* shape): rule
+ *  effects are `auto_approve | deny | require_approval`; decisions are
+ *  `allow | deny | require`. An `auto_approve` rule produces an `allow`
+ *  decision; a `require_approval` rule produces a `require` decision
+ *  unless a fresh approval is already in flight (which turns it into
+ *  `allow`). See the flowchart in policy-evaluation-flow.md.
+ *
+ *  **No runtime validation.** Decisions are produced by `evaluate()`
+ *  from validated inputs, never parsed from untrusted data, so a Zod
+ *  schema here would be dead weight. The type alone is the contract.
+ */
+export type PolicyDecision =
+  | {
+      kind: 'allow'
+      /** ID of the matching rule. Absent when the default branch fires
+       *  (no rule matched + tool not in `requireAuthoredPolicy`). */
+      rule?: string
+    }
+  | {
+      kind: 'deny'
+      rule: string
+      /** Short, non-sensitive prose surfaced to Claude so the model
+       *  knows why the tool call was rejected. */
+      reason: string
+    }
+  | {
+      kind: 'require'
+      rule: string
+      /** For now always the human approver; named so future expansion
+       *  (peer-agent approvals, escalation paths) can extend the union. */
+      approver: 'human_approver'
+      /** How long an approval, once granted, is fresh for. Propagated
+       *  from the matching `RequireApprovalRule.ttlMs`. */
+      ttlMs: number
+    }
+
+// ---------------------------------------------------------------------------
+// Path canonicalization (CWE-22) — see policy-evaluation-flow.md §174-196.
+// ---------------------------------------------------------------------------
+
+/** Canonicalize a `match.pathPrefix` at load time.
+ *
+ *  The policy loader calls this once per rule and caches the result.
+ *  `realpathSync.native` resolves every symlink in the configured
+ *  prefix, so the comparison at evaluate time is a prefix-check on
+ *  two canonical paths — no TOCTOU, no smuggling.
+ *
+ *  Throws if the prefix does not exist on disk. That's intentional:
+ *  a rule pointing at a nonexistent path can never match anything, so
+ *  it's almost certainly a typo that the operator should fix at load
+ *  time, not a mystery-miss at evaluation time. Fail loud.
+ *
+ *  See policy-evaluation-flow.md §174-196 for the full design rationale
+ *  and CWE-22 mitigation story.
+ */
+export function canonicalizeRulePathPrefix(raw: string): string {
+  return realpathSync.native(resolve(raw))
+}
+
+/** Canonicalize a per-call request path.
+ *
+ *  Unlike the prefix (canonicalized once at load), the input path is
+ *  canonicalized on every tool call — fresh `realpath` each time so a
+ *  newly-created symlink between calls is caught on the next match.
+ *
+ *  Throws if the path does not exist. That's the desired fail-closed
+ *  posture: a tool call referencing a nonexistent path gets a policy
+ *  error (loud) rather than matching a rule against an unresolvable
+ *  lexical string (quiet).
+ */
+export function canonicalizeRequestPath(raw: string, cwd: string = process.cwd()): string {
+  return realpathSync.native(resolve(cwd, raw))
+}
+
+/** Prefix-matches a canonicalized request path against a canonicalized
+ *  rule prefix. Both args MUST already be realpath-resolved via the
+ *  helpers above — this function does no I/O, just a string compare.
+ *
+ *  The `+ sep` guard prevents `/etc/passwd` from matching prefix
+ *  `/etc/pass` while still allowing an exact-equality match (the common
+ *  case of a rule targeting a file, not a directory).
+ */
+export function pathMatchesPrefix(resolvedPath: string, resolvedPrefix: string): boolean {
+  return resolvedPath === resolvedPrefix || resolvedPath.startsWith(resolvedPrefix + sep)
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -1872,3 +1872,164 @@ describe('PolicyRule schema (29-A.1)', () => {
     expect(rules).toHaveLength(2)
   })
 })
+
+// ---------------------------------------------------------------------------
+// PolicyDecision — ccsc-v1b.2 tagged union
+//
+// Decisions are produced by evaluate() (not yet landed), so these tests
+// just verify all three kinds construct cleanly and carry the fields the
+// design doc (§27-30) specifies. No runtime parse — the type alone is
+// the contract.
+// ---------------------------------------------------------------------------
+
+describe('PolicyDecision shape (29-A.2)', () => {
+  test('allow decision constructs with optional rule', () => {
+    // Using typeof import so TS narrows PolicyDecision correctly.
+    type PD = import('./policy.ts').PolicyDecision
+    const allowWithRule: PD = { kind: 'allow', rule: 'r1' }
+    const allowDefault: PD = { kind: 'allow' }
+    expect(allowWithRule.kind).toBe('allow')
+    expect(allowDefault.kind).toBe('allow')
+    expect(allowDefault.rule).toBeUndefined()
+  })
+
+  test('deny decision requires rule + reason', async () => {
+    type PD = import('./policy.ts').PolicyDecision
+    const d: PD = {
+      kind: 'deny',
+      rule: 'no-upload-env',
+      reason: 'uploads of env files are not permitted',
+    }
+    expect(d.kind).toBe('deny')
+    // Type-narrowing: only the deny branch carries reason.
+    if (d.kind === 'deny') {
+      expect(d.reason.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('require decision carries rule + approver + ttlMs', async () => {
+    type PD = import('./policy.ts').PolicyDecision
+    const r: PD = {
+      kind: 'require',
+      rule: 'upload-approval',
+      approver: 'human_approver',
+      ttlMs: 5 * 60 * 1000,
+    }
+    expect(r.kind).toBe('require')
+    if (r.kind === 'require') {
+      expect(r.approver).toBe('human_approver')
+      expect(r.ttlMs).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Path canonicalization (ccsc-v1b.4) — see policy-evaluation-flow.md §174-196
+// ---------------------------------------------------------------------------
+
+describe('path canonicalization for match.pathPrefix (29-A.4)', () => {
+  let rawRoot: string
+  let tmpRoot: string
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'policy-canon-'))
+    tmpRoot = realpathSync.native(rawRoot)
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  test('canonicalizeRulePathPrefix resolves symlinks at load time', async () => {
+    const { canonicalizeRulePathPrefix } = await import('./policy.ts')
+    const real = join(tmpRoot, 'real-target')
+    mkdirSync(real, { recursive: true })
+    const link = join(tmpRoot, 'link-to-target')
+    symlinkSync(real, link)
+
+    expect(canonicalizeRulePathPrefix(link)).toBe(real)
+  })
+
+  test('canonicalizeRulePathPrefix throws on a nonexistent prefix (fail-loud at load)', async () => {
+    const { canonicalizeRulePathPrefix } = await import('./policy.ts')
+    expect(() => canonicalizeRulePathPrefix(join(tmpRoot, 'nope-does-not-exist'))).toThrow()
+  })
+
+  test('canonicalizeRequestPath resolves symlinks at call time', async () => {
+    const { canonicalizeRequestPath } = await import('./policy.ts')
+    const real = join(tmpRoot, 'doc.txt')
+    writeFileSync(real, 'content', { mode: 0o600 })
+    const link = join(tmpRoot, 'alias.txt')
+    symlinkSync(real, link)
+
+    expect(canonicalizeRequestPath(link)).toBe(real)
+  })
+
+  test('canonicalizeRequestPath throws on nonexistent path (fail-closed)', async () => {
+    const { canonicalizeRequestPath } = await import('./policy.ts')
+    expect(() => canonicalizeRequestPath(join(tmpRoot, 'ghost.txt'))).toThrow()
+  })
+
+  test('pathMatchesPrefix: exact-equal match returns true', async () => {
+    const { pathMatchesPrefix } = await import('./policy.ts')
+    expect(pathMatchesPrefix('/var/log/app', '/var/log/app')).toBe(true)
+  })
+
+  test('pathMatchesPrefix: descendant returns true', async () => {
+    const { pathMatchesPrefix } = await import('./policy.ts')
+    expect(pathMatchesPrefix('/var/log/app/today.log', '/var/log/app')).toBe(true)
+  })
+
+  test('pathMatchesPrefix: sibling rejected (no partial-prefix match)', async () => {
+    const { pathMatchesPrefix } = await import('./policy.ts')
+    // The classic bug: /etc/passwd should NOT match prefix /etc/pass.
+    expect(pathMatchesPrefix('/etc/passwd', '/etc/pass')).toBe(false)
+  })
+
+  test('pathMatchesPrefix: non-descendant rejected', async () => {
+    const { pathMatchesPrefix } = await import('./policy.ts')
+    expect(pathMatchesPrefix('/var/other', '/var/log/app')).toBe(false)
+  })
+
+  test('CWE-22: ../ traversal is defeated by canonicalizing both sides', async () => {
+    const { canonicalizeRulePathPrefix, canonicalizeRequestPath, pathMatchesPrefix } =
+      await import('./policy.ts')
+    // Rule scopes reads to /<tmpRoot>/safe/. A request asks for
+    // /<tmpRoot>/safe/../secrets — lexically inside, realpath-wise outside.
+    const safe = join(tmpRoot, 'safe')
+    const secrets = join(tmpRoot, 'secrets')
+    mkdirSync(safe, { recursive: true })
+    mkdirSync(secrets, { recursive: true })
+    const secretFile = join(secrets, 'key.txt')
+    writeFileSync(secretFile, 'SENSITIVE', { mode: 0o600 })
+
+    const resolvedPrefix = canonicalizeRulePathPrefix(safe)
+    // Compose a traversal: /safe/../secrets/key.txt → /secrets/key.txt
+    const traversalInput = join(safe, '..', 'secrets', 'key.txt')
+    const resolvedInput = canonicalizeRequestPath(traversalInput)
+
+    expect(pathMatchesPrefix(resolvedInput, resolvedPrefix)).toBe(false)
+  })
+
+  test('Symlink-out escape is defeated by realpath in canonicalizeRequestPath', async () => {
+    const { canonicalizeRulePathPrefix, canonicalizeRequestPath, pathMatchesPrefix } =
+      await import('./policy.ts')
+    // Rule allows /<tmpRoot>/safe/. Attacker plants a symlink inside
+    // /safe pointing to /<tmpRoot>/secrets/key.txt.
+    const safe = join(tmpRoot, 'safe')
+    const secrets = join(tmpRoot, 'secrets')
+    mkdirSync(safe, { recursive: true })
+    mkdirSync(secrets, { recursive: true })
+    const secretFile = join(secrets, 'key.txt')
+    writeFileSync(secretFile, 'SENSITIVE', { mode: 0o600 })
+
+    const link = join(safe, 'looks-innocent.txt')
+    symlinkSync(secretFile, link)
+
+    const resolvedPrefix = canonicalizeRulePathPrefix(safe)
+    const resolvedInput = canonicalizeRequestPath(link)
+
+    // realpath collapses the symlink to /secrets/key.txt — outside /safe.
+    expect(resolvedInput).toBe(secretFile)
+    expect(pathMatchesPrefix(resolvedInput, resolvedPrefix)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Closes sub-epic **`ccsc-v1b.10`** — *Define what a policy rule looks like*. Bundles the last two leaves after v1b.1 (PolicyRule schema) shipped in PR #47.

- **`ccsc-v1b.2`** — `PolicyDecision` tagged union (output of `evaluate()`)
- **`ccsc-v1b.4`** — Path canonicalization helpers for `match.pathPrefix` (CWE-22 mitigation)

Only sub-epic `ccsc-v1b.11` remains before Epic 29-A (policy engine core) is complete.

## PolicyDecision (v1b.2)

Per design doc [§27-30](./000-docs/policy-evaluation-flow.md):

```ts
type PolicyDecision =
  | { kind: 'allow';   rule?: string }
  | { kind: 'deny';    rule: string; reason: string }
  | { kind: 'require'; rule: string; approver: 'human_approver'; ttlMs: number }
```

Distinct from `PolicyRule.effect` (`auto_approve | deny | require_approval`): rule effects are input shape, decisions are output kind. An `auto_approve` rule → `allow` decision; a `require_approval` rule → `require` decision unless a fresh approval flips it to `allow`.

Type-only. No Zod schema — decisions come from `evaluate()` on validated inputs, never from untrusted sources.

## Path canonicalization (v1b.4)

Per design doc [§174-196](./000-docs/policy-evaluation-flow.md). Three pure helpers:

| Function | When called | Throws on ENOENT | Purpose |
|---|---|---|---|
| `canonicalizeRulePathPrefix(raw)` | Load time, once per rule, cached | Yes (fail loud on typo) | Resolve symlinks in the rule's configured prefix |
| `canonicalizeRequestPath(raw, cwd)` | Per call, fresh each time | Yes (fail closed) | Resolve symlinks in the tool call's input path |
| `pathMatchesPrefix(a, b)` | After both canonicalized | — (no I/O) | String compare with `+ sep` guard |

The `+ sep` guard stops `/etc/passwd` from matching prefix `/etc/pass` while preserving exact-equal matches (when a rule targets a file, not a directory).

## Test coverage — 13 new

| Group | Tests |
|---|---|
| `PolicyDecision` shape | allow-with/without rule, deny requires reason, require carries approver + ttlMs |
| Path canonicalization | load-time realpath, load-time ENOENT throws, call-time realpath, call-time ENOENT throws, exact-equal match, descendant match, sibling rejected, non-descendant rejected, **CWE-22 traversal defeated**, **symlink-out escape defeated** |

**172 pass / 0 fail / 353 expects. Typecheck clean.**

## Runtime impact

**None.** No call sites in `server.ts`. `evaluate()` (arriving in sub-epic `ccsc-v1b.11`) will consume these helpers.

Jeremy made me do it
-claude