### PR TITLE
feat(journal): JournalEvent schema + type (ccsc-5pi.1, Epic 30-A)

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -1,0 +1,237 @@
+/**
+ * journal.ts — Tamper-evident audit journal for the Slack↔Claude-Code bridge.
+ *
+ * This file is the Epic 30-A entry point. Scope of this bead (ccsc-5pi.1)
+ * is narrow: the `JournalEvent` schema and its inferred type. The writer,
+ * redaction module, canonical-JSON serializer, and verification command
+ * land in sibling beads (ccsc-5pi.2 – ccsc-5pi.16). See
+ * 000-docs/audit-journal-architecture.md for the full contract.
+ *
+ * Shape of a journal event (audit-journal-architecture.md §19-59):
+ *
+ *   {
+ *     v:        1,                          // schema version; chain refuses mixed versions
+ *     ts:       '2026-04-19T12:34:56.789Z', // ISO-8601 UTC with ms precision
+ *     seq:      42,                         // monotonic per chain
+ *     kind:     'gate.inbound.drop',        // discriminated union of 19 event kinds
+ *     toolName?: 'reply',
+ *     input?:   { chat_id: 'C01', text: '...' },     // post-redaction
+ *     outcome?: 'allow' | 'deny' | 'require' | 'drop' | 'n/a',
+ *     reason?:  'peer bot not in allowFrom',
+ *     ruleId?:  'no-exfil-to-untrusted-channel',
+ *     sessionKey?: { channel: 'C01', thread: '1711000000.000100' },
+ *     actor?:   'session_owner' | 'claude_process' | ...,
+ *     correlationId?: 'req-abc123',
+ *     prevHash: 'e3b0c44...',                // sha256 hex, 64 chars
+ *     hash:     'b94d27b...',                // sha256 hex, 64 chars
+ *   }
+ *
+ * Why `strict()` on the schema: the chain property depends on every writer
+ * and every verifier hashing the **same bytes**. Accepting unknown fields
+ * would let callers sneak unredacted content through the writer's redactor
+ * (which only walks the documented fields). Strict mode surfaces those
+ * mistakes at build time or on the first `parse()` call.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { z } from 'zod'
+import type { SessionKey } from './lib'
+
+// ---------------------------------------------------------------------------
+// Event kinds — discriminated union tag
+// ---------------------------------------------------------------------------
+
+/** Every security-relevant event the journal records. Pinned by
+ *  000-docs/audit-journal-architecture.md §40-59; adding a new kind is an
+ *  intentional schema change and should be justified in a design-doc PR
+ *  before the code PR.
+ *
+ *  Grouping (for the reader, not enforced):
+ *    - `gate.*`        inbound/outbound gate decisions (lib.ts)
+ *    - `policy.*`      evaluator decisions + approval flow (policy.ts)
+ *    - `exfil.block`   `assertSendable()` refusal
+ *    - `session.*`     supervisor lifecycle transitions (supervisor.ts)
+ *    - `pairing.*`     DM-pairing state machine (access.json)
+ *    - `system.*`      boot, shutdown, rotation
+ */
+export const EventKind = z.enum([
+  'gate.inbound.deliver',
+  'gate.inbound.drop',
+  'gate.outbound.allow',
+  'gate.outbound.deny',
+  'policy.allow',
+  'policy.deny',
+  'policy.require',
+  'policy.approved',
+  'exfil.block',
+  'session.activate',
+  'session.quiesce',
+  'session.deactivate',
+  'session.quarantine',
+  'pairing.issued',
+  'pairing.accepted',
+  'pairing.expired',
+  'system.boot',
+  'system.shutdown',
+  'system.reload',
+])
+
+/** TypeScript string union of the 19 event kinds. */
+export type EventKind = z.infer<typeof EventKind>
+
+// ---------------------------------------------------------------------------
+// Supporting enums
+// ---------------------------------------------------------------------------
+
+/** Outcome of a gated action. `n/a` is the legitimate value for events
+ *  that are observational rather than decision-emitting (e.g.
+ *  `system.boot`, `session.activate`). Keep this set tight so the
+ *  verification tool can normalize cleanly. */
+export const Outcome = z.enum(['allow', 'deny', 'require', 'drop', 'n/a'])
+export type Outcome = z.infer<typeof Outcome>
+
+/** Who initiated or owns the action being recorded. Mirrors the
+ *  four-principal model in ARCHITECTURE.md; `system` is the catch-all
+ *  for supervisor / reaper / boot-path entries that have no human or
+ *  agent actor. */
+export const Actor = z.enum([
+  'session_owner',
+  'claude_process',
+  'human_approver',
+  'peer_agent',
+  'system',
+])
+export type Actor = z.infer<typeof Actor>
+
+// ---------------------------------------------------------------------------
+// Primitive shapes
+// ---------------------------------------------------------------------------
+
+/** SHA-256 hex string: exactly 64 lowercase hex chars. Enforced at
+ *  parse time so a malformed `prevHash` / `hash` is caught before it
+ *  reaches the verifier. The writer produces them via `toString('hex')`
+ *  on a Node crypto digest, which is guaranteed lowercase. */
+const Sha256Hex = z
+  .string()
+  .regex(/^[0-9a-f]{64}$/, {
+    message: 'sha256 hex must be 64 lowercase hex chars',
+  })
+
+/** Subset match of `SessionKey` from lib.ts. Duplicated here rather
+ *  than reusing the lib schema because the journal must be hashable
+ *  independent of whether lib.ts is loaded; keeping the structure
+ *  literal keeps the JCS canonical form frozen to this file.
+ *
+ *  The `satisfies` assertion guarantees the shape stays in lock-step
+ *  with the `SessionKey` type — a lib-side rename breaks the build
+ *  here, forcing a schema bump. */
+const SessionKeyShape = z.object({
+  channel: z.string(),
+  thread: z.string(),
+}) satisfies z.ZodType<SessionKey>
+
+// ---------------------------------------------------------------------------
+// JournalEvent — the on-disk record shape
+// ---------------------------------------------------------------------------
+
+/** One line in `audit.log` after canonical serialization. Every field
+ *  is either required (carried by every event) or optional with a clear
+ *  meaning when absent.
+ *
+ *  Why `strict()`: unknown fields on a journal event mean either (a) a
+ *  caller is trying to sneak unredacted data through the writer, or
+ *  (b) two components disagree on the schema. Both need to be loud,
+ *  not swallowed. The cost is that schema growth requires a coordinated
+ *  bump of `v` — which is exactly the right friction for a forensic
+ *  record.
+ *
+ *  Canonicalisation note: when the writer (ccsc-5pi.2) hashes an event
+ *  it strips `hash` and JCS-serializes the rest. The schema therefore
+ *  accepts `hash` as required — partial events without `hash` are a
+ *  writer-internal intermediate, not a valid on-disk record.
+ */
+export const JournalEvent = z
+  .object({
+    /** Schema version. Bumped on any shape change; verify-journal (ccsc-
+     *  5pi.9) refuses a chain that mixes versions so a v1 → v2 rollover
+     *  cannot silently desync. */
+    v: z.literal(1),
+
+    /** ISO-8601 UTC timestamp with millisecond precision, e.g.
+     *  `2026-04-19T12:34:56.789Z`. The writer sets this from `nowIso()`
+     *  at append time; callers must not pre-populate. `z.string().datetime()`
+     *  enforces the ISO form and mandates a trailing `Z` / offset. */
+    ts: z.string().datetime({ offset: true, precision: 3 }),
+
+    /** Monotonic sequence number. Starts at 1 on the first event after
+     *  boot and never resets within a chain. A gap between consecutive
+     *  events is a tamper signal during verification — see audit-
+     *  journal-architecture.md §61-73. */
+    seq: z.number().int().nonnegative(),
+
+    /** Discriminated tag identifying what happened. See `EventKind`
+     *  above for the enumerated set. */
+    kind: EventKind,
+
+    /** MCP tool name when the event involves a tool call. Absent for
+     *  session / pairing / system events. */
+    toolName: z.string().min(1).optional(),
+
+    /** Redacted tool-call arguments. Every secret-shaped value has been
+     *  replaced with `[REDACTED:<kind>]` before this field is hashed or
+     *  written. Nested structures are walked recursively by the redactor
+     *  (ccsc-5pi.4). */
+    input: z.record(z.string(), z.unknown()).optional(),
+
+    /** Outcome classifier for decision events. `n/a` is valid and
+     *  required for observational events; absence is valid too (same
+     *  semantic). */
+    outcome: Outcome.optional(),
+
+    /** Short, human-readable explanation. Redacted before hashing.
+     *  Carries no PII or secret material by contract — if you find a
+     *  counter-example, file a bead against the caller, not the schema. */
+    reason: z.string().optional(),
+
+    /** Identifier of the matched policy rule for `policy.*` events. */
+    ruleId: z.string().min(1).optional(),
+
+    /** Owning session when the event is session-scoped. Absent for
+     *  `system.*` and some `pairing.*` events that predate session
+     *  creation. */
+    sessionKey: SessionKeyShape.optional(),
+
+    /** Who triggered or owns the event. See `Actor` above. */
+    actor: Actor.optional(),
+
+    /** Dapper-style correlation id linking related events — a single
+     *  tool call's policy-require → pairing-issued → pairing-accepted →
+     *  policy-approved → gate-outbound-allow all share one
+     *  `correlationId`. Absent for events that have no cross-cutting
+     *  trace (boot, reload). */
+    correlationId: z.string().min(1).optional(),
+
+    /** SHA-256 hex of the preceding event. The very first event in a
+     *  chain uses `sha256(TRUSTED_ANCHOR)`; see audit-journal-
+     *  architecture.md §76-85 for the anchor contract. */
+    prevHash: Sha256Hex,
+
+    /** SHA-256 hex of `prevHash || canonicalJson(event sans hash)`.
+     *  Computed by the writer (ccsc-5pi.2) and verified bit-for-bit by
+     *  the verify-journal command (ccsc-5pi.9). */
+    hash: Sha256Hex,
+  })
+  .strict()
+
+/** Inferred TypeScript shape of `JournalEvent`. Prefer this over the
+ *  Zod type when writing application code — the Zod object is the
+ *  parser, the TS type is the data. */
+export type JournalEvent = z.infer<typeof JournalEvent>
+
+/** Narrower type for the writer's pre-hash intermediate form: all the
+ *  fields that go into the hash, without `hash` itself. The writer
+ *  computes `sha256(prevHash || jcs(PartialEvent))` and then attaches
+ *  `hash` to produce a full `JournalEvent`. Not exported as a Zod
+ *  schema — it is a writer-internal shape, not a valid on-disk record. */
+export type PartialJournalEvent = Omit<JournalEvent, 'hash'>

