### PR TITLE
feat(supervisor): session supervisor interface (ccsc-xa3.1, Epic 32-B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Slack channel for the Claude Code — two-way chat bridge via Socket Mode + MCP 
 
 ## Architecture
 
-Two-file MCP server: `server.ts` (stateful runtime, ~1000 lines) and `lib.ts` (pure functions, ~460 lines). Four runtime dependencies: `@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`. No frameworks.
+Two-file MCP server: `server.ts` (stateful runtime, ~1100 lines) and `lib.ts` (pure functions, ~915 lines). Four runtime dependencies: `@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`. No frameworks.
 
 ```
 Slack workspace → Socket Mode WebSocket → server.ts → MCP stdio → Claude Code
@@ -62,7 +62,7 @@ echo '{"strict":true, "contexts":["Typecheck"]}' | gh api -X PATCH repos/jeremyl
 
 - `server.ts` — MCP server runtime: bootstrap, Slack clients, tools, event handling
 - `lib.ts` — pure functions: gate logic, security guards, text chunking, session types
-- `policy.ts` — Zod schema for PolicyRule (29-A.1 landed; evaluator lands in follow-up beads)
+- `policy.ts` — PolicyRule Zod schema, `evaluate()` decision procedure, `detectShadowing` linter, `checkMonotonicity` (Epic 29-A closed)
 - `server.test.ts` — test suite covering security-critical functions (uses `bun:test`)
 - `skills/configure/SKILL.md` — `/slack-channel:configure` token setup skill
 - `skills/access/SKILL.md` — `/slack-channel:access` pairing/allowlist management skill

--- a/lib.ts
+++ b/lib.ts
@@ -98,8 +98,8 @@ export type SessionSchemaVersion = 1
  *  session-state-machine supervisor can migrate shapes without rewriting
  *  every field.
  *
- *  This type is the *file* shape; the in-memory SessionHandle (32-A.5)
- *  wraps it with mutex and lifecycle metadata.
+ *  This type is the *file* shape; the in-memory SessionHandle (32-B.1,
+ *  supervisor.ts) wraps it with mutex and lifecycle metadata.
  */
 export interface Session {
   /** Schema version of this session file. */

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -1,0 +1,199 @@
+/**
+ * supervisor.ts — Session supervisor interface for the MCP server.
+ *
+ * This file is the Epic 32-B entry point. It declares the shape of the
+ * SessionSupervisor actor — the single component allowed to create,
+ * transition, or destroy sessions — without providing a runtime. The
+ * activate / quiesce / deactivate implementations land in sibling beads
+ * (ccsc-xa3.2, ccsc-xa3.3, and the deactivate + reaper beads under
+ * ccsc-xa3.14). See 000-docs/session-state-machine.md §221-267 for the
+ * full behavioural contract this interface pins down, and Armstrong
+ * (2003) for the supervisor / lifecycle pattern it borrows from.
+ *
+ * Design notes:
+ *
+ *   - **Actor, not a library.** Every mutation of a live session flows
+ *     through a single SessionSupervisor owned by server.ts. lib.ts
+ *     primitives (sessionPath, saveSession, loadSession) are called only
+ *     from here. A session file written by any other path is a bug.
+ *
+ *   - **One mutex per session file.** Two Slack threads in the same
+ *     channel are independent; their handles carry independent mutexes.
+ *     The supervisor guarantees serialised `update()` calls per key, not
+ *     per channel.
+ *
+ *   - **Crash is not data loss.** The on-disk file is the source of
+ *     truth. In-memory handles are caches. If the process crashes mid-
+ *     flight, the next inbound event for that key re-enters Activating
+ *     and re-reads the file (see session-state-machine.md §239-247).
+ *
+ *   - **No policy, no gate, no journal.** The supervisor decides when a
+ *     session is loaded, held, flushed, or quarantined — it does not
+ *     decide who can speak (inbound gate), which tools run (Epic 29-B),
+ *     or what gets logged (Epic 30-A). Those subsystems observe session
+ *     state; they never mutate it.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { Session, SessionKey } from './lib'
+
+// ---------------------------------------------------------------------------
+// Lifecycle state
+// ---------------------------------------------------------------------------
+
+/** Observable lifecycle state for one session, mirroring the five-state
+ *  FSM in 000-docs/session-state-machine.md §109-155. Nonexistent is
+ *  implicit (no handle) so it is not an enumerated value here.
+ *
+ *  Transitions are strict and are the supervisor's responsibility — the
+ *  doc diagram is authoritative, this type is descriptive.
+ *
+ *    - `activating`   — load-or-create in progress; single-writer critical
+ *                       section. Callers of activate() observe this only
+ *                       through the returned Promise resolving.
+ *    - `active`       — handle is live, `session` reflects the on-disk
+ *                       file after the most recent `update()`.
+ *    - `quiescing`    — refusing new work; pending writes still flushing.
+ *                       `update()` rejects.
+ *    - `deactivating` — last flush resolved; handle about to be released.
+ *                       Terminal from the caller's perspective.
+ *    - `quarantined`  — save or load failure; supervisor filed a beads
+ *                       issue and will not auto-reload. Only a human
+ *                       (SO) clears this; see session-state-machine.md
+ *                       §132-137.
+ */
+export type SessionState =
+  | 'activating'
+  | 'active'
+  | 'quiescing'
+  | 'deactivating'
+  | 'quarantined'
+
+// ---------------------------------------------------------------------------
+// SessionHandle — in-memory wrapper around one Session file
+// ---------------------------------------------------------------------------
+
+/** Live handle to one session. Returned by `SessionSupervisor.activate()`.
+ *
+ *  Callers treat the handle as opaque: read `session` for the current
+ *  snapshot, call `update()` to persist a change. The handle enforces
+ *  serialised writes through an internal mutex keyed on this session's
+ *  path — two concurrent `update()` calls on the same handle run in
+ *  strict order (see session-state-machine.md §210 invariant 1).
+ *
+ *  A handle is valid only while `state === 'active'`. Once quiesce has
+ *  started, `update()` rejects; callers must re-activate to resume.
+ */
+export interface SessionHandle {
+  /** Identity. Immutable for the lifetime of the handle. */
+  readonly key: SessionKey
+
+  /** Lifecycle state of this handle as observed by the supervisor.
+   *  Consumers may read but must not assume state is stable between
+   *  awaits — the reaper or a shutdown signal can transition the
+   *  handle out from under them. Always re-check after an `await`. */
+  readonly state: SessionState
+
+  /** Most recent successfully persisted snapshot of this session. The
+   *  reference may point to frozen / read-only data; callers must not
+   *  mutate it in place. Produce the next version inside `update()`. */
+  readonly session: Session
+
+  /** Serialise an update through the per-session mutex, persist it via
+   *  the atomic writer (`saveSession()`), and refresh `this.session`.
+   *
+   *  Contract:
+   *    - `fn` receives the current session and returns the next one.
+   *      It must be pure — no I/O, no sleeps, no throwing except to
+   *      signal a validation failure that should abort the update.
+   *    - The supervisor persists the returned value with the atomic
+   *      writer. Partial state never lands on disk.
+   *    - On save failure the handle transitions to `quarantined` and
+   *      the returned promise rejects. In-memory `session` reverts to
+   *      the pre-update value; no consumer ever sees the failed draft.
+   *    - While `state !== 'active'` the promise rejects without
+   *      calling `fn`. */
+  update(fn: (prev: Session) => Session): Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// SessionSupervisor — the actor contract
+// ---------------------------------------------------------------------------
+
+/** Supervisor for the per-thread session population. There is exactly one
+ *  `SessionSupervisor` per MCP server process; it owns the
+ *  `Map<SessionKey, SessionHandle>` named in session-state-machine.md
+ *  §229 and is the only code permitted to drive state transitions on
+ *  that map.
+ *
+ *  Armstrong-style shape: the supervisor is a long-lived actor that
+ *  delegates work to short-lived per-session children (the handles).
+ *  Crashes of a single session are isolated — quarantine a handle, keep
+ *  serving every other key. Crashes of the supervisor itself restart
+ *  the whole population from disk (see §239-247).
+ *
+ *  The supervisor is **not** responsible for deciding whether an inbound
+ *  event reaches Claude (that is the inbound `gate()` in lib.ts), for
+ *  deciding whether a tool call runs (policy evaluator, Epic 29), or
+ *  for persisting the audit log (journal sink, Epic 30). It is a pure
+ *  session-lifecycle authority.
+ */
+export interface SessionSupervisor {
+  /** Activate the session for `key`: load the file if it exists, create
+   *  an empty one if not, and return a live handle.
+   *
+   *  Contract:
+   *    - Idempotent per key. Two concurrent activate() calls for the
+   *      same key return the same handle (single-flight, per
+   *      session-state-machine.md §266).
+   *    - While loading/creating the handle observes `state =
+   *      'activating'`; the returned promise resolves only after the
+   *      handle reaches `active`.
+   *    - Load failure on an existing file transitions to `quarantined`
+   *      and rejects the promise; the supervisor files a beads issue
+   *      for the SO and never auto-retries.
+   *    - Path-validation failure (realpath escape, bad SessionKey
+   *      component) rejects before any on-disk work; no session is
+   *      recorded for the key.
+   *    - Does not enforce idle TTL. Reaper logic lives in the deactivate
+   *      path, not here. */
+  activate(key: SessionKey): Promise<SessionHandle>
+
+  /** Refuse new work on `key` and wait for pending writes to flush.
+   *
+   *  Contract:
+   *    - After `quiesce()` begins, `update()` on the associated handle
+   *      rejects. New `activate()` calls for the same key wait for
+   *      quiesce to complete, then re-activate from disk.
+   *    - A new inbound event may cancel the quiesce and return the
+   *      handle to `active`, per session-state-machine.md §124 (the
+   *      `Quiescing → Active` transition). That decision is the
+   *      supervisor's; callers of `quiesce()` receive a promise that
+   *      resolves in either terminal case.
+   *    - Quiesce is idempotent: a second call during an in-flight
+   *      quiesce joins the same promise. */
+  quiesce(key: SessionKey): Promise<void>
+
+  /** Release the in-memory handle. The on-disk file is left alone.
+   *
+   *  Contract:
+   *    - Must be preceded by a completed `quiesce(key)`. Calling
+   *      `deactivate` on an `active` key is a programmer error and
+   *      rejects.
+   *    - After deactivation, the supervisor's live map no longer
+   *      contains `key`. Future inbound events for the same key
+   *      re-enter `activate()` and reload the file from disk.
+   *    - Quarantined handles are not deactivated through this path —
+   *      they persist until a human clears the quarantine flag. */
+  deactivate(key: SessionKey): Promise<void>
+
+  /** Graceful shutdown. Quiesces every live session in parallel, awaits
+   *  all flushes, then deactivates. Called from server.ts on SIGTERM /
+   *  SIGINT and on stdin EOF from the Claude Code host.
+   *
+   *  After `shutdown()` resolves the supervisor is unusable; a second
+   *  `activate()` call rejects. A new supervisor instance is required
+   *  to resume, and it will rebuild state from disk. */
+  shutdown(): Promise<void>
+}


### PR DESCRIPTION
## Summary

First bead under Epic 32-B (`ccsc-xa3`). Declares the `SessionSupervisor` actor contract in a new `supervisor.ts` module, following the five-state FSM and Armstrong-style supervision tree pinned in [`000-docs/session-state-machine.md`](000-docs/session-state-machine.md) §221-267.

- **`SessionSupervisor`** — `activate` / `quiesce` / `deactivate` / `shutdown` contract, with per-method pre/post semantics (single-flight, idempotent quiesce, shutdown terminality).
- **`SessionHandle`** — in-memory wrapper around one `Session` file with a mutex-guarded `update(fn)`. Rejects when not `active`; reverts in-memory snapshot on save failure.
- **`SessionState`** — five-state discriminated union mirroring the doc diagram (`activating` / `active` / `quiescing` / `deactivating` / `quarantined`).

Interface-only PR. No runtime — the activate/quiesce/deactivate implementations land in sibling beads (`ccsc-xa3.2`, `ccsc-xa3.3`, and the deactivate/reaper beads under `ccsc-xa3.14`).

Also folds in two drift fixes:
- `lib.ts:101` — cross-ref for `SessionHandle` pointed to 32-A.5 (which shipped without a handle type); now points to 32-B.1 / `supervisor.ts`.
- `CLAUDE.md` — `lib.ts` line count (460 → 915) and `policy.ts` description updated to reflect Epic 29-A closure (d3bd36a).

Closes bead `ccsc-xa3.1`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 200 pass / 0 fail / 392 expect()
- [x] No runtime code introduced; no behavioural tests needed for this bead

Jeremy made me do it
-claude