### PR TITLE
docs(29-A): worked examples + ACCESS.md policy schema (closes Epic 29-A)

### DIFF
--- a/000-docs/policy-evaluation-flow.md
+++ b/000-docs/policy-evaluation-flow.md
@@ -339,6 +339,142 @@ Every 29-A PR is checked against these.
 
 ---
 
+## Worked examples
+
+Concrete policy sets that exercise the combining algorithm. Every
+example is a legal input to `parsePolicyRules` and produces the
+decisions shown. Operators can paste these into a test harness to
+verify local changes behave as expected.
+
+### Example 1 — Allow replies, gate every upload
+
+The smallest policy set that changes default behavior. `reply` is not
+in `requireAuthoredPolicy`, so the authored rule is a no-op for it
+(default already allows); it's listed here to make the policy
+self-documenting for future readers.
+
+```json
+[
+  { "id": "allow-replies",   "effect": "auto_approve",     "match": { "tool": "reply" } },
+  { "id": "gate-uploads",    "effect": "require_approval", "match": { "tool": "upload_file" }, "ttlMs": 300000 }
+]
+```
+
+| Call                                      | Decision                                                                |
+|-------------------------------------------|-------------------------------------------------------------------------|
+| `tool: reply`                             | `{ kind: 'allow', rule: 'allow-replies' }`                              |
+| `tool: upload_file`, no prior approval    | `{ kind: 'require', rule: 'gate-uploads', approver: 'human_approver' }` |
+| `tool: upload_file`, approval in flight   | `{ kind: 'allow', rule: 'gate-uploads' }`                               |
+| `tool: edit_message`                      | `{ kind: 'allow' }` (default branch)                                    |
+
+### Example 2 — Path-scoped upload: auto-approve inside `/safe/`, deny `/etc/`
+
+Demonstrates first-applicable ordering + CWE-22 mitigation. A traversal
+`/safe/../etc/passwd` realpath-resolves to `/etc/passwd` and falls
+through to the deny rule — the "looks safe" path doesn't bypass the
+guard.
+
+```json
+[
+  { "id": "deny-etc",        "effect": "deny",
+    "match": { "tool": "upload_file", "pathPrefix": "/etc" },
+    "reason": "uploads from /etc are never permitted" },
+
+  { "id": "allow-safe-dir",  "effect": "auto_approve",
+    "match": { "tool": "upload_file", "pathPrefix": "/safe" } }
+]
+```
+
+| Call                                                | Decision                                                            |
+|-----------------------------------------------------|---------------------------------------------------------------------|
+| `upload_file` path=`/safe/report.pdf`               | `{ kind: 'allow', rule: 'allow-safe-dir' }`                         |
+| `upload_file` path=`/etc/passwd`                    | `{ kind: 'deny',  rule: 'deny-etc', reason: '…' }`                  |
+| `upload_file` path=`/safe/../etc/passwd` (traversal)| `{ kind: 'deny',  rule: 'deny-etc', reason: '…' }` — realpath wins  |
+| `upload_file` path=`/other/x.pdf`                   | `{ kind: 'deny',  rule: 'default', reason: 'no policy authored…' }` |
+
+### Example 3 — Channel + actor scoping for incident response
+
+Incident channel wants hands-off auto-approval for the on-call Claude
+process; other channels fall through to default. Shows how `channel`
+and `actor` narrow the match.
+
+```json
+[
+  { "id": "incidents-autoreply",
+    "effect": "auto_approve",
+    "match": { "tool": "reply", "channel": "C_INCIDENTS", "actor": "claude_process" } }
+]
+```
+
+| Call                                                         | Decision                                      |
+|--------------------------------------------------------------|-----------------------------------------------|
+| `reply` in `C_INCIDENTS`, actor=`claude_process`             | `{ kind: 'allow', rule: 'incidents-autoreply' }` |
+| `reply` in `C_INCIDENTS`, actor=`session_owner`              | `{ kind: 'allow' }` (default — actor mismatch) |
+| `reply` in `C_OTHER_CHANNEL`                                 | `{ kind: 'allow' }` (default — channel mismatch) |
+| `upload_file` in `C_INCIDENTS`                               | `{ kind: 'deny', rule: 'default' }` (tool mismatch → default deny) |
+
+### Example 4 — Shadow warning (operator-visible at load)
+
+This policy set produces a warning but still boots. The linter's job
+is to point out the dead rule so the operator can reorder or narrow.
+
+```json
+[
+  { "id": "auto-approve-all-uploads", "effect": "auto_approve", "match": { "tool": "upload_file" } },
+  { "id": "deny-env-upload",          "effect": "deny",
+    "match": { "tool": "upload_file", "pathPrefix": "/etc" },
+    "reason": "blocks env files" }
+]
+```
+
+At load, `detectShadowing()` returns:
+
+```
+[
+  { later: 'deny-env-upload',
+    earlier: 'auto-approve-all-uploads',
+    message: "rule 'deny-env-upload' is shadowed by earlier rule 'auto-approve-all-uploads' …" }
+]
+```
+
+Every call to `upload_file` matches the earlier `auto_approve` first,
+so `deny-env-upload` never fires. The fix is to reorder — put the deny
+before the allow — or to narrow the allow to a specific pathPrefix.
+
+### Example 5 — Monotonicity violation (load refused)
+
+Operator edits the policy file and adds an auto-approve that would
+weaken an existing deny. Reload refuses; `prev` stays active.
+
+```json
+// prev (currently loaded)
+[{ "id": "deny-uploads", "effect": "deny", "match": { "tool": "upload_file" }, "reason": "default-off" }]
+
+// next (attempted reload)
+[
+  { "id": "deny-uploads", "effect": "deny", "match": { "tool": "upload_file" }, "reason": "default-off" },
+  { "id": "allow-pdfs",   "effect": "auto_approve",
+    "match": { "tool": "upload_file", "argEquals": { "mimeType": "application/pdf" } } }
+]
+```
+
+`checkMonotonicity(prev, next)` returns:
+
+```
+[
+  { newRule: 'allow-pdfs',
+    existingDeny: 'deny-uploads',
+    message: "new auto_approve rule 'allow-pdfs' weakens existing deny 'deny-uploads' — reload refused" }
+]
+```
+
+The operator has two clean paths forward:
+
+1. **Remove the old deny first.** A reload that *removes* a deny is allowed — the operator has signed off by deleting the rule. Then reload the new auto-approve separately.
+2. **Make the new auto-approve orthogonal.** If the intent was to allow a narrower case *and* keep the deny as a catch-all, the rules need to be authored so the allow is strictly narrower and placed earlier (first-applicable will match the allow first). The monotonicity check flags the current pair because the new rule's match is a subset of the deny's match — they are *not* orthogonal.
+
+---
+
 ## References
 
 - OASIS (2013). *eXtensible Access Control Markup Language (XACML)

