### PR TITLE
feat(supervisor): implement quiesce(key) (ccsc-xa3.3, Epic 32-B)

### DIFF
--- a/server.test.ts
+++ b/server.test.ts
@@ -2585,9 +2585,8 @@ describe('createSessionSupervisor.activate', () => {
     expect(handle.state).toBe('active')
   })
 
-  test('quiesce/deactivate/shutdown are staged stubs that reject with bead pointers', async () => {
+  test('deactivate/shutdown are staged stubs that reject with bead pointers', async () => {
     const sup = makeSupervisor()
-    await expect(sup.quiesce(key)).rejects.toThrow(/xa3\.3/)
     await expect(sup.deactivate(key)).rejects.toThrow(/xa3\.14/)
     await expect(sup.shutdown()).rejects.toThrow(/xa3\.14/)
   })
@@ -2596,5 +2595,190 @@ describe('createSessionSupervisor.activate', () => {
     const sup = makeSupervisor()
     const handle = await sup.activate(key, 'U_OWNER')
     await expect(handle.update((s) => s)).rejects.toThrow(/not yet implemented/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SessionSupervisor.quiesce — 000-docs/session-state-machine.md §119-124, §266
+// ---------------------------------------------------------------------------
+
+describe('createSessionSupervisor.quiesce', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let logged: Array<{ event: string; fields: Record<string, unknown> }>
+
+  const key = { channel: 'C_QS', thread: 'T1.0' }
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'supervisor-quiesce-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    logged = []
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  function makeSupervisor() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createSessionSupervisor } = require('./supervisor.ts') as typeof import('./supervisor.ts')
+    return createSessionSupervisor({
+      stateRoot: tmpRoot,
+      log: (event, fields) => {
+        logged.push({ event, fields })
+      },
+      clock: () => 1_700_000_000_000,
+    })
+  }
+
+  // Type-assert the package-private drain API for tests. Callers in
+  // server.ts reach this surface through the supervisor; tests poke it
+  // directly to exercise the drain without waiting for ccsc-xa3.15 to
+  // wire up the tool-call path.
+  type DrainHandle = import('./supervisor.ts').SessionHandle & {
+    beginWork(requestId: string): AbortController
+    endWork(requestId: string): void
+    readonly inFlight: Map<string, AbortController>
+  }
+
+  test('quiesce on an unknown key is a silent no-op and emits no log', async () => {
+    const sup = makeSupervisor()
+    await expect(sup.quiesce(key)).resolves.toBeUndefined()
+    expect(logged.filter((l) => l.event === 'session.quiesce')).toHaveLength(0)
+  })
+
+  test('quiesce transitions state active → quiescing and resolves when map is empty', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(key, 'U_OWNER')
+    expect(handle.state).toBe('active')
+
+    const drain = sup.quiesce(key)
+    // State must flip synchronously before the drain promise resolves;
+    // otherwise a racing activate() would see stale 'active' and issue
+    // new work.
+    expect(handle.state).toBe('quiescing')
+
+    await drain
+    expect(handle.state).toBe('quiescing')
+  })
+
+  test('quiesce emits session.quiesce log with channel, thread, inflight count', async () => {
+    const sup = makeSupervisor()
+    const handle = (await sup.activate(key, 'U_OWNER')) as DrainHandle
+    handle.beginWork('req-1')
+    handle.beginWork('req-2')
+
+    const drain = sup.quiesce(key)
+    const hit = logged.find((l) => l.event === 'session.quiesce')
+    expect(hit).toBeDefined()
+    expect(hit!.fields).toEqual({
+      channel: 'C_QS',
+      thread: 'T1.0',
+      inflight: 2,
+    })
+
+    handle.endWork('req-1')
+    handle.endWork('req-2')
+    await drain
+  })
+
+  test('quiesce waits for in-flight work to drain before resolving', async () => {
+    const sup = makeSupervisor()
+    const handle = (await sup.activate(key, 'U_OWNER')) as DrainHandle
+    handle.beginWork('req-tool-1')
+
+    let resolved = false
+    const drain = sup.quiesce(key).then(() => {
+      resolved = true
+    })
+
+    // Let the microtask queue run — drain must NOT resolve yet because
+    // req-tool-1 is still in flight.
+    await new Promise<void>((r) => queueMicrotask(r))
+    expect(resolved).toBe(false)
+
+    handle.endWork('req-tool-1')
+    await drain
+    expect(resolved).toBe(true)
+  })
+
+  test('quiesce is idempotent: concurrent calls share one drain promise', async () => {
+    const sup = makeSupervisor()
+    const handle = (await sup.activate(key, 'U_OWNER')) as DrainHandle
+    handle.beginWork('req-A')
+
+    // Three parallel quiesce() calls. The first emits the log; the
+    // other two must join the same drain without firing a second log.
+    const [p1, p2, p3] = [sup.quiesce(key), sup.quiesce(key), sup.quiesce(key)]
+
+    // quiesce() returns a fresh resolved promise for the no-log path,
+    // but in the log-emitting path they all point at the same handle
+    // drain. We don't rely on reference equality across the three
+    // promises (Promise.resolve wrappers differ); we rely on behaviour
+    // — exactly one log, and all three resolve together.
+    handle.endWork('req-A')
+    await Promise.all([p1, p2, p3])
+
+    expect(logged.filter((l) => l.event === 'session.quiesce')).toHaveLength(3)
+    // Three log lines because each supervisor.quiesce() call logs on
+    // entry. The underlying drain is shared; only the log is
+    // per-call. That matches the 'session.quiesce' contract — each
+    // quiesce *request* is audit-worthy even if they coalesce.
+  })
+
+  test('quiesce called again after drain already completed resolves without changing state', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(key, 'U_OWNER')
+
+    await sup.quiesce(key) // first drain: empty map, resolves on microtask
+    expect(handle.state).toBe('quiescing')
+
+    // Second quiesce on an already-quiesced handle should return the
+    // cached drain promise (already resolved) and not try to re-enter
+    // the active→quiescing edge.
+    await expect(sup.quiesce(key)).resolves.toBeUndefined()
+    expect(handle.state).toBe('quiescing')
+  })
+
+  test('endWork on an unknown requestId is a no-op, does not spuriously resolve drain', async () => {
+    const sup = makeSupervisor()
+    const handle = (await sup.activate(key, 'U_OWNER')) as DrainHandle
+    handle.beginWork('real-req')
+
+    // Drain should still be pending because real-req is live.
+    let resolved = false
+    const drain = sup.quiesce(key).then(() => {
+      resolved = true
+    })
+
+    handle.endWork('bogus-req') // unknown — should be ignored
+    await new Promise<void>((r) => queueMicrotask(r))
+    expect(resolved).toBe(false)
+
+    handle.endWork('real-req')
+    await drain
+  })
+
+  test('beginWork rejects duplicate requestId', async () => {
+    const sup = makeSupervisor()
+    const handle = (await sup.activate(key, 'U_OWNER')) as DrainHandle
+    handle.beginWork('dup')
+    expect(() => handle.beginWork('dup')).toThrow(/already in flight/)
+  })
+
+  test('quiesce does not mutate inFlight map contents', async () => {
+    const sup = makeSupervisor()
+    const handle = (await sup.activate(key, 'U_OWNER')) as DrainHandle
+    const ctrl = handle.beginWork('abort-me')
+
+    const drain = sup.quiesce(key)
+    // quiesce must NOT abort in-flight work — graceful drain awaits
+    // natural completion. The shutdown path (ccsc-xa3.14) is the one
+    // that will call .abort(). Verify the controller is still live
+    // and the entry is still in the map.
+    expect(ctrl.signal.aborted).toBe(false)
+    expect(handle.inFlight.has('abort-me')).toBe(true)
+
+    handle.endWork('abort-me')
+    await drain
   })
 })

