### PR TITLE
feat(supervisor): implement activate(key) (ccsc-xa3.2, Epic 32-B)

### DIFF
--- a/server.test.ts
+++ b/server.test.ts
@@ -2436,3 +2436,165 @@ describe('checkMonotonicity() — hot-reload invariant (29-A.6)', () => {
     expect(checkMonotonicity([], next)).toEqual([])
   })
 })
+
+// ---------------------------------------------------------------------------
+// SessionSupervisor.activate — 000-docs/session-state-machine.md §221-267
+// ---------------------------------------------------------------------------
+
+describe('createSessionSupervisor.activate', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let logged: Array<{ event: string; fields: Record<string, unknown> }>
+  let nowValue: number
+
+  const key = { channel: 'C_SUP', thread: 'T1.0' }
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'supervisor-activate-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    logged = []
+    nowValue = 1_700_000_000_000
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  function makeSupervisor() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createSessionSupervisor } = require('./supervisor.ts') as typeof import('./supervisor.ts')
+    return createSessionSupervisor({
+      stateRoot: tmpRoot,
+      log: (event, fields) => {
+        logged.push({ event, fields })
+      },
+      clock: () => nowValue,
+    })
+  }
+
+  test('activate with no existing file creates a new session and saves it', async () => {
+    const sup = makeSupervisor()
+
+    const handle = await sup.activate(key, 'U_OWNER')
+
+    expect(handle.key).toEqual(key)
+    expect(handle.state).toBe('active')
+    expect(handle.session.ownerId).toBe('U_OWNER')
+    expect(handle.session.v).toBe(1)
+    expect(handle.session.createdAt).toBe(nowValue)
+    expect(handle.session.lastActiveAt).toBe(nowValue)
+    expect(handle.session.data).toEqual({})
+
+    // File landed on disk with 0o600.
+    const p = sessionPath(tmpRoot, key)
+    const st = statSync(p)
+    expect(st.mode & 0o777).toBe(0o600)
+    const persisted = JSON.parse(readFileSync(p, 'utf8')) as Session
+    expect(persisted).toEqual(handle.session)
+  })
+
+  test('activate loads an existing session file and preserves ownerId', async () => {
+    // Pre-seed a session file that the supervisor should just load.
+    const pre: Session = {
+      v: 1,
+      key,
+      createdAt: 1_600_000_000_000,
+      lastActiveAt: 1_600_000_500_000,
+      ownerId: 'U_PRIOR',
+      data: { turns: [{ role: 'user', content: 'hi' }] },
+    }
+    const p = sessionPath(tmpRoot, key)
+    await saveSession(p, pre)
+
+    const sup = makeSupervisor()
+    // Supply a different initialOwnerId — it should be ignored because
+    // the file already exists.
+    const handle = await sup.activate(key, 'U_SHOULD_BE_IGNORED')
+
+    expect(handle.state).toBe('active')
+    expect(handle.session.ownerId).toBe('U_PRIOR')
+    expect(handle.session.data).toEqual({ turns: [{ role: 'user', content: 'hi' }] })
+  })
+
+  test('activate emits session.activate log with channel, thread, ownerId', async () => {
+    const sup = makeSupervisor()
+    await sup.activate(key, 'U_LOG_ME')
+
+    const hit = logged.find((l) => l.event === 'session.activate')
+    expect(hit).toBeDefined()
+    expect(hit!.fields).toEqual({
+      channel: 'C_SUP',
+      thread: 'T1.0',
+      ownerId: 'U_LOG_ME',
+    })
+  })
+
+  test('activate rejects when file missing and no initialOwnerId given', async () => {
+    const sup = makeSupervisor()
+    // No existing file; caller omits the owner. Contract says reject
+    // rather than synthesize identity.
+    await expect(sup.activate(key)).rejects.toThrow(/initialOwnerId/)
+  })
+
+  test('activate is single-flight: concurrent calls for same key share one handle', async () => {
+    const sup = makeSupervisor()
+    const [h1, h2, h3] = await Promise.all([
+      sup.activate(key, 'U_A'),
+      sup.activate(key, 'U_B'), // loses the race; owner should be U_A
+      sup.activate(key, 'U_C'), // loses the race; owner should be U_A
+    ])
+    expect(h1).toBe(h2)
+    expect(h2).toBe(h3)
+    expect(h1.session.ownerId).toBe('U_A')
+
+    // Only one session.activate log emission for three concurrent
+    // callers — the single-flight guarantee includes the log.
+    const events = logged.filter((l) => l.event === 'session.activate')
+    expect(events).toHaveLength(1)
+  })
+
+  test('cached activate: second call after first settles returns the same handle', async () => {
+    const sup = makeSupervisor()
+    const first = await sup.activate(key, 'U_OWNER')
+    const second = await sup.activate(key) // no owner needed, cached
+    expect(second).toBe(first)
+  })
+
+  test('activate allocates an empty in-flight AbortController map on the handle', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(key, 'U_OWNER')
+    // The map is internal (not on the interface), but exposed as a
+    // readonly property on ConcreteHandle for server.ts (ccsc-xa3.15)
+    // to attach abort controllers onto. Shape-check it here.
+    const inFlight = (handle as unknown as { inFlight: Map<string, AbortController> })
+      .inFlight
+    expect(inFlight).toBeInstanceOf(Map)
+    expect(inFlight.size).toBe(0)
+  })
+
+  test('activate rejects with malformed SessionKey components (no disk write)', async () => {
+    const sup = makeSupervisor()
+    // `..` is rejected by sessionPath(); supervisor must surface the
+    // error without caching a handle.
+    await expect(
+      sup.activate({ channel: '..', thread: 'T1' }, 'U_X'),
+    ).rejects.toThrow(/invalid channel/)
+
+    // A subsequent good activate must not observe stale in-flight
+    // state (single-flight map cleared).
+    const handle = await sup.activate(key, 'U_OK')
+    expect(handle.state).toBe('active')
+  })
+
+  test('quiesce/deactivate/shutdown are staged stubs that reject with bead pointers', async () => {
+    const sup = makeSupervisor()
+    await expect(sup.quiesce(key)).rejects.toThrow(/xa3\.3/)
+    await expect(sup.deactivate(key)).rejects.toThrow(/xa3\.14/)
+    await expect(sup.shutdown()).rejects.toThrow(/xa3\.14/)
+  })
+
+  test('handle.update is a staged stub that rejects with a bead pointer', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(key, 'U_OWNER')
+    await expect(handle.update((s) => s)).rejects.toThrow(/not yet implemented/)
+  })
+})

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -36,6 +36,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+import { loadSession, saveSession, sessionPath } from './lib'
 import type { Session, SessionKey } from './lib'
 
 // ---------------------------------------------------------------------------