--- a/journal.ts
+++ b/journal.ts
@@ -125,11 +125,18 @@ const Sha256Hex = z
  *
  *  The `satisfies` assertion guarantees the shape stays in lock-step
  *  with the `SessionKey` type — a lib-side rename breaks the build
- *  here, forcing a schema bump. */
-const SessionKeyShape = z.object({
-  channel: z.string(),
-  thread: z.string(),
-}) satisfies z.ZodType<SessionKey>
+ *  here, forcing a schema bump.
+ *
+ *  `.strict()` for the same reason the top-level `JournalEvent` is
+ *  strict: two writers that disagree on what fields live inside
+ *  `sessionKey` would hash to different canonical forms and break the
+ *  chain. Reject unknown fields at parse time. */
+const SessionKeyShape = z
+  .object({
+    channel: z.string(),
+    thread: z.string(),
+  })
+  .strict() satisfies z.ZodType<SessionKey>
 
 // ---------------------------------------------------------------------------
 // JournalEvent — the on-disk record shape

--- a/server.test.ts
+++ b/server.test.ts
@@ -2775,3 +2775,179 @@ describe('createSessionSupervisor.quiesce', () => {
     await drain
   })
 })
+
+// ---------------------------------------------------------------------------
+// JournalEvent schema — 000-docs/audit-journal-architecture.md §19-59
+// ---------------------------------------------------------------------------
+
+describe('JournalEvent', () => {
+  // Any 64-char lowercase hex string is a valid sha256 for the schema.
+  // Using deterministic literals keeps the assertions readable.
+  const SHA_A = 'a'.repeat(64)
+  const SHA_B = 'b'.repeat(64)
+
+  function minimal(overrides: Record<string, unknown> = {}) {
+    return {
+      v: 1,
+      ts: '2026-04-19T12:34:56.789Z',
+      seq: 1,
+      kind: 'system.boot',
+      prevHash: SHA_A,
+      hash: SHA_B,
+      ...overrides,
+    }
+  }
+
+  test('accepts a minimal event with only required fields', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    const parsed = JournalEvent.parse(minimal())
+    expect(parsed.v).toBe(1)
+    expect(parsed.kind).toBe('system.boot')
+    expect(parsed.hash).toBe(SHA_B)
+  })
+
+  test('accepts a full event with every optional field populated', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    const full = {
+      ...minimal({ kind: 'policy.require' }),
+      toolName: 'upload_file',
+      input: { path: '/safe/upload.txt', size: 1024 },
+      outcome: 'require' as const,
+      reason: 'tool requires human approval under rule allow-uploads',
+      ruleId: 'allow-uploads',
+      sessionKey: { channel: 'C0123456789', thread: '1711000000.000100' },
+      actor: 'session_owner' as const,
+      correlationId: 'req-abc123',
+    }
+    const parsed = JournalEvent.parse(full)
+    expect(parsed.outcome).toBe('require')
+    expect(parsed.actor).toBe('session_owner')
+    expect(parsed.sessionKey).toEqual({
+      channel: 'C0123456789',
+      thread: '1711000000.000100',
+    })
+  })
+
+  test('rejects wrong schema version', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    expect(() => JournalEvent.parse(minimal({ v: 2 }))).toThrow()
+    expect(() => JournalEvent.parse(minimal({ v: '1' }))).toThrow()
+  })
+
+  test('rejects unknown event kind', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    expect(() =>
+      JournalEvent.parse(minimal({ kind: 'gate.inbound.maybe' })),
+    ).toThrow()
+    expect(() => JournalEvent.parse(minimal({ kind: '' }))).toThrow()
+  })
+
+  test('rejects malformed sha256 hex in prevHash or hash', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    // Too short
+    expect(() => JournalEvent.parse(minimal({ prevHash: 'abcd' }))).toThrow()
+    // Uppercase — canonical form is lowercase
+    expect(() =>
+      JournalEvent.parse(minimal({ hash: 'A'.repeat(64) })),
+    ).toThrow()
+    // Non-hex char
+    expect(() =>
+      JournalEvent.parse(minimal({ hash: 'g'.repeat(64) })),
+    ).toThrow()
+    // Off-by-one
+    expect(() =>
+      JournalEvent.parse(minimal({ prevHash: 'a'.repeat(63) })),
+    ).toThrow()
+  })
+
+  test('rejects non-ISO / non-UTC ts', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    // Missing ms precision
+    expect(() =>
+      JournalEvent.parse(minimal({ ts: '2026-04-19T12:34:56Z' })),
+    ).toThrow()
+    // No timezone
+    expect(() =>
+      JournalEvent.parse(minimal({ ts: '2026-04-19T12:34:56.789' })),
+    ).toThrow()
+    // Space instead of T
+    expect(() =>
+      JournalEvent.parse(minimal({ ts: '2026-04-19 12:34:56.789Z' })),
+    ).toThrow()
+  })
+
+  test('rejects negative or non-integer seq', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    expect(() => JournalEvent.parse(minimal({ seq: -1 }))).toThrow()
+    expect(() => JournalEvent.parse(minimal({ seq: 1.5 }))).toThrow()
+    expect(() => JournalEvent.parse(minimal({ seq: '1' }))).toThrow()
+    // Zero is allowed (nonnegative); the writer starts at 1 by convention
+    // but the schema itself is permissive here so boot-time bootstrapping
+    // has room to use 0 as a sentinel.
+    expect(() => JournalEvent.parse(minimal({ seq: 0 }))).not.toThrow()
+  })
+
+  test('strict: rejects unknown top-level fields to prevent hash-form drift', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    // An extra field that would be silently stripped in lax mode would
+    // get included in some serializers' output but not others, breaking
+    // the chain property. Must reject at parse time.
+    expect(() =>
+      JournalEvent.parse(minimal({ extraneous: 'oops' })),
+    ).toThrow()
+  })
+
+  test('outcome enum rejects unknown values', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    expect(() =>
+      JournalEvent.parse(minimal({ outcome: 'maybe' })),
+    ).toThrow()
+    // All five legitimate values pass
+    for (const o of ['allow', 'deny', 'require', 'drop', 'n/a']) {
+      expect(() =>
+        JournalEvent.parse(minimal({ outcome: o })),
+      ).not.toThrow()
+    }
+  })
+
+  test('actor enum rejects unknown values', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    expect(() =>
+      JournalEvent.parse(minimal({ actor: 'admin' })),
+    ).toThrow()
+    for (const a of [
+      'session_owner',
+      'claude_process',
+      'human_approver',
+      'peer_agent',
+      'system',
+    ]) {
+      expect(() =>
+        JournalEvent.parse(minimal({ actor: a })),
+      ).not.toThrow()
+    }
+  })
+
+  test('sessionKey: both channel and thread required when present', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    expect(() =>
+      JournalEvent.parse(minimal({ sessionKey: { channel: 'C01' } })),
+    ).toThrow()
+    expect(() =>
+      JournalEvent.parse(minimal({ sessionKey: { thread: 'T01' } })),
+    ).toThrow()
+    // Extra fields on sessionKey also rejected (strict nested shape)
+    // — Zod objects default to strip, but the critical invariant is at
+    // the top level; nested loose is acceptable for now because the
+    // writer only reads the two declared keys.
+  })
+
+  test('covers every EventKind value enumerated in the design doc', async () => {
+    const { JournalEvent, EventKind } = await import('./journal.ts')
+    const kinds = EventKind.options
+    expect(kinds).toHaveLength(19)
+    for (const k of kinds) {
+      expect(() => JournalEvent.parse(minimal({ kind: k }))).not.toThrow()
+    }
+  })
+})

--- a/server.test.ts
+++ b/server.test.ts
@@ -2936,10 +2936,20 @@ describe('JournalEvent', () => {
     expect(() =>
       JournalEvent.parse(minimal({ sessionKey: { thread: 'T01' } })),
     ).toThrow()
-    // Extra fields on sessionKey also rejected (strict nested shape)
-    // — Zod objects default to strip, but the critical invariant is at
-    // the top level; nested loose is acceptable for now because the
-    // writer only reads the two declared keys.
+  })
+
+  test('sessionKey: strict — rejects unknown nested fields to protect hash form', async () => {
+    const { JournalEvent } = await import('./journal.ts')
+    // Two writers that disagreed on sessionKey contents would hash to
+    // different canonical forms and break the chain. Strict rejection
+    // surfaces that mistake at parse time.
+    expect(() =>
+      JournalEvent.parse(
+        minimal({
+          sessionKey: { channel: 'C01', thread: 'T01', extra: 'oops' },
+        }),
+      ),
+    ).toThrow()
   })
 
   test('covers every EventKind value enumerated in the design doc', async () => {


### PR DESCRIPTION
## Summary

First bead under **Epic 30-A (ccsc-5pi)** — tamper-evident audit journal, shipping in v0.5.1. Introduces \`journal.ts\` with the Zod schema and inferred TypeScript type for audit log records, matching [\`000-docs/audit-journal-architecture.md\`](000-docs/audit-journal-architecture.md) §19-59.

### What's in the schema

- \`v: 1\` — literal version, chain refuses mixed versions (verifier behaviour lands in ccsc-5pi.9)
- \`ts\` — ISO-8601 UTC with ms precision, enforced via \`z.string().datetime({ offset: true, precision: 3 })\`
- \`seq\` — nonnegative integer, monotonic per chain
- \`kind\` — 19-value \`z.enum\` covering gate, policy, exfil, session, pairing, system events
- Optional per-event: \`toolName\`, \`input\` (post-redaction), \`outcome\`, \`reason\`, \`ruleId\`, \`sessionKey\`, \`actor\`, \`correlationId\`
- \`prevHash\` / \`hash\` — SHA-256 hex, regex-enforced: 64 lowercase hex chars
- **\`.strict()\` at the top level** — unknown fields reject at parse time so callers cannot silently drift the on-disk hash form from the verifier's expected form (§312-326 invariant 7)

### Also exported

- \`EventKind\` / \`Outcome\` / \`Actor\` Zod enums + inferred types
- \`PartialJournalEvent\` — writer-internal hash-input shape (\`Omit<JournalEvent, 'hash'>\`); kept close to the type so the writer and verifier share vocabulary

### Scope cut

Writer + redaction + canonical-JSON serializer + \`verify-journal\` CLI land in ccsc-5pi.2 / .4 / .7 / .9. No runtime wiring in this PR — pure types + validation.

Closes bead \`ccsc-5pi.1\`.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 231 pass / 0 fail / 492 expect() (up from 219)
- [x] 12 new tests: minimal + full events, version rejection, unknown kind, malformed SHA-256 (short / upper / non-hex / off-by-one), non-ISO ts variants, negative / non-integer seq, strict unknown-field rejection, outcome + actor enum coverage, sessionKey required fields, parameterized sweep across all 19 \`EventKind\` values.

Jeremy made me do it
-claude