### PR TITLE
feat(policy): evaluate() + detectShadowing + checkMonotonicity (closes Epic 29-A)

### DIFF
--- a/policy.ts
+++ b/policy.ts
@@ -229,3 +229,264 @@ export function canonicalizeRequestPath(raw: string, cwd: string = process.cwd()
 export function pathMatchesPrefix(resolvedPath: string, resolvedPrefix: string): boolean {
   return resolvedPath === resolvedPrefix || resolvedPath.startsWith(resolvedPrefix + sep)
 }
+
+// ---------------------------------------------------------------------------
+// evaluate() — first-applicable combining (XACML) per policy-evaluation-flow.md
+// ---------------------------------------------------------------------------
+
+/** Surface of a tool call as the evaluator sees it.
+ *
+ *  Path-bearing tools put the caller-supplied path in `input.path`;
+ *  evaluate() canonicalizes it when a rule constrains `pathPrefix`.
+ *  `actor` is the direct caller — human approvers arrive as later turns,
+ *  never as the `actor` on the original call. */
+export interface ToolCall {
+  tool: string
+  input: Record<string, unknown>
+  sessionKey: { channel: string; thread: string }
+  actor: 'session_owner' | 'claude_process'
+}
+
+/** Key into the approvals map: `${ruleId}:${channel}:${thread}`. Scoped
+ *  to (rule, session) per policy-evaluation-flow.md §285-287 so a
+ *  different session in the same channel never inherits the approval. */
+export type ApprovalKey = string
+
+/** Build the approval-map key for a (rule, sessionKey) pair. */
+export function approvalKey(
+  ruleId: string,
+  sessionKey: { channel: string; thread: string },
+): ApprovalKey {
+  return `${ruleId}:${sessionKey.channel}:${sessionKey.thread}`
+}
+
+/** Set of tools for which an unmatched call defaults to deny-by-omission
+ *  (rather than the blanket allow for everything else). Mutation of
+ *  external state goes here; read-only tools do not — see
+ *  policy-evaluation-flow.md §107-117. */
+export const DEFAULT_REQUIRE_AUTHORED_POLICY: ReadonlySet<string> = new Set(['upload_file'])
+
+export interface EvaluateOptions {
+  /** (rule, session) → approval window. An entry with `ttlExpires > now`
+   *  flips a `require_approval` rule into an `allow` decision. Written
+   *  by the permission-reply handler, not by `evaluate()`. */
+  approvals?: ReadonlyMap<ApprovalKey, { ttlExpires: number }>
+  /** Tools that require an authored rule; unmatched calls return deny. */
+  requireAuthoredPolicy?: ReadonlySet<string>
+}
+
+/** Pure evaluator. Walks `rules` in authored order and returns on the
+ *  first match (XACML first-applicable, see policy-evaluation-flow.md
+ *  §89-93). Side-effect-free: journal emission, approval recording,
+ *  and Slack posts happen outside, after evaluate() returns.
+ *
+ *  Path matching canonicalizes both sides via `realpath` on every call
+ *  (see canonicalizeRequestPath + canonicalizeRulePathPrefix). If
+ *  either path does not exist, the `pathPrefix` constraint is treated
+ *  as "not matching" — fail-closed: a rule can't match a path that
+ *  doesn't resolve.
+ *
+ *  Returns the default decision when no rule matches:
+ *    - `deny` (rule = 'default') if `call.tool` is in requireAuthoredPolicy
+ *    - `allow` (rule undefined) otherwise
+ */
+export function evaluate(
+  call: ToolCall,
+  rules: readonly PolicyRule[],
+  now: number,
+  opts: EvaluateOptions = {},
+): PolicyDecision {
+  const approvals = opts.approvals ?? new Map<ApprovalKey, { ttlExpires: number }>()
+  const requireAuthored = opts.requireAuthoredPolicy ?? DEFAULT_REQUIRE_AUTHORED_POLICY
+
+  for (const rule of rules) {
+    if (!matchApplies(rule.match, call)) continue
+
+    switch (rule.effect) {
+      case 'auto_approve':
+        return { kind: 'allow', rule: rule.id }
+      case 'deny':
+        return { kind: 'deny', rule: rule.id, reason: rule.reason }
+      case 'require_approval': {
+        const approval = approvals.get(approvalKey(rule.id, call.sessionKey))
+        if (approval && approval.ttlExpires > now) {
+          return { kind: 'allow', rule: rule.id }
+        }
+        return {
+          kind: 'require',
+          rule: rule.id,
+          approver: 'human_approver',
+          ttlMs: rule.ttlMs,
+        }
+      }
+    }
+  }
+
+  // No rule matched — default branch.
+  if (requireAuthored.has(call.tool)) {
+    return {
+      kind: 'deny',
+      rule: 'default',
+      reason: `no policy authored for tool '${call.tool}'`,
+    }
+  }
+  return { kind: 'allow' }
+}
+
+/** Does `match` apply to `call`? Every undefined field is a wildcard. */
+function matchApplies(match: MatchSpec, call: ToolCall): boolean {
+  if (match.tool !== undefined && match.tool !== call.tool) return false
+  if (match.channel !== undefined && match.channel !== call.sessionKey.channel) return false
+  if (match.actor !== undefined && match.actor !== call.actor) return false
+
+  if (match.pathPrefix !== undefined) {
+    const raw = call.input['path']
+    if (typeof raw !== 'string') return false
+    try {
+      const resolvedPrefix = canonicalizeRulePathPrefix(match.pathPrefix)
+      const resolvedInput = canonicalizeRequestPath(raw)
+      if (!pathMatchesPrefix(resolvedInput, resolvedPrefix)) return false
+    } catch {
+      // Either side failed to resolve: treat as non-match. Fail-closed.
+      return false
+    }
+  }
+
+  if (match.argEquals !== undefined) {
+    for (const [k, v] of Object.entries(match.argEquals)) {
+      if (!jsonEqual(call.input[k], v)) return false
+    }
+  }
+
+  return true
+}
+
+/** Structural equality via JSON round-trip. Good enough for validated
+ *  MCP input (plain JSON, no functions/cycles/dates); if perf becomes
+ *  an issue, swap in a real deep-eq. Returns false on non-serializable
+ *  inputs rather than throwing. */
+function jsonEqual(a: unknown, b: unknown): boolean {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// detectShadowing() — load-time linter per policy-evaluation-flow.md §199-230
+// ---------------------------------------------------------------------------
+
+export interface ShadowWarning {
+  /** The rule that never gets reached. */
+  later: string
+  /** The earlier rule that swallows every call the later rule would match. */
+  earlier: string
+  message: string
+}
+
+/** Static subset-check over MatchSpec fields. A later rule is shadowed
+ *  when an earlier rule's match is less-specific-or-equal on every
+ *  field. Warn-not-block: the warnings go to stderr at load time so the
+ *  operator can reorder or narrow. Never fail-closed — an operator who
+ *  intentionally wrote an unreachable rule (e.g., as a placeholder
+ *  during a refactor) shouldn't be forced to delete it just to boot.
+ */
+export function detectShadowing(rules: readonly PolicyRule[]): ShadowWarning[] {
+  const warnings: ShadowWarning[] = []
+  for (let j = 1; j < rules.length; j++) {
+    const later = rules[j]!
+    for (let i = 0; i < j; i++) {
+      const earlier = rules[i]!
+      if (matchSubsetOrEqual(earlier.match, later.match)) {
+        warnings.push({
+          later: later.id,
+          earlier: earlier.id,
+          message: `rule '${later.id}' is shadowed by earlier rule '${earlier.id}' — every call the later rule would match is already caught by the earlier one`,
+        })
+        break // first shadow is sufficient; don't double-report
+      }
+    }
+  }
+  return warnings
+}
+
+/** Is `outer.match` less-specific-or-equal to `inner.match` on every
+ *  field? Used by both shadow detection and monotonicity — if yes,
+ *  `outer` matches a superset of what `inner` matches. */
+function matchSubsetOrEqual(outer: MatchSpec, inner: MatchSpec): boolean {
+  if (outer.tool !== undefined && outer.tool !== inner.tool) return false
+  if (outer.channel !== undefined && outer.channel !== inner.channel) return false
+  if (outer.actor !== undefined && outer.actor !== inner.actor) return false
+
+  if (outer.pathPrefix !== undefined) {
+    if (inner.pathPrefix === undefined) return false
+    // Lexical prefix check (both would be canonicalized in practice).
+    if (
+      inner.pathPrefix !== outer.pathPrefix &&
+      !inner.pathPrefix.startsWith(outer.pathPrefix + sep)
+    ) {
+      return false
+    }
+  }
+
+  if (outer.argEquals !== undefined) {
+    if (inner.argEquals === undefined) return false
+    for (const [k, v] of Object.entries(outer.argEquals)) {
+      if (!jsonEqual(inner.argEquals[k], v)) return false
+    }
+  }
+
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// checkMonotonicity() — hot-reload invariant per policy-evaluation-flow.md §234-244
+// ---------------------------------------------------------------------------
+
+export interface MonotonicityViolation {
+  /** The newly-added auto_approve rule that would weaken policy. */
+  newRule: string
+  /** The existing deny rule whose match the new rule supersets. */
+  existingDeny: string
+  message: string
+}
+
+/** Detects whether adopting `next` as the active policy set would
+ *  weaken policy compared to `prev`. A violation is:
+ *
+ *    A newly-added rule R with effect 'auto_approve' whose `match` is
+ *    a subset of an existing 'deny' rule's match — i.e., the deny
+ *    would have covered R's calls, so adding R silently opens a hole.
+ *
+ *  Caller's responsibility: if this returns a non-empty array, refuse
+ *  to adopt `next` and keep `prev` active. The server logs the
+ *  violation, surfaces a beads issue, and requires operator action
+ *  (doc §237-249). Removed rules don't trigger — removing a deny
+ *  obviously weakens policy, and the operator signed off by removing.
+ */
+export function checkMonotonicity(
+  prev: readonly PolicyRule[],
+  next: readonly PolicyRule[],
+): MonotonicityViolation[] {
+  const violations: MonotonicityViolation[] = []
+  const prevIds = new Set(prev.map((r) => r.id))
+  const prevDenies = prev.filter((r): r is Extract<PolicyRule, { effect: 'deny' }> => r.effect === 'deny')
+
+  for (const newRule of next) {
+    if (prevIds.has(newRule.id)) continue // unchanged or modified, not added
+    if (newRule.effect !== 'auto_approve') continue
+
+    for (const existingDeny of prevDenies) {
+      if (matchSubsetOrEqual(existingDeny.match, newRule.match)) {
+        violations.push({
+          newRule: newRule.id,
+          existingDeny: existingDeny.id,
+          message: `new auto_approve rule '${newRule.id}' weakens existing deny '${existingDeny.id}' — reload refused`,
+        })
+      }
+    }
+  }
+
+  return violations
+}

--- a/server.test.ts
+++ b/server.test.ts
@@ -2033,3 +2033,406 @@ describe('path canonicalization for match.pathPrefix (29-A.4)', () => {
     expect(pathMatchesPrefix(resolvedInput, resolvedPrefix)).toBe(false)
   })
 })
+
+// ---------------------------------------------------------------------------
+// evaluate() + detectShadowing() + checkMonotonicity() — ccsc-v1b.3/.5/.6/.7
+//
+// Full matrix covering first-applicable combining, every effect branch,
+// approval-turns-into-allow flow, match field interactions, path traversal
+// rejection, default branches, shadow detection, and hot-reload
+// monotonicity. Design doc: 000-docs/policy-evaluation-flow.md.
+// ---------------------------------------------------------------------------
+
+describe('evaluate() — policy engine (29-A.3)', () => {
+  const baseCall = (overrides: Partial<import('./policy.ts').ToolCall> = {}): import('./policy.ts').ToolCall => ({
+    tool: 'reply',
+    input: {},
+    sessionKey: { channel: 'C_CHAN', thread: 'T1.0' },
+    actor: 'claude_process',
+    ...overrides,
+  })
+
+  const rule = (partial: Partial<import('./policy.ts').PolicyRule> & { id: string; effect: string }): import('./policy.ts').PolicyRule =>
+    ({
+      match: { tool: 'reply' },
+      priority: 100,
+      ...partial,
+    } as import('./policy.ts').PolicyRule)
+
+  // ── Single-rule branches ───────────────────────────────────────────────
+
+  test('auto_approve rule → allow with rule id', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [rule({ id: 'r1', effect: 'auto_approve' })]
+    const decision = evaluate(baseCall(), rules, 0)
+    expect(decision).toEqual({ kind: 'allow', rule: 'r1' })
+  })
+
+  test('deny rule → deny with reason + rule id', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [rule({ id: 'r1', effect: 'deny', reason: 'nope' } as never)]
+    const decision = evaluate(baseCall(), rules, 0)
+    expect(decision).toEqual({ kind: 'deny', rule: 'r1', reason: 'nope' })
+  })
+
+  test('require_approval rule → require with ttlMs', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [rule({ id: 'r1', effect: 'require_approval', ttlMs: 60_000 } as never)]
+    const decision = evaluate(baseCall(), rules, 0)
+    expect(decision).toEqual({
+      kind: 'require',
+      rule: 'r1',
+      approver: 'human_approver',
+      ttlMs: 60_000,
+    })
+  })
+
+  // ── Approval flow ──────────────────────────────────────────────────────
+
+  test('fresh approval turns require_approval into allow', async () => {
+    const { evaluate, approvalKey } = await import('./policy.ts')
+    const rules = [rule({ id: 'r1', effect: 'require_approval', ttlMs: 60_000 } as never)]
+    const approvals = new Map([
+      [approvalKey('r1', { channel: 'C_CHAN', thread: 'T1.0' }), { ttlExpires: 5_000 }],
+    ])
+    const decision = evaluate(baseCall(), rules, 1_000, { approvals })
+    expect(decision).toEqual({ kind: 'allow', rule: 'r1' })
+  })
+
+  test('expired approval does NOT turn require into allow', async () => {
+    const { evaluate, approvalKey } = await import('./policy.ts')
+    const rules = [rule({ id: 'r1', effect: 'require_approval', ttlMs: 60_000 } as never)]
+    const approvals = new Map([
+      [approvalKey('r1', { channel: 'C_CHAN', thread: 'T1.0' }), { ttlExpires: 500 }],
+    ])
+    const decision = evaluate(baseCall(), rules, 1_000, { approvals })
+    expect(decision.kind).toBe('require')
+  })
+
+  test('approval scoped to (rule, sessionKey) — different thread does NOT inherit', async () => {
+    const { evaluate, approvalKey } = await import('./policy.ts')
+    const rules = [rule({ id: 'r1', effect: 'require_approval', ttlMs: 60_000 } as never)]
+    // Approval is for thread T1.0; caller is on T2.0.
+    const approvals = new Map([
+      [approvalKey('r1', { channel: 'C_CHAN', thread: 'T1.0' }), { ttlExpires: 5_000 }],
+    ])
+    const decision = evaluate(
+      baseCall({ sessionKey: { channel: 'C_CHAN', thread: 'T2.0' } }),
+      rules,
+      1_000,
+      { approvals },
+    )
+    expect(decision.kind).toBe('require')
+  })
+
+  // ── First-applicable combining ────────────────────────────────────────
+
+  test('first matching rule wins (first-applicable XACML)', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [
+      rule({ id: 'deny-first', effect: 'deny', reason: 'no' } as never),
+      rule({ id: 'allow-second', effect: 'auto_approve' }),
+    ]
+    const decision = evaluate(baseCall(), rules, 0)
+    expect(decision.kind).toBe('deny')
+    if (decision.kind === 'deny') expect(decision.rule).toBe('deny-first')
+  })
+
+  test('non-matching rule is skipped; next rule evaluated', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [
+      rule({ id: 'wrong-tool', effect: 'deny', reason: 'x', match: { tool: 'upload_file' } } as never),
+      rule({ id: 'right-tool', effect: 'auto_approve', match: { tool: 'reply' } }),
+    ]
+    const decision = evaluate(baseCall(), rules, 0)
+    expect(decision.kind).toBe('allow')
+    if (decision.kind === 'allow') expect(decision.rule).toBe('right-tool')
+  })
+
+  // ── Match field semantics ─────────────────────────────────────────────
+
+  test('channel field mismatch → rule skipped', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [
+      rule({ id: 'r1', effect: 'auto_approve', match: { channel: 'C_OTHER' } }),
+    ]
+    const decision = evaluate(baseCall(), rules, 0)
+    // Default: reply is not in requireAuthoredPolicy → allow default.
+    expect(decision.kind).toBe('allow')
+    if (decision.kind === 'allow') expect(decision.rule).toBeUndefined()
+  })
+
+  test('actor field mismatch → rule skipped', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [
+      rule({ id: 'r1', effect: 'auto_approve', match: { actor: 'session_owner' } }),
+    ]
+    const decision = evaluate(baseCall({ actor: 'claude_process' }), rules, 0)
+    expect((decision as { kind: string }).kind).toBe('allow')
+  })
+
+  test('argEquals match with exact value', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [
+      rule({
+        id: 'r1',
+        effect: 'deny',
+        reason: 'no',
+        match: { tool: 'upload_file', argEquals: { mimeType: 'text/plain' } },
+      } as never),
+    ]
+    const decision = evaluate(
+      baseCall({ tool: 'upload_file', input: { mimeType: 'text/plain' } }),
+      rules,
+      0,
+    )
+    expect(decision.kind).toBe('deny')
+  })
+
+  test('argEquals mismatch → rule skipped', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const rules = [
+      rule({
+        id: 'r1',
+        effect: 'deny',
+        reason: 'no',
+        match: { tool: 'upload_file', argEquals: { mimeType: 'text/plain' } },
+      } as never),
+    ]
+    const decision = evaluate(
+      baseCall({ tool: 'upload_file', input: { mimeType: 'application/pdf' } }),
+      rules,
+      0,
+    )
+    // Default for upload_file: deny (in requireAuthoredPolicy).
+    expect(decision.kind).toBe('deny')
+    if (decision.kind === 'deny') expect(decision.rule).toBe('default')
+  })
+
+  // ── Path-prefix matching (realpath-based) ─────────────────────────────
+
+  test('path-prefix match with realpath canonicalization', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const root = mkdtempSync(join(tmpdir(), 'eval-path-'))
+    try {
+      const safeDir = join(root, 'safe')
+      mkdirSync(safeDir, { recursive: true })
+      const doc = join(safeDir, 'doc.txt')
+      writeFileSync(doc, 'x')
+
+      const rules = [
+        rule({
+          id: 'r1',
+          effect: 'auto_approve',
+          match: { tool: 'upload_file', pathPrefix: safeDir },
+        }),
+      ]
+      const decision = evaluate(
+        baseCall({ tool: 'upload_file', input: { path: doc } }),
+        rules,
+        0,
+      )
+      expect(decision.kind).toBe('allow')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('CWE-22: path traversal via ../ does not match a narrower pathPrefix', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const root = mkdtempSync(join(tmpdir(), 'eval-traversal-'))
+    try {
+      const safeDir = join(root, 'safe')
+      const secretsDir = join(root, 'secrets')
+      mkdirSync(safeDir, { recursive: true })
+      mkdirSync(secretsDir, { recursive: true })
+      const secret = join(secretsDir, 'key')
+      writeFileSync(secret, 'sensitive')
+
+      const rules = [
+        rule({
+          id: 'allow-safe',
+          effect: 'auto_approve',
+          match: { tool: 'upload_file', pathPrefix: safeDir },
+        }),
+      ]
+      const decision = evaluate(
+        baseCall({
+          tool: 'upload_file',
+          input: { path: join(safeDir, '..', 'secrets', 'key') },
+        }),
+        rules,
+        0,
+      )
+      // Traversal resolves outside safeDir → rule doesn't match → default
+      // branch (upload_file is in requireAuthoredPolicy) → deny.
+      expect(decision.kind).toBe('deny')
+      if (decision.kind === 'deny') expect(decision.rule).toBe('default')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('pathPrefix rule with nonexistent input path → rule skipped (fail-closed)', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const root = mkdtempSync(join(tmpdir(), 'eval-nopath-'))
+    try {
+      const rules = [
+        rule({
+          id: 'r1',
+          effect: 'auto_approve',
+          match: { tool: 'upload_file', pathPrefix: root },
+        }),
+      ]
+      const decision = evaluate(
+        baseCall({ tool: 'upload_file', input: { path: join(root, 'ghost.txt') } }),
+        rules,
+        0,
+      )
+      // upload_file default: deny.
+      expect(decision.kind).toBe('deny')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  // ── Default branches (no rule matches) ────────────────────────────────
+
+  test('default allow for tools not in requireAuthoredPolicy', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const decision = evaluate(baseCall({ tool: 'reply' }), [], 0)
+    expect(decision).toEqual({ kind: 'allow' })
+  })
+
+  test('default deny for tools in requireAuthoredPolicy (default set includes upload_file)', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const decision = evaluate(baseCall({ tool: 'upload_file' }), [], 0)
+    expect(decision.kind).toBe('deny')
+    if (decision.kind === 'deny') {
+      expect(decision.rule).toBe('default')
+      expect(decision.reason).toMatch(/no policy authored/)
+    }
+  })
+
+  test('custom requireAuthoredPolicy set overrides the default', async () => {
+    const { evaluate } = await import('./policy.ts')
+    const decision = evaluate(baseCall({ tool: 'delete_message' }), [], 0, {
+      requireAuthoredPolicy: new Set(['delete_message']),
+    })
+    expect(decision.kind).toBe('deny')
+  })
+})
+
+describe('detectShadowing() — load-time linter (29-A.5)', () => {
+  const rule = (id: string, effect: string, match: Record<string, unknown> = {}, extras: Record<string, unknown> = {}): import('./policy.ts').PolicyRule =>
+    ({ id, effect, match, priority: 100, ...extras } as import('./policy.ts').PolicyRule)
+
+  test('broad auto_approve shadows narrower deny placed after it', async () => {
+    const { detectShadowing } = await import('./policy.ts')
+    const rules = [
+      rule('allow-all-uploads', 'auto_approve', { tool: 'upload_file' }),
+      rule('deny-env-upload', 'deny', { tool: 'upload_file', pathPrefix: '/etc' }, {
+        reason: 'blocks env',
+      }),
+    ]
+    const warnings = detectShadowing(rules)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]!.later).toBe('deny-env-upload')
+    expect(warnings[0]!.earlier).toBe('allow-all-uploads')
+  })
+
+  test('no shadow when fields differ (different tool)', async () => {
+    const { detectShadowing } = await import('./policy.ts')
+    const rules = [
+      rule('r1', 'auto_approve', { tool: 'reply' }),
+      rule('r2', 'deny', { tool: 'upload_file' }, { reason: 'x' }),
+    ]
+    expect(detectShadowing(rules)).toEqual([])
+  })
+
+  test('no shadow when later rule is more-specific-different-value (different channel)', async () => {
+    const { detectShadowing } = await import('./policy.ts')
+    const rules = [
+      rule('r1', 'auto_approve', { channel: 'C_ONE' }),
+      rule('r2', 'deny', { channel: 'C_TWO' }, { reason: 'x' }),
+    ]
+    expect(detectShadowing(rules)).toEqual([])
+  })
+
+  test('shadow when earlier has fewer constraints and later has a superset of them', async () => {
+    const { detectShadowing } = await import('./policy.ts')
+    const rules = [
+      rule('broad', 'auto_approve', { tool: 'reply' }),
+      rule('narrow', 'deny', { tool: 'reply', channel: 'C_A' }, { reason: 'x' }),
+    ]
+    expect(detectShadowing(rules)).toHaveLength(1)
+  })
+
+  test('reports only the first shadowing earlier rule per later rule', async () => {
+    const { detectShadowing } = await import('./policy.ts')
+    const rules = [
+      rule('a', 'auto_approve', { tool: 'reply' }),
+      rule('b', 'auto_approve', { tool: 'reply' }), // also shadows c
+      rule('c', 'deny', { tool: 'reply' }, { reason: 'x' }),
+    ]
+    const warnings = detectShadowing(rules)
+    // "c" is shadowed, but only reported once (against "a").
+    expect(warnings.filter((w) => w.later === 'c')).toHaveLength(1)
+  })
+})
+
+describe('checkMonotonicity() — hot-reload invariant (29-A.6)', () => {
+  const rule = (id: string, effect: string, match: Record<string, unknown> = {}, extras: Record<string, unknown> = {}): import('./policy.ts').PolicyRule =>
+    ({ id, effect, match, priority: 100, ...extras } as import('./policy.ts').PolicyRule)
+
+  test('new auto_approve covered by existing deny → violation', async () => {
+    const { checkMonotonicity } = await import('./policy.ts')
+    const prev = [rule('deny-all', 'deny', { tool: 'upload_file' }, { reason: 'x' })]
+    const next = [
+      rule('deny-all', 'deny', { tool: 'upload_file' }, { reason: 'x' }),
+      rule('allow-pdf', 'auto_approve', { tool: 'upload_file', argEquals: { mime: 'pdf' } }),
+    ]
+    const violations = checkMonotonicity(prev, next)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]!.newRule).toBe('allow-pdf')
+    expect(violations[0]!.existingDeny).toBe('deny-all')
+  })
+
+  test('new deny rule does not trigger violation (doesn\'t weaken)', async () => {
+    const { checkMonotonicity } = await import('./policy.ts')
+    const prev = [rule('r1', 'auto_approve', { tool: 'reply' })]
+    const next = [
+      rule('r1', 'auto_approve', { tool: 'reply' }),
+      rule('new-deny', 'deny', { tool: 'upload_file' }, { reason: 'x' }),
+    ]
+    expect(checkMonotonicity(prev, next)).toEqual([])
+  })
+
+  test('modified rule (same id) does not count as "new" — no violation', async () => {
+    const { checkMonotonicity } = await import('./policy.ts')
+    // r1 changed effect, but same id — doc says removed/modified rules
+    // are not checked (operator signed off by editing).
+    const prev = [rule('deny-x', 'deny', { tool: 'upload_file' }, { reason: 'x' })]
+    const next = [rule('deny-x', 'auto_approve', { tool: 'upload_file' })]
+    expect(checkMonotonicity(prev, next)).toEqual([])
+  })
+
+  test('adding auto_approve orthogonal to any existing deny → no violation', async () => {
+    const { checkMonotonicity } = await import('./policy.ts')
+    const prev = [rule('deny-uploads', 'deny', { tool: 'upload_file' }, { reason: 'x' })]
+    const next = [
+      rule('deny-uploads', 'deny', { tool: 'upload_file' }, { reason: 'x' }),
+      rule('allow-replies', 'auto_approve', { tool: 'reply' }), // different tool
+    ]
+    expect(checkMonotonicity(prev, next)).toEqual([])
+  })
+
+  test('empty prev + new auto_approves → no violations (nothing existing to weaken)', async () => {
+    const { checkMonotonicity } = await import('./policy.ts')
+    const next = [
+      rule('r1', 'auto_approve', { tool: 'reply' }),
+      rule('r2', 'auto_approve', { tool: 'upload_file' }),
+    ]
+    expect(checkMonotonicity([], next)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

**Closes Epic `ccsc-v1b` — the policy engine's core logic.**

Bundles the last four leaves of sub-epic `ccsc-v1b.11` into one coherent change. With this PR + previously-landed sub-epic `v1b.10`, Epic 29-A (the policy engine as a pure library) is complete. Wire-into-server.ts belongs to Epic 29-B.

- **`ccsc-v1b.3`** — `evaluate(call, rules, now, opts?)` first-applicable (XACML)
- **`ccsc-v1b.5`** — `detectShadowing(rules)` load-time linter (warn-not-block)
- **`ccsc-v1b.6`** — `checkMonotonicity(prev, next)` hot-reload invariant (fail-closed)
- **`ccsc-v1b.7`** — full test matrix (26 new tests; exceeds the 15+ minimum)

## `evaluate()` — first-applicable combining

Pure function; walks `rules` in authored order, returns on the first match. No side effects — journal emission, approval recording, Slack posts happen outside.

- **Path matching** canonicalizes both `rule.pathPrefix` and `call.input.path` via `realpath` on every call (fail-closed on `ENOENT`).
- **Approval flow**: optional `Approvals` map flips a `require_approval` into `allow` when a fresh approval exists for `(rule.id, sessionKey)`. Scoped to `(rule, session)` per doc §285-287 — a different thread in the same channel does **not** inherit.
- **Default branch**: `deny` with `rule='default'` when `tool ∈ requireAuthoredPolicy` (starts as `['upload_file']`); `allow` otherwise.

## `detectShadowing()` — load-time warnings

Static subset-check over `MatchSpec`. A later rule is shadowed when every field of an earlier rule's match is less-specific-or-equal. Returns structured warnings; **fail-warn, not fail-closed** — an operator who wrote an intentionally unreachable rule shouldn't be blocked from booting.

## `checkMonotonicity()` — hot-reload invariant

Per doc §234-244. A newly-added `auto_approve` whose match is covered by an existing `deny` = violation. Non-empty return = caller refuses adoption. Removed/modified rules are not checked (operator signed off by editing).

## Test matrix — 26 new tests

| Suite | Coverage |
|---|---|
| `evaluate` (16) | three effect branches, approval-flow + session-scope + expiry, first-applicable ordering, every match-field semantic, path-prefix with realpath, **CWE-22 traversal defeat**, pathPrefix+ENOENT fail-closed, default allow, default deny, custom `requireAuthoredPolicy` |
| `detectShadowing` (5) | broad-shadows-narrow, orthogonal fields, different-value same-field, subset-is-superset asymmetry, single-report-per-later-rule |
| `checkMonotonicity` (5) | new auto_approve covered by existing deny, new deny, modified rule, orthogonal-new-rule, empty-prev baseline |

**200 pass / 0 fail / 392 expects. Typecheck clean.**

## Runtime impact

**None.** `evaluate()`/`detectShadowing()`/`checkMonotonicity()` have zero call sites in `server.ts`. Epic 29-B (`ccsc-me6`) wires them into the permission-relay path. Policy engine ships as a pure library in this PR — 29-B is the integration.

## Epic 29-A final status

```
ccsc-v1b — Build the policy engine's core logic                  ✅ closing
├── v1b.10 Define what a policy rule looks like                  ✅
│   ├── .1 PolicyRule Zod schema              (PR #47)           ✅
│   ├── .2 PolicyDecision tagged union        (PR #57)           ✅
│   └── .4 Path canonicalization (CWE-22)     (PR #57)           ✅
└── v1b.11 Evaluate rules and catch bad configs                  ✅ (this PR)
    ├── .3 evaluate() first-applicable                           ✅
    ├── .5 detectShadowing linter                                ✅
    ├── .6 checkMonotonicity invariant                           ✅
    └── .7 full test matrix                                      ✅
```

Jeremy made me do it
-claude