--- a/server.test.ts
+++ b/server.test.ts
@@ -2706,23 +2706,16 @@ describe('createSessionSupervisor.quiesce', () => {
     const handle = (await sup.activate(key, 'U_OWNER')) as DrainHandle
     handle.beginWork('req-A')
 
-    // Three parallel quiesce() calls. The first emits the log; the
-    // other two must join the same drain without firing a second log.
+    // Three parallel quiesce() calls. Each call is audit-worthy and
+    // emits a log line on entry; they all join the same underlying
+    // drain promise on the handle so only one real drain runs.
     const [p1, p2, p3] = [sup.quiesce(key), sup.quiesce(key), sup.quiesce(key)]
 
-    // quiesce() returns a fresh resolved promise for the no-log path,
-    // but in the log-emitting path they all point at the same handle
-    // drain. We don't rely on reference equality across the three
-    // promises (Promise.resolve wrappers differ); we rely on behaviour
-    // — exactly one log, and all three resolve together.
     handle.endWork('req-A')
     await Promise.all([p1, p2, p3])
 
+    // One log per quiesce() call (audit), one shared drain (behaviour).
     expect(logged.filter((l) => l.event === 'session.quiesce')).toHaveLength(3)
-    // Three log lines because each supervisor.quiesce() call logs on
-    // entry. The underlying drain is shared; only the log is
-    // per-call. That matches the 'session.quiesce' contract — each
-    // quiesce *request* is audit-worthy even if they coalesce.
   })
 
   test('quiesce called again after drain already completed resolves without changing state', async () => {

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -381,11 +381,25 @@ export function createSessionSupervisor(
       return promise
     },
 
-    quiesce(_key: SessionKey): Promise<void> {
-      // ccsc-xa3.3.
-      return Promise.reject(
-        new Error('SessionSupervisor.quiesce: not yet implemented (ccsc-xa3.3)'),
-      )
+    quiesce(key: SessionKey): Promise<void> {
+      const id = keyId(key)
+      const handle = live.get(id)
+      if (handle === undefined) {
+        // Nothing to drain. Per session-state-machine.md §124 a
+        // quiesce() on a Nonexistent key is a no-op — there is no
+        // handle to transition and no work to flush. Do not emit a
+        // log line for the empty case; it adds no information and
+        // would confuse the journal sink's per-session correlation.
+        return Promise.resolve()
+      }
+
+      log('session.quiesce', {
+        channel: key.channel,
+        thread: key.thread,
+        inflight: handle.inFlight.size,
+      })
+
+      return handle.beginQuiesce()
     },
 
     deactivate(_key: SessionKey): Promise<void> {
@@ -415,13 +429,16 @@ export function createSessionSupervisor(
 /** In-process implementation of SessionHandle.
  *
  *  Not exported: callers consume the `SessionHandle` interface. Keeping
- *  the class private lets later beads (update(), quiesce()) grow its
+ *  the class private lets later beads (update(), deactivate()) grow its
  *  internals without widening the public surface.
  *
- *  This bead (ccsc-xa3.2) provides just enough handle shape to return
- *  from activate(): identity, state, snapshot, and the in-flight
- *  tool-call map required by the bead description. The `update()` body
- *  and quiesce-aware state transitions are staged in sibling beads. */
+ *  Current scope:
+ *    - ccsc-xa3.2 — identity, state, snapshot, in-flight map allocation,
+ *      markActive() transition.
+ *    - ccsc-xa3.3 — beginQuiesce()/beginWork()/endWork() drain mechanics
+ *      and the active → quiescing transition.
+ *    - update() body and Quiescing → Deactivating / cancellation edges
+ *      land in later beads. */
 class ConcreteHandle implements SessionHandle {
   readonly key: SessionKey
   session: Session
@@ -433,17 +450,27 @@ class ConcreteHandle implements SessionHandle {
   private _state: SessionState = 'activating'
 
   /** Per-request AbortControllers for tool calls dispatched against
-   *  this session. Populated by server.ts when it issues a tool call;
-   *  consumed by quiesce/shutdown to abort in-flight work before
-   *  persisting the final snapshot. Allocated here to satisfy the
-   *  activate-time contract in ccsc-xa3.2; the wiring into the tool-
-   *  call path is ccsc-xa3.15. */
+   *  this session. Populated by `beginWork()` (called from server.ts's
+   *  tool-call path in ccsc-xa3.15); cleared by `endWork()` when the
+   *  call settles. Quiesce waits for this map to drain; shutdown will
+   *  abort every entry before deactivating (ccsc-xa3.14). */
   readonly inFlight: Map<string, AbortController> = new Map()
 
   /** Resolved path this session's file lives at. Kept on the handle so
-   *  later beads' `update()` and quiesce paths do not re-run
+   *  later beads' `update()` and deactivate paths do not re-run
    *  `sessionPath()` (which would re-mkdir the parent). */
   readonly path: string
+
+  /** In-flight drain promise allocated by `beginQuiesce()`. Null when
+   *  the handle is Active (nothing to drain). Callers of quiesce share
+   *  this promise so concurrent quiesce() requests do not allocate
+   *  multiple drains. */
+  private quiescePromise: Promise<void> | null = null
+
+  /** Resolver for `quiescePromise`. Called by `endWork()` when the
+   *  last in-flight entry drains, or directly by `beginQuiesce()` when
+   *  the map is already empty at quiesce time. */
+  private resolveQuiesce: (() => void) | null = null
 
   constructor(key: SessionKey, session: Session, path: string) {
     this.key = key
@@ -464,10 +491,105 @@ class ConcreteHandle implements SessionHandle {
     this._state = 'active'
   }
 
+  /** Begin a graceful drain. Transitions state `active` → `quiescing`
+   *  and returns a promise that resolves when the in-flight map reaches
+   *  zero entries. Contract:
+   *
+   *    - Idempotent when already quiescing: returns the existing drain
+   *      promise so two concurrent callers share one drain.
+   *    - Idempotent no-op when the in-flight map is already empty:
+   *      resolves on the next microtask to preserve the promise
+   *      ordering callers expect.
+   *    - Rejects if called from any state other than `active` or
+   *      `quiescing` — the FSM has no edge there.
+   *
+   *  Called by `SessionSupervisor.quiesce()`. Not a SessionHandle
+   *  interface method; consumers use the supervisor's quiesce() entry
+   *  point which emits the `session.quiesce` log line. */
+  beginQuiesce(): Promise<void> {
+    if (this._state === 'quiescing') {
+      // Join the already-running drain (session-state-machine.md §266
+      // documents quiesce() as idempotent — a second call receives the
+      // first's promise).
+      if (this.quiescePromise === null) {
+        // Defensive: state is quiescing but no promise was recorded.
+        // That's a programmer error (markActive / beginQuiesce sequence
+        // violated). Fail loudly rather than silently synthesize.
+        return Promise.reject(
+          new Error('beginQuiesce: quiescing state without drain promise'),
+        )
+      }
+      return this.quiescePromise
+    }
+
+    if (this._state !== 'active') {
+      return Promise.reject(
+        new Error(
+          `beginQuiesce: cannot quiesce from state ${JSON.stringify(this._state)}`,
+        ),
+      )
+    }
+
+    this._state = 'quiescing'
+
+    this.quiescePromise = new Promise<void>((resolve) => {
+      this.resolveQuiesce = resolve
+    })
+
+    // If nothing is in flight at quiesce time, resolve on the next
+    // microtask. Queueing (rather than resolving inline) keeps the
+    // promise-returns-before-handler semantic consistent with the
+    // drain-via-endWork() path, so callers cannot accidentally depend
+    // on synchronous resolution.
+    if (this.inFlight.size === 0) {
+      queueMicrotask(() => {
+        this.resolveQuiesce?.()
+      })
+    }
+
+    return this.quiescePromise
+  }
+
+  /** Register an AbortController for an in-flight tool call and return
+   *  it to the caller. The caller's responsibility is to invoke
+   *  `endWork(requestId)` when the call settles. On shutdown (ccsc-
+   *  xa3.14) the supervisor will call `.abort()` on every entry still
+   *  in the map.
+   *
+   *  Not used in this bead — xa3.15 wires it into the tool-call path.
+   *  Published here so `beginQuiesce()` has a real drain contract to
+   *  honour and tests can exercise the drain path. */
+  beginWork(requestId: string): AbortController {
+    if (this.inFlight.has(requestId)) {
+      throw new Error(
+        `beginWork: requestId already in flight: ${JSON.stringify(requestId)}`,
+      )
+    }
+    const ctrl = new AbortController()
+    this.inFlight.set(requestId, ctrl)
+    return ctrl
+  }
+
+  /** Mark a tool call complete. Removes the controller from the in-
+   *  flight map and, if the handle is quiescing and the map is now
+   *  empty, resolves the drain promise. Safe to call with an unknown
+   *  requestId — treated as a no-op so crash-recovery bookkeeping
+   *  that double-ends is not a fatal error. */
+  endWork(requestId: string): void {
+    const had = this.inFlight.delete(requestId)
+    if (!had) return
+
+    if (this._state === 'quiescing' && this.inFlight.size === 0) {
+      this.resolveQuiesce?.()
+    }
+  }
+
   update(_fn: (prev: Session) => Session): Promise<void> {
     // Staged for a later bead. update() is documented in the interface
     // so later code can rely on the shape, but the mutex + atomic-write
-    // plumbing lands with the first real consumer (29-B or 32-B.3).
+    // plumbing lands with the first real consumer (29-B or a follow-up
+    // 32-B bead). The interface's "rejects when state !== 'active'"
+    // clause lands with the real impl — for now we reject uniformly.
     return Promise.reject(
       new Error('SessionHandle.update: not yet implemented (later 32-B bead)'),
     )

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -529,9 +529,7 @@ class ConcreteHandle implements SessionHandle {
 
     if (this._state !== 'active') {
       return Promise.reject(
-        new Error(
-          `beginQuiesce: cannot quiesce from state ${JSON.stringify(this._state)}`,
-        ),
+        new Error(`beginQuiesce: cannot quiesce from state '${this._state}'`),
       )
     }
 
@@ -567,7 +565,7 @@ class ConcreteHandle implements SessionHandle {
   beginWork(requestId: string): AbortController {
     if (this.inFlight.has(requestId)) {
       throw new Error(
-        `beginWork: requestId already in flight: ${JSON.stringify(requestId)}`,
+        `beginWork: requestId already in flight: '${requestId}'`,
       )
     }
     const ctrl = new AbortController()

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -514,9 +514,14 @@ class ConcreteHandle implements SessionHandle {
       if (this.quiescePromise === null) {
         // Defensive: state is quiescing but no promise was recorded.
         // That's a programmer error (markActive / beginQuiesce sequence
-        // violated). Fail loudly rather than silently synthesize.
+        // violated). Fail loudly rather than silently synthesize. The
+        // key is included so the journal sink can correlate the bug
+        // back to the offending session without grepping the running
+        // process.
         return Promise.reject(
-          new Error('beginQuiesce: quiescing state without drain promise'),
+          new Error(
+            `beginQuiesce: quiescing state without drain promise for ${JSON.stringify(this.key)}`,
+          ),
         )
       }
       return this.quiescePromise


### PR DESCRIPTION
## Summary

Second runtime under Epic 32-B. Replaces the staged stub on \`SessionSupervisor.quiesce()\` with a real graceful-drain implementation and grows \`ConcreteHandle\` with the package-private \`beginQuiesce\` / \`beginWork\` / \`endWork\` surface that the tool-call path (\`ccsc-xa3.15\`) will plug into.

### Behaviour

- **State transition** — \`supervisor.quiesce(key)\` looks up the live handle and calls \`handle.beginQuiesce()\`, flipping state \`active\` → \`quiescing\` synchronously. Missing key → silent no-op (no log) since there is no session to drain.
- **Drain** — returns a promise that resolves when the in-flight map reaches zero entries. If the map is already empty, resolution is queued on the next microtask (not inline) so callers cannot accidentally depend on synchronous resolution.
- **Idempotent (concurrent)** — parallel \`quiesce()\` calls share one drain promise via the handle. Each call still emits one \`session.quiesce\` log line because every quiesce *request* is audit-worthy.
- **Idempotent (post-drain)** — quiesce on an already-drained handle returns the cached resolved promise without re-entering the FSM edge.
- **Log** — \`session.quiesce\` with \`{ channel, thread, inflight }\`.
- **Graceful, not forceful** — \`beginQuiesce()\` does NOT abort in-flight work. That's the shutdown path (\`ccsc-xa3.14\`), which will call \`.abort()\` on every entry.

### ConcreteHandle growth

- \`beginWork(requestId)\` allocates and registers an AbortController. Throws on duplicate \`requestId\` to catch bookkeeping bugs before they mask double-resolve drains.
- \`endWork(requestId)\` removes the controller and resolves the drain if applicable. Unknown \`requestId\` is a deliberate no-op so crash-recovery double-end is not fatal.

### Scope notes

- **Not in this bead:** Quiescing → Deactivating (\`ccsc-xa3.14\`), Quiescing → Active cancellation (reaper-era optimization), \`update()\` impl. \`update()\` remains a staged stub — the interface's "rejects when state !== 'active'" clause lands with the real impl.
- **Not yet wired:** consumers of \`activate()\` never observe a quiescing handle because \`server.ts\` does not yet call \`quiesce()\`. That wiring is the reaper bead under \`ccsc-xa3.14\`.

Closes bead \`ccsc-xa3.3\`.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 219 pass / 0 fail / 436 expect() (up from 210)
- [x] 9 new tests: unknown-key no-op, state-transition visibility, log shape, drain-awaits-inflight, idempotent-concurrent, idempotent-post-drain, unknown-requestId no-op, duplicate-requestId rejection, quiesce-does-not-abort

Jeremy made me do it
-claude