@@ -143,6 +144,15 @@ export interface SessionSupervisor {
   /** Activate the session for `key`: load the file if it exists, create
    *  an empty one if not, and return a live handle.
    *
+   *  `initialOwnerId` is the Slack user ID to record as `ownerId` on a
+   *  newly-created session file. It is consulted **only** on the create
+   *  branch; if the session file already exists, the stored owner wins
+   *  and the argument is ignored. A caller that knows the session
+   *  already exists may omit it. A caller that cannot vouch for owner
+   *  (supervisor rehydration on boot, internal bookkeeping) may omit it
+   *  as well — activate() will then reject if the file is missing,
+   *  rather than synthesize an owner.
+   *
    *  Contract:
    *    - Idempotent per key. Two concurrent activate() calls for the
    *      same key return the same handle (single-flight, per
@@ -158,7 +168,7 @@ export interface SessionSupervisor {
    *      recorded for the key.
    *    - Does not enforce idle TTL. Reaper logic lives in the deactivate
    *      path, not here. */
-  activate(key: SessionKey): Promise<SessionHandle>
+  activate(key: SessionKey, initialOwnerId?: string): Promise<SessionHandle>
 
   /** Refuse new work on `key` and wait for pending writes to flush.
    *
@@ -196,4 +206,292 @@ export interface SessionSupervisor {
    *  `activate()` call rejects. A new supervisor instance is required
    *  to resume, and it will rebuild state from disk. */
   shutdown(): Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Factory — createSessionSupervisor
+// ---------------------------------------------------------------------------
+
+/** Structured log line emitted by the supervisor. `event` is a stable
+ *  identifier (e.g. `session.activate`); `fields` carries the event's
+ *  payload. Consumers are expected to inject their own writer; the
+ *  default writes one newline-delimited JSON object per call to stdout
+ *  so the journal sink (Epic 30-A) can tail the stream. */
+export type SupervisorLog = (
+  event: string,
+  fields: Record<string, unknown>,
+) => void
+
+/** Injection points for a SessionSupervisor. All are optional; defaults
+ *  give you a production-shaped supervisor that writes to stdout and
+ *  reads real wall-clock time. Tests supply their own `log` and `clock`
+ *  to keep assertions deterministic. */
+export interface SupervisorOptions {
+  /** State directory root, e.g. `~/.claude/channels/slack`. The same
+   *  root passed to `sessionPath()` and `loadSession()` in lib.ts. */
+  stateRoot: string
+  /** Optional structured log sink. Defaults to a stdout JSON-line
+   *  writer. */
+  log?: SupervisorLog
+  /** Optional wall-clock source, returning epoch-ms. Defaults to
+   *  `Date.now`. Injected for deterministic tests of `createdAt` and
+   *  `lastActiveAt`. */
+  clock?: () => number
+}
+
+/** Default structured log writer: one newline-delimited JSON object per
+ *  call, written to stdout. Matches the format the journal sink will
+ *  tail. Keeping this internal means callers who want a different sink
+ *  just pass their own `log` — no global config. */
+function defaultLog(event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ event, ...fields })
+  // process.stdout.write is sync for TTYs, async for pipes; either way
+  // the supervisor does not await the flush. Structured logs are best-
+  // effort; loss of a line is not a correctness issue.
+  process.stdout.write(line + '\n')
+}
+
+/** Construct a SessionSupervisor bound to a state directory.
+ *
+ *  Build one of these at server boot per state root. The supervisor is
+ *  long-lived; every inbound event flows through the same instance.
+ *
+ *  This factory currently returns a supervisor whose `activate()` is
+ *  fully wired (ccsc-xa3.2) and whose `quiesce()`, `deactivate()`, and
+ *  `shutdown()` throw `not yet implemented`. Those land in sibling
+ *  beads (ccsc-xa3.3, ccsc-xa3.14). Handle `update()` is also staged
+ *  for a later bead and currently rejects — callers of `activate()`
+ *  can read state but not yet persist changes. See
+ *  000-docs/session-state-machine.md §221-267 for the full target
+ *  behaviour. */
+export function createSessionSupervisor(
+  opts: SupervisorOptions,
+): SessionSupervisor {
+  const log = opts.log ?? defaultLog
+  const clock = opts.clock ?? Date.now
+  const { stateRoot } = opts
+
+  // Live handles, keyed by the stringified SessionKey. Use a composite
+  // string because `Map<object, ...>` keys by reference and two equal-
+  // valued SessionKey literals would not collide.
+  const live = new Map<string, ConcreteHandle>()
+
+  // Single-flight: concurrent activate() calls for the same key share
+  // one load/create promise. Cleared after the promise settles so a
+  // post-deactivate re-activation is not served a stale entry.
+  const activating = new Map<string, Promise<SessionHandle>>()
+
+  function keyId(k: SessionKey): string {
+    // `\0` is not a legal character in a Slack channel/ts string, so it
+    // is safe as a separator. Avoids the `"C1:T1" vs "C:1T1"` collision
+    // you would get with a single-colon join.
+    return `${k.channel}\0${k.thread}`
+  }
+
+  async function doActivate(
+    key: SessionKey,
+    initialOwnerId: string | undefined,
+  ): Promise<SessionHandle> {
+    // Path validation runs first — a malformed key never touches disk.
+    // Any throw here propagates; no handle is recorded.
+    const path = sessionPath(stateRoot, key)
+
+    let session: Session
+    try {
+      session = await loadSession(stateRoot, path)
+    } catch (err) {
+      if (!isNotFound(err)) {
+        // Real read failure: permissions, I/O, corrupt JSON, realpath
+        // escape. Caller treats this as a Quarantined transition; the
+        // quarantine bookkeeping (bead-filing, live-map entry with
+        // `state: 'quarantined'`) lands in ccsc-xa3.14. For now, surface
+        // the error and do not cache a handle. See session-state-
+        // machine.md §259-267 for the target failure-mode matrix.
+        log('session.activate_error', {
+          channel: key.channel,
+          thread: key.thread,
+          error: errorMessage(err),
+        })
+        throw err
+      }
+      // ENOENT branch: this key has never been activated. Require the
+      // caller to name the initial owner; otherwise refuse rather than
+      // synthesize identity. Aligned with session-state-machine.md §39
+      // ("the identity primitive does not accept user-authored values").
+      if (initialOwnerId === undefined) {
+        throw new Error(
+          `activate: session file missing and no initialOwnerId provided for ${JSON.stringify(
+            key,
+          )}`,
+        )
+      }
+      const now = clock()
+      session = {
+        v: 1,
+        key,
+        createdAt: now,
+        lastActiveAt: now,
+        ownerId: initialOwnerId,
+        data: {},
+      }
+      await saveSession(path, session)
+    }
+
+    const handle = new ConcreteHandle(key, session, path)
+    handle.markActive()
+    live.set(keyId(key), handle)
+
+    log('session.activate', {
+      channel: key.channel,
+      thread: key.thread,
+      ownerId: session.ownerId,
+    })
+
+    return handle
+  }
+
+  return {
+    activate(
+      key: SessionKey,
+      initialOwnerId?: string,
+    ): Promise<SessionHandle> {
+      const id = keyId(key)
+
+      // Cached handle wins: subsequent activate() on a live key returns
+      // the same handle without re-reading the file (session-state-
+      // machine.md §266 invariant).
+      const existing = live.get(id)
+      if (existing !== undefined) {
+        return Promise.resolve(existing)
+      }
+
+      // Single-flight: if a concurrent activation is already in
+      // progress, join it. The initialOwnerId from the second caller is
+      // discarded — the first caller won the race and their owner
+      // (if any) is the authoritative first owner.
+      const inflight = activating.get(id)
+      if (inflight !== undefined) {
+        return inflight
+      }
+
+      const promise = doActivate(key, initialOwnerId).finally(() => {
+        activating.delete(id)
+      })
+      activating.set(id, promise)
+      return promise
+    },
+
+    quiesce(_key: SessionKey): Promise<void> {
+      // ccsc-xa3.3.
+      return Promise.reject(
+        new Error('SessionSupervisor.quiesce: not yet implemented (ccsc-xa3.3)'),
+      )
+    },
+
+    deactivate(_key: SessionKey): Promise<void> {
+      // Under ccsc-xa3.14 (deactivate + reaper sub-epic).
+      return Promise.reject(
+        new Error(
+          'SessionSupervisor.deactivate: not yet implemented (ccsc-xa3.14)',
+        ),
+      )
+    },
+
+    shutdown(): Promise<void> {
+      // Under ccsc-xa3.14 (deactivate + reaper sub-epic).
+      return Promise.reject(
+        new Error(
+          'SessionSupervisor.shutdown: not yet implemented (ccsc-xa3.14)',
+        ),
+      )
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal — ConcreteHandle
+// ---------------------------------------------------------------------------
+
+/** In-process implementation of SessionHandle.
+ *
+ *  Not exported: callers consume the `SessionHandle` interface. Keeping
+ *  the class private lets later beads (update(), quiesce()) grow its
+ *  internals without widening the public surface.
+ *
+ *  This bead (ccsc-xa3.2) provides just enough handle shape to return
+ *  from activate(): identity, state, snapshot, and the in-flight
+ *  tool-call map required by the bead description. The `update()` body
+ *  and quiesce-aware state transitions are staged in sibling beads. */
+class ConcreteHandle implements SessionHandle {
+  readonly key: SessionKey
+  session: Session
+
+  // Backing field for the public `state` accessor. Starts in
+  // 'activating' so a consumer who somehow observes the handle before
+  // markActive() runs sees the honest transient state rather than a
+  // false 'active'.
+  private _state: SessionState = 'activating'
+
+  /** Per-request AbortControllers for tool calls dispatched against
+   *  this session. Populated by server.ts when it issues a tool call;
+   *  consumed by quiesce/shutdown to abort in-flight work before
+   *  persisting the final snapshot. Allocated here to satisfy the
+   *  activate-time contract in ccsc-xa3.2; the wiring into the tool-
+   *  call path is ccsc-xa3.15. */
+  readonly inFlight: Map<string, AbortController> = new Map()
+
+  /** Resolved path this session's file lives at. Kept on the handle so
+   *  later beads' `update()` and quiesce paths do not re-run
+   *  `sessionPath()` (which would re-mkdir the parent). */
+  readonly path: string
+
+  constructor(key: SessionKey, session: Session, path: string) {
+    this.key = key
+    this.session = session
+    this.path = path
+  }
+
+  get state(): SessionState {
+    return this._state
+  }
+
+  /** Transition from `activating` → `active`. Called by the supervisor
+   *  once the handle is fully wired and live in the map. Package-
+   *  private by convention; callers outside this file must not invoke
+   *  it. Later beads replace this with a proper state-transition method
+   *  that accepts the full FSM. */
+  markActive(): void {
+    this._state = 'active'
+  }
+
+  update(_fn: (prev: Session) => Session): Promise<void> {
+    // Staged for a later bead. update() is documented in the interface
+    // so later code can rely on the shape, but the mutex + atomic-write
+    // plumbing lands with the first real consumer (29-B or 32-B.3).
+    return Promise.reject(
+      new Error('SessionHandle.update: not yet implemented (later 32-B bead)'),
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal — error helpers
+// ---------------------------------------------------------------------------
+
+/** True for errors thrown by `loadSession` when the session file does
+ *  not exist yet. `realpathSync.native` surfaces a NodeJS.ErrnoException
+ *  with `code === 'ENOENT'`; we check `code` defensively in case the
+ *  error was wrapped. */
+function isNotFound(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const e = err as { code?: unknown }
+  return e.code === 'ENOENT'
+}
+
+/** Best-effort error message extractor for structured logs. Uses
+ *  `Error.message` when available; falls back to the stringified value
+ *  so non-Error throws (string, number) still log something. */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
 }


### PR DESCRIPTION
## Summary

First runtime under Epic 32-B. Adds `createSessionSupervisor()` factory and a fully-wired `activate()`. Other supervisor methods remain staged stubs that reject with bead pointers (`xa3.3` for quiesce, `xa3.14` for deactivate/shutdown, a later 32-B bead for `update()`).

### activate() behaviour

- **Single-flight per key** — concurrent `activate()` calls for the same SessionKey share one load/create promise and emit one log line. Losers' `initialOwnerId` is discarded; the first caller wins.
- **Cached-handle short-circuit** — a second `activate()` after the first settles returns the same handle, no re-read.
- **ENOENT requires `initialOwnerId`** — activate() refuses to synthesize identity for a brand-new session (session-state-machine.md §39 invariant). A caller who knows the session exists may omit it.
- **Atomic creation** — new sessions land via `saveSession()` (tmp + chmod 0o600 + rename).
- **Structured log** — one `session.activate` line per successful activation with `{ channel, thread, ownerId }`. Injectable for tests; default writes newline-delimited JSON to stdout so the Epic 30-A journal sink can tail it.
- **In-flight map** — `Map<requestId, AbortController>` allocated on the handle for ccsc-xa3.15 to populate.
- **Real load failures** emit `session.activate_error` and propagate; full Quarantined bookkeeping lands with ccsc-xa3.14.

### Interface amendment

`SessionSupervisor.activate()` now takes an optional `initialOwnerId`. The interface landed three commits ago (#60) with no downstream consumers yet, so the widening is safe. Rationale: the bead requires `ownerId` in the `session.activate` log line, and the only authoritative source for that on the create branch is the caller.

Closes bead `ccsc-xa3.2`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 210 pass / 0 fail / 420 expect() (up from 200 pass)
- [x] 10 new tests: new-file creation, existing-file load, ownerId-ignored-on-load, log emission shape, owner-required-on-create, single-flight semantics, cached-handle return, in-flight map allocation, malformed-key rejection without disk write, staged-stub rejection with bead-pointer messages.

Jeremy made me do it
-claude