### PR TITLE
feat: add Node.js/tsx as alternative runtime

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "slack": {
-      "command": "bun",
-      "args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--shell=bun", "--silent", "start"]
+      "command": "${CLAUDE_PLUGIN_ROOT}/node_modules/.bin/tsx",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server.ts"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@slack/socket-mode": "2.0.6",
     "@slack/web-api": "7.15.0",
+    "tsx": "^4.21.0",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/server.ts
+++ b/server.ts
@@ -7,7 +7,6 @@
  *
  * SPDX-License-Identifier: MIT
  */
-
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
@@ -860,7 +859,6 @@ async function handleMessage(event: unknown): Promise<void> {
   if (isDuplicateEvent(ev, seenEvents, Date.now(), EVENT_DEDUP_TTL_MS)) return
 
   const result = await gate(event)
-
   switch (result.action) {
     case 'drop':
       return


### PR DESCRIPTION
## Summary
- Switch `.mcp.json` from Bun to tsx (Node.js) as MCP server command
- Add `tsx` as runtime dependency in `package.json`
- Fixes Bun event loop bug where Socket Mode `message` events stop firing when `StdioServerTransport` is also active on stdin

## Context
When running under Bun, the Socket Mode WebSocket `message` handler never fires once `StdioServerTransport` attaches its own `data` listener to `process.stdin`. The same code works correctly under Node.js/tsx. Isolated with minimal test scripts confirming the issue is Bun-specific.

## Test plan
- [ ] Verify `bun test` still passes (tests use `bun:test`, unaffected)
- [ ] Verify MCP server starts and connects to Slack via Socket Mode under tsx
- [ ] Verify DM delivery and reply round-trip works
- [ ] Verify pairing flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)