--- a/ACCESS.md
+++ b/ACCESS.md
@@ -162,6 +162,65 @@ Existing conversations that predate thread-scoping surface as the `default` thre
 
 Full design reference: [`000-docs/session-state-machine.md`](000-docs/session-state-machine.md).
 
+## Policy schema (v0.5.0+)
+
+A **policy** decides whether an MCP tool call proceeds, is denied, or requires a human approver. Policies are authored as JSON and validated at load with a Zod schema. The evaluator (`evaluate()` in `policy.ts`) is pure and uses first-applicable combining — the first rule whose `match` applies wins. See [`000-docs/policy-evaluation-flow.md`](000-docs/policy-evaluation-flow.md) for the full decision procedure and worked examples.
+
+### PolicyRule
+
+```ts
+type PolicyRule =
+  | { id: string; effect: 'auto_approve';     match: MatchSpec; priority?: number }
+  | { id: string; effect: 'deny';             match: MatchSpec; priority?: number; reason: string }
+  | { id: string; effect: 'require_approval'; match: MatchSpec; priority?: number; ttlMs?: number }
+```
+
+- **`id`** — stable, human-readable. Shows up in the audit journal and any error surfaced to Claude. Duplicate ids are a load-time error.
+- **`effect`** — one of three: `auto_approve` (allow without prompting), `deny` (refuse with a non-sensitive reason string), `require_approval` (hold until a human approver responds on Slack within `ttlMs`).
+- **`priority`** — default `100`. Position in the policy array is the *primary* sort key (first-applicable). `priority` is a tie-breaker *within effect* when two rules would otherwise be equivalent — not a global sort.
+- **`reason`** (deny only) — 1–200 chars, surfaced to Claude so the model knows why the call was rejected. Keep non-sensitive.
+- **`ttlMs`** (require_approval only) — approval freshness window. Default 5 minutes, hard ceiling 24 hours. Once granted, an approval auto-approves subsequent matching calls in the same `(rule, sessionKey)` until expiry.
+
+### MatchSpec
+
+```ts
+type MatchSpec = {
+  tool?:       string              // exact MCP tool name, e.g. "upload_file"
+  pathPrefix?: string              // canonicalized via realpath before compare (CWE-22 safe)
+  channel?:    string              // Slack channel ID, ^[CD][A-Z0-9]+$
+  actor?:      'session_owner' | 'claude_process'
+  argEquals?:  Record<string, unknown>   // subset-equality on validated MCP input args
+}
+```
+
+**At least one field must be constrained.** A match that restricts zero fields (either literally `{}` or `{ argEquals: {} }`) is a load-time error — a rule that matches every call is almost always a bug.
+
+- **`tool`** — exact match only; no globbing.
+- **`pathPrefix`** — compared after `realpath` resolves both sides; `/etc/passwd` does **not** match prefix `/etc/pass` (there's a `+ sep` guard). A rule pointing at a nonexistent path is a load-time error.
+- **`channel`** — Slack IDs starting with `C` (channel) or `D` (DM). Validated against `^[CD][A-Z0-9]+$`.
+- **`actor`** — who is calling the tool. `session_owner` is the human at the terminal; `claude_process` is the Claude Code session. Human approvers arrive as a later turn (permission reply) and are never the `actor` on the original call.
+- **`argEquals`** — subset equality on the MCP input object. Every listed key must match the call's input. Comparison is structural (JSON round-trip) — suitable for plain-JSON values only.
+
+### Default-branch behavior
+
+When no rule matches:
+
+- **Deny** — if the tool is in the `requireAuthoredPolicy` set (`['upload_file']` by default; grows as dangerous tools are added). Decision: `{ kind: 'deny', rule: 'default', reason: 'no policy authored for …' }`.
+- **Allow** — otherwise. Decision: `{ kind: 'allow' }` (no `rule` field, since no rule matched).
+
+The evaluator is a **veto layer**, not the sole gate. Even an allowed decision still flows through `assertOutboundAllowed` and `assertSendable` downstream — the policy engine is additional authorization, never sole authorization.
+
+### Safety checks the loader runs
+
+- **Schema validation** — Zod rejects malformed rules with structured errors naming the field and id.
+- **Duplicate-id rejection** — two rules sharing an `id` fail load.
+- **Shadow-detection linter** — warns (doesn't block) when a later rule is unreachable because an earlier rule's match is less-specific-or-equal on every field. Warnings go to stderr + audit log; operator sees them at boot and in CI.
+- **Monotonicity invariant** — on hot reload, refuses to adopt a policy set that contains a new `auto_approve` rule whose match is covered by an existing `deny`. Fail-closed because an accidental weakening reload is the exact shape of an attack via operator coercion.
+
+### Where policies live
+
+Currently: policies are consumed as a `PolicyRule[]` by `evaluate()` — the loader and on-disk format land with the server integration in **Epic 29-B**. This section will be updated when the file format is frozen; until then, treat the schema above as the stable contract.
+
 ## File attachments — sendable roots
 
 The `reply` tool can attach files to Slack messages, but only files whose


### PR DESCRIPTION
## Summary

Closes sub-epic **`ccsc-v1b.12`** (docs) and with it the parent **Epic `ccsc-v1b`** (policy engine core). Two leaves bundled:

- **`ccsc-v1b.8`** — Worked examples in `000-docs/policy-evaluation-flow.md`
- **`ccsc-v1b.9`** — `ACCESS.md` policy-schema section

## Worked examples (v1b.8)

Five concrete policy sets added to the evaluation-flow doc between Invariants and References. Each is a legal input to `parsePolicyRules` with a decision table per call shape:

1. **Allow replies, gate every upload** — smallest working policy.
2. **Path-scoped upload** with `/safe/` allow + `/etc/` deny; **CWE-22 traversal defeat** demonstrated inline against the same rules.
3. **Channel + actor scoping** for incident response.
4. **Shadow warning** — policy boots with a warning; operator sees which rule is unreachable.
5. **Monotonicity violation** — reload refused; two documented paths forward (remove old deny first; or narrow the new allow).

## ACCESS.md policy schema (v1b.9)

New section between "State directory layout" and "File attachments". Covers:

- `PolicyRule` shape — all three effects, priority semantics (tie-breaker within-effect, not global sort), `ttlMs` default + 24h ceiling.
- `MatchSpec` — every field, the at-least-one-field refinement, channel regex, `argEquals` structural semantics.
- Default-branch behavior — when the evaluator falls through to `allow` vs. `deny-by-omission` (`requireAuthoredPolicy`).
- Safety checks the loader runs — schema validation, duplicate-id rejection, `detectShadowing` (warn), `checkMonotonicity` (fail-closed).
- Note: the on-disk file format lands with **Epic 29-B**.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — **200 pass / 0 fail / 392 expects**
- [x] Internal doc links verified

## Epic 29-A final status

```
ccsc-v1b — Build the policy engine's core logic             ✅ closing
├── v1b.10 Rule shape                                        ✅
├── v1b.11 Evaluator + linter + monotonicity                 ✅
└── v1b.12 Docs                                              ✅ (this PR)
```

Pure library is complete. Wire-up is **Epic 29-B** (`ccsc-me6`).

Jeremy made me do it
-claude