### PR TITLE
feat(journal): SHA-256 hash-chained JournalWriter (ccsc-5pi.2, Epic 30-A)

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -36,6 +36,9 @@
  */
 
 import { z } from 'zod'
+import { createHash, randomBytes } from 'crypto'
+import { open as fsOpen, type FileHandle } from 'fs/promises'
+import { existsSync, readFileSync } from 'fs'
 import type { SessionKey } from './lib'
 
 // ---------------------------------------------------------------------------
@@ -242,3 +245,328 @@ export type JournalEvent = z.infer<typeof JournalEvent>
  *  `hash` to produce a full `JournalEvent`. Not exported as a Zod
  *  schema — it is a writer-internal shape, not a valid on-disk record. */
 export type PartialJournalEvent = Omit<JournalEvent, 'hash'>
+
+// ---------------------------------------------------------------------------
+// JournalWriter — SHA-256 hash-chained append-only writer (ccsc-5pi.2)
+// ---------------------------------------------------------------------------
+
+/** Everything a caller supplies for a new event. The writer fills in the
+ *  framing fields (`v`, `ts`, `seq`, `prevHash`, `hash`) so callers cannot
+ *  drift the hash-determining fields by accident.
+ *
+ *  Note the Omit excludes `v` even though it is a literal — the writer
+ *  always sets it to 1. When the schema version bumps, callers do not
+ *  need to update. */
+export type WriteInput = Omit<JournalEvent, 'v' | 'ts' | 'seq' | 'prevHash' | 'hash'>
+
+/** Construction options for `JournalWriter.open()`.
+ *
+ *  Defaults give you a production-shaped writer. Tests override `now` and
+ *  `initialPrevHash` to keep hash assertions deterministic.
+ */
+export interface WriterOptions {
+  /** Absolute path to the audit log file. Created with mode `0o600` if
+   *  it doesn't exist. */
+  path: string
+
+  /** Genesis `prevHash` for an empty file. Default is a fresh random
+   *  32-byte sha256, matching the "TRUSTED_ANCHOR" concept in
+   *  audit-journal-architecture.md §76-85. Callers that want the anchor
+   *  recorded in the first event's body pre-compute it and pass it here.
+   *  Ignored when the file is non-empty — existing chains dictate their
+   *  own lastHash. */
+  initialPrevHash?: string
+
+  /** Clock source for `ts`. Injected in tests so assertions can fix the
+   *  timestamp. Default: real wall clock. */
+  now?: () => Date
+}
+
+/** Module-level registry of open audit-log paths. Enforces the
+ *  "single JournalWriter per process" invariant (audit-journal-
+ *  architecture.md §148-151, invariant §312-326 #1). A second `open()`
+ *  on the same path while the first writer is still live rejects rather
+ *  than allowing two writers to interleave their hash chains silently. */
+const ACTIVE_PATHS = new Set<string>()
+
+/** Tamper-evident append-only writer. See audit-journal-architecture.md
+ *  §76-161 for the full contract. One writer per process per path.
+ *
+ *  Lifecycle:
+ *    1. `JournalWriter.open({ path })` — opens the file in append mode,
+ *       reads any existing content to recover `lastHash` + `seq`, and
+ *       registers the path.
+ *    2. `.writeEvent(input)` — serializes through an internal queue so
+ *       concurrent callers cannot interleave increments. Computes
+ *       `hash = sha256(lastHash || jcs(event sans hash))`, appends a
+ *       newline-delimited JSON line, and returns the full event.
+ *    3. `.close()` — flushes, closes the file descriptor, frees the
+ *       path registration.
+ *
+ *  Fail-loud posture: any write failure puts the writer into a broken
+ *  state and subsequent `writeEvent` calls reject. Recovery is an
+ *  operator concern — inspect and restart. Silent recovery would
+ *  violate the forensic-record invariant.
+ */
+export class JournalWriter {
+  private fh: FileHandle | null
+  private lastHash: string
+  private nextSeq: number
+  private readonly now: () => Date
+  private readonly path: string
+
+  /** Serialization queue. Every `writeEvent` chains onto this promise so
+   *  that increment → hash → append runs as a single critical section
+   *  per call, regardless of how many callers await concurrently. */
+  private queue: Promise<unknown> = Promise.resolve()
+
+  /** Non-null when the writer has encountered a fatal write error. All
+   *  subsequent `writeEvent` calls reject with this error. */
+  private broken: Error | null = null
+
+  private constructor(
+    fh: FileHandle,
+    lastHash: string,
+    nextSeq: number,
+    now: () => Date,
+    path: string,
+  ) {
+    this.fh = fh
+    this.lastHash = lastHash
+    this.nextSeq = nextSeq
+    this.now = now
+    this.path = path
+  }
+
+  /** Open (or create) an audit log at `opts.path` and return a ready-
+   *  to-write JournalWriter.
+   *
+   *  Recovers chain state from the existing file: reads the last
+   *  newline-delimited JSON line, parses it through the `JournalEvent`
+   *  schema, and uses its `hash` and `seq + 1` as the seeds for new
+   *  writes. If the file is empty or absent, seeds from
+   *  `opts.initialPrevHash` (or a fresh random sha256 if unset) and
+   *  seq 1.
+   *
+   *  Throws if:
+   *    - Another `JournalWriter` is already open on the same path in
+   *      this process (single-writer invariant).
+   *    - The existing file's last line is not valid `JournalEvent`
+   *      JSON — fail loudly rather than silently start a new chain
+   *      that the verifier would reject anyway.
+   */
+  static async open(opts: WriterOptions): Promise<JournalWriter> {
+    if (ACTIVE_PATHS.has(opts.path)) {
+      throw new Error(
+        `JournalWriter.open: path already has an active writer in this process: ${opts.path}`,
+      )
+    }
+
+    let lastHash: string
+    let nextSeq: number
+
+    if (existsSync(opts.path)) {
+      const content = readFileSync(opts.path, 'utf8')
+      const lines = content.split('\n').filter((line) => line.length > 0)
+      if (lines.length === 0) {
+        // File exists but is empty — treat as fresh chain. Not an error;
+        // happens when an operator pre-created the file with `touch`.
+        lastHash = opts.initialPrevHash ?? sha256Hex(randomBytes(32))
+        nextSeq = 1
+      } else {
+        const lastLine = lines[lines.length - 1]!
+        let parsed: JournalEvent
+        try {
+          parsed = JournalEvent.parse(JSON.parse(lastLine))
+        } catch (err) {
+          throw new Error(
+            `JournalWriter.open: last line of ${opts.path} is not a valid JournalEvent — refusing to start a new chain that would be unverifiable. Underlying error: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          )
+        }
+        lastHash = parsed.hash
+        nextSeq = parsed.seq + 1
+      }
+    } else {
+      lastHash = opts.initialPrevHash ?? sha256Hex(randomBytes(32))
+      nextSeq = 1
+    }
+
+    // Mode 0o600 on creation; 'a' flag sets O_APPEND|O_WRONLY|O_CREAT.
+    // POSIX guarantees O_APPEND writes land atomically at EOF even with
+    // concurrent writers — we still serialize via the queue for the
+    // hash chain, not for write safety.
+    const fh = await fsOpen(opts.path, 'a', 0o600)
+    ACTIVE_PATHS.add(opts.path)
+
+    return new JournalWriter(
+      fh,
+      lastHash,
+      nextSeq,
+      opts.now ?? ((): Date => new Date()),
+      opts.path,
+    )
+  }
+
+  /** Append a new event. Returns the fully-framed `JournalEvent` that
+   *  was persisted, including the writer-assigned `v`, `ts`, `seq`,
+   *  `prevHash`, and `hash`.
+   *
+   *  Concurrent calls are serialized: if caller A and caller B both
+   *  `writeEvent()` without awaiting, the promises resolve in call
+   *  order and each sees a contiguous seq/hash chain.
+   */
+  async writeEvent(input: WriteInput): Promise<JournalEvent> {
+    if (this.broken) {
+      return Promise.reject(
+        new Error(
+          `JournalWriter is broken after a prior write failure: ${this.broken.message}`,
+        ),
+      )
+    }
+    if (this.fh === null) {
+      return Promise.reject(new Error('JournalWriter.writeEvent: writer is closed'))
+    }
+    // Chain onto the existing queue so increments are serialized. Using
+    // .then (not await) captures the write call's position in line
+    // immediately; callers observe monotonic order regardless of
+    // microtask scheduling.
+    const p = this.queue.then(() => this._doWrite(input))
+    // Swallow rejections on the queue itself so one failed write does
+    // not poison the queue chain. The caller still sees the rejection
+    // from `p`. The writer's `broken` field guards future calls.
+    this.queue = p.then(
+      () => undefined,
+      () => undefined,
+    )
+    return p
+  }
+
+  private async _doWrite(input: WriteInput): Promise<JournalEvent> {
+    if (this.fh === null) {
+      throw new Error('JournalWriter._doWrite: writer closed mid-queue')
+    }
+    const partial: PartialJournalEvent = {
+      v: 1,
+      ts: this.now().toISOString(),
+      seq: this.nextSeq,
+      prevHash: this.lastHash,
+      ...input,
+    }
+    const hash = sha256Hex(this.lastHash + canonicalJson(partial))
+    const event: JournalEvent = { ...partial, hash }
+
+    // Validate through the schema at the boundary. Catches caller-
+    // supplied fields that violate the strict schema (unknown keys,
+    // malformed types) before they land on disk and desync the chain.
+    JournalEvent.parse(event)
+
+    const line = JSON.stringify(event) + '\n'
+    try {
+      await this.fh.write(line)
+    } catch (err) {
+      this.broken = err instanceof Error ? err : new Error(String(err))
+      throw this.broken
+    }
+
+    // Advance chain state only after the write succeeds. A crash mid-
+    // write leaves `lastHash` and `nextSeq` at the pre-write values,
+    // so a restart-then-write resumes at the same point rather than
+    // gapping the seq or duplicating the hash.
+    this.nextSeq += 1
+    this.lastHash = hash
+
+    return event
+  }
+
+  /** The current chain-head hash. Exposed so callers that need the
+   *  "latest known good" pointer (e.g. the tail-anchor publisher in
+   *  Epic 30-B) can read it without parsing the last line of disk. */
+  get headHash(): string {
+    return this.lastHash
+  }
+
+  /** The seq the next successful write will carry. Useful for tests
+   *  and for operator diagnostics. */
+  get nextSequenceNumber(): number {
+    return this.nextSeq
+  }
+
+  /** Flush and release the file descriptor. Idempotent: calling
+   *  `close()` on an already-closed writer is a no-op. After close,
+   *  `writeEvent()` rejects. */
+  async close(): Promise<void> {
+    if (this.fh === null) return
+    try {
+      await this.fh.close()
+    } finally {
+      this.fh = null
+      ACTIVE_PATHS.delete(this.path)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical JSON (RFC 8785 subset for integer-only event shapes)
+// ---------------------------------------------------------------------------
+
+/** Canonicalise `value` for hashing. Two independent encoders must
+ *  produce identical byte output so the verifier can recompute the
+ *  chain bit-for-bit.
+ *
+ *  RFC 8785 compliance notes:
+ *    - Strings: `JSON.stringify` matches the RFC 8785 escape rules for
+ *      all inputs that avoid non-BMP Unicode. Our event schema never
+ *      has strings chosen from outside the BMP (hashes are hex; ts is
+ *      ISO-8601; Slack IDs are ASCII; policy reason strings are
+ *      operator-authored ASCII).
+ *    - Numbers: the RFC mandates shortest IEEE-754 double form. Our
+ *      schema permits only integers (`seq`); other number forms throw.
+ *    - Objects: keys sorted by UTF-16 code-unit order (the RFC form),
+ *      which `Array.prototype.sort` delivers for the ASCII key names
+ *      the schema uses.
+ *    - Arrays: order-preserving.
+ *    - No whitespace.
+ *
+ *  Throws on `undefined`, functions, symbols, bigints — none are valid
+ *  `JournalEvent` content; the throw turns a schema-validation miss
+ *  into a loud failure at hash time.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      throw new Error(
+        `canonicalJson: only finite integer numbers supported (got ${String(value)})`,
+      )
+    }
+    return String(value)
+  }
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalJson).join(',') + ']'
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj).sort()
+    const pairs = keys.map(
+      (k) => JSON.stringify(k) + ':' + canonicalJson(obj[k]),
+    )
+    return '{' + pairs.join(',') + '}'
+  }
+  throw new Error(`canonicalJson: unsupported value type: ${typeof value}`)
+}
+
+// ---------------------------------------------------------------------------
+// sha256 helper
+// ---------------------------------------------------------------------------
+
+/** Compute SHA-256 over `input` and return 64-char lowercase hex. Used
+ *  by the writer for the hash chain and re-used by the verifier
+ *  (ccsc-5pi.9). Kept close to the type + writer so all hash producers
+ *  in this module share one implementation. */
+export function sha256Hex(input: string | Uint8Array): string {
+  return createHash('sha256').update(input).digest('hex')
+}

--- a/journal.ts
+++ b/journal.ts
@@ -366,6 +366,12 @@ export class JournalWriter {
     let nextSeq: number
 
     if (existsSync(opts.path)) {
+      // ccsc-otd: this reads the whole file into memory to recover the
+      // last line. Fine for a per-developer install whose journal is
+      // MB-scale; not fine at GB-scale. Follow-up replaces this with a
+      // reverse-chunked scan (64 KiB windows from EOF until the last
+      // newline). Rotation (Epic 30-B) bounds file size further; this
+      // fallback just stops being the bottleneck once files grow.
       const content = readFileSync(opts.path, 'utf8')
       const lines = content.split('\n').filter((line) => line.length > 0)
       if (lines.length === 0) {

--- a/server.test.ts
+++ b/server.test.ts
@@ -2961,3 +2961,307 @@ describe('JournalEvent', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// canonicalJson — RFC 8785 subset used by the hash chain
+// ---------------------------------------------------------------------------
+
+describe('canonicalJson', () => {
+  test('serializes primitives', async () => {
+    const { canonicalJson } = await import('./journal.ts')
+    expect(canonicalJson(null)).toBe('null')
+    expect(canonicalJson(true)).toBe('true')
+    expect(canonicalJson(false)).toBe('false')
+    expect(canonicalJson(0)).toBe('0')
+    expect(canonicalJson(42)).toBe('42')
+    expect(canonicalJson(-7)).toBe('-7')
+    expect(canonicalJson('hello')).toBe('"hello"')
+    expect(canonicalJson('with\nnewline')).toBe('"with\\nnewline"')
+  })
+
+  test('sorts object keys lexicographically', async () => {
+    const { canonicalJson } = await import('./journal.ts')
+    // Two objects with identical content but different key-insertion
+    // order must canonicalize to the same bytes — that is the whole
+    // point of canonicalization.
+    expect(canonicalJson({ b: 1, a: 2, c: 3 })).toBe('{"a":2,"b":1,"c":3}')
+    expect(canonicalJson({ c: 3, a: 2, b: 1 })).toBe('{"a":2,"b":1,"c":3}')
+  })
+
+  test('recurses into nested objects and arrays', async () => {
+    const { canonicalJson } = await import('./journal.ts')
+    const val = { outer: { z: 1, a: [3, 2, 1] }, alpha: null }
+    // Inner object keys sorted; array order preserved; outer keys sorted.
+    expect(canonicalJson(val)).toBe('{"alpha":null,"outer":{"a":[3,2,1],"z":1}}')
+  })
+
+  test('emits no whitespace', async () => {
+    const { canonicalJson } = await import('./journal.ts')
+    const out = canonicalJson({ a: 1, b: [1, 2, 3], c: { d: 'e' } })
+    expect(out).not.toMatch(/\s/)
+  })
+
+  test('rejects non-integer and non-finite numbers', async () => {
+    const { canonicalJson } = await import('./journal.ts')
+    expect(() => canonicalJson(1.5)).toThrow(/integer/)
+    expect(() => canonicalJson(Number.POSITIVE_INFINITY)).toThrow(/integer/)
+    expect(() => canonicalJson(Number.NaN)).toThrow(/integer/)
+  })
+
+  test('rejects unsupported value types', async () => {
+    const { canonicalJson } = await import('./journal.ts')
+    expect(() => canonicalJson(undefined)).toThrow()
+    expect(() => canonicalJson(() => 1)).toThrow()
+    expect(() => canonicalJson(Symbol('x'))).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sha256Hex
+// ---------------------------------------------------------------------------
+
+describe('sha256Hex', () => {
+  test('empty string has the known SHA-256 digest', async () => {
+    const { sha256Hex } = await import('./journal.ts')
+    expect(sha256Hex('')).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    )
+  })
+
+  test('produces 64 lowercase hex chars for any input', async () => {
+    const { sha256Hex } = await import('./journal.ts')
+    const h = sha256Hex('some content')
+    expect(h).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// JournalWriter — ccsc-5pi.2
+// ---------------------------------------------------------------------------
+
+describe('JournalWriter', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let logPath: string
+  const fixedNow = new Date('2026-04-19T12:34:56.789Z')
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'journal-writer-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    logPath = join(tmpRoot, 'audit.log')
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  const stableAnchor = 'a'.repeat(64)
+  const sysBoot = { kind: 'system.boot' as const }
+
+  test('first write on an empty file seeds from initialPrevHash', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      const ev = await w.writeEvent(sysBoot)
+      expect(ev.v).toBe(1)
+      expect(ev.ts).toBe('2026-04-19T12:34:56.789Z')
+      expect(ev.seq).toBe(1)
+      expect(ev.prevHash).toBe(stableAnchor)
+      expect(ev.kind).toBe('system.boot')
+      expect(ev.hash).toMatch(/^[0-9a-f]{64}$/)
+      expect(ev.hash).not.toBe(stableAnchor)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('file is mode 0o600 after open', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    try {
+      const st = statSync(logPath)
+      expect(st.mode & 0o777).toBe(0o600)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('hash chain: event N prevHash equals event N-1 hash', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      const a = await w.writeEvent(sysBoot)
+      const b = await w.writeEvent({ kind: 'session.activate' })
+      const c = await w.writeEvent({ kind: 'gate.inbound.drop' })
+      expect(b.prevHash).toBe(a.hash)
+      expect(c.prevHash).toBe(b.hash)
+      expect(a.seq).toBe(1)
+      expect(b.seq).toBe(2)
+      expect(c.seq).toBe(3)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('persisted bytes round-trip through JournalEvent.parse for each line', async () => {
+    const { JournalWriter, JournalEvent } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      await w.writeEvent(sysBoot)
+      await w.writeEvent({ kind: 'session.activate' })
+    } finally {
+      await w.close()
+    }
+    const content = readFileSync(logPath, 'utf8')
+    const lines = content.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(2)
+    for (const line of lines) {
+      const parsed = JournalEvent.parse(JSON.parse(line))
+      expect(parsed.v).toBe(1)
+    }
+  })
+
+  test('hash is reproducible: sha256(prevHash || canonicalJson(event sans hash))', async () => {
+    const { JournalWriter, canonicalJson, sha256Hex } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      const ev = await w.writeEvent(sysBoot)
+      const { hash: _h, ...rest } = ev
+      void _h
+      const recomputed = sha256Hex(stableAnchor + canonicalJson(rest))
+      expect(recomputed).toBe(ev.hash)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('reopening recovers lastHash and nextSeq from the existing file', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w1 = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    const first = await w1.writeEvent(sysBoot)
+    const second = await w1.writeEvent({ kind: 'session.activate' })
+    await w1.close()
+
+    // Reopen — no initialPrevHash provided; writer should read lastHash
+    // and next seq from disk.
+    const w2 = await JournalWriter.open({ path: logPath, now: () => fixedNow })
+    try {
+      expect(w2.headHash).toBe(second.hash)
+      expect(w2.nextSequenceNumber).toBe(3)
+      const third = await w2.writeEvent({ kind: 'session.quiesce' })
+      expect(third.prevHash).toBe(second.hash)
+      expect(third.seq).toBe(3)
+      // And the chain still ties back to the genesis anchor via `first`.
+      expect(first.prevHash).toBe(stableAnchor)
+    } finally {
+      await w2.close()
+    }
+  })
+
+  test('reopen rejects if the last line is not a valid JournalEvent', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    writeFileSync(logPath, 'this is not json\n', { mode: 0o600 })
+    await expect(
+      JournalWriter.open({ path: logPath, initialPrevHash: stableAnchor }),
+    ).rejects.toThrow(/valid JournalEvent/)
+  })
+
+  test('concurrent writeEvent calls serialize in call order', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      // Fire five writes without awaiting between them.
+      const promises = Array.from({ length: 5 }, (_, i) =>
+        w.writeEvent({ kind: 'session.activate', correlationId: `req-${i}` }),
+      )
+      const events = await Promise.all(promises)
+      // Monotonic seq in call order.
+      expect(events.map((e) => e.seq)).toEqual([1, 2, 3, 4, 5])
+      // Hash chain intact — each event's prevHash matches the previous
+      // event's hash, regardless of microtask scheduling.
+      for (let i = 1; i < events.length; i++) {
+        expect(events[i]!.prevHash).toBe(events[i - 1]!.hash)
+      }
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('single-writer invariant: second open on same path rejects', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w1 = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    try {
+      await expect(
+        JournalWriter.open({ path: logPath, initialPrevHash: stableAnchor }),
+      ).rejects.toThrow(/active writer/)
+    } finally {
+      await w1.close()
+    }
+    // After close, a fresh open must succeed — registry releases on close.
+    const w2 = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    await w2.close()
+  })
+
+  test('close is idempotent and subsequent writeEvent rejects', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    await w.close()
+    await w.close() // no throw
+    await expect(w.writeEvent(sysBoot)).rejects.toThrow(/closed/)
+  })
+
+  test('schema rejection at write time: invalid caller input does not land on disk', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    try {
+      // Unknown kind — schema rejects. No line should be appended, seq
+      // should not advance.
+      await expect(
+        w.writeEvent({ kind: 'not.a.real.kind' as never }),
+      ).rejects.toThrow()
+      expect(w.nextSequenceNumber).toBe(1)
+      const content = readFileSync(logPath, 'utf8')
+      expect(content).toBe('')
+    } finally {
+      await w.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Second bead under Epic 30-A. Tamper-evident append-only writer per [\`000-docs/audit-journal-architecture.md\`](000-docs/audit-journal-architecture.md) §76-161.

### Surface

- \`JournalWriter.open({ path, initialPrevHash?, now? })\` — async factory. Opens append-mode, mode \`0o600\` on create, recovers \`lastHash\` + \`nextSeq\` from the existing file's last line, registers path in module-level set to enforce single-writer-per-process. Refuses to start a new chain if the existing last line doesn't parse.
- \`writer.writeEvent(input)\` — fills in \`v\`/\`ts\`/\`seq\`/\`prevHash\`/\`hash\`, runs through \`JournalEvent.parse\` at the boundary, computes \`hash = sha256(lastHash || canonicalJson(partial))\`, appends one newline-delimited JSON line.
- Concurrent writes serialize through an internal promise queue: five concurrent \`writeEvent()\` calls yield contiguous seq 1..5 with each event's \`prevHash\` matching the previous hash.
- Fail-loud: write I/O error → broken state → subsequent writes reject. Schema failure is pre-flight — nothing lands on disk and \`nextSeq\` doesn't advance.
- \`close()\` idempotent; releases registry slot. Accessors: \`headHash\`, \`nextSequenceNumber\`.

### Helpers also landed

- \`canonicalJson()\` — RFC 8785 subset for integer-only event shapes. Sorted keys, recursive, zero whitespace. Throws on non-integer numbers / undefined / functions / symbols / bigints — a loud failure at hash time rather than silent hash divergence.
- \`sha256Hex()\` — shared so writer and verifier (ccsc-5pi.9) produce bit-identical output.
- \`WriteInput\` type — caller's payload shape.

### Scope cuts (sibling beads)

- Redaction → \`ccsc-5pi.4\` (caller responsible until then).
- Truncation → \`ccsc-5pi.6\`. CLI flag / env → \`ccsc-5pi.14\`. Verify command → \`ccsc-5pi.9\`. Rotation / reload → Epic 30-B.

Closes bead \`ccsc-5pi.2\`.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 251 pass / 0 fail / 546 expect() (up from 232)
- [x] 19 new tests: canonicalJson primitives / key-sort / nesting / whitespace / non-integer + unsupported-type rejection; sha256Hex known-value + shape; writer: first-write seeding, file mode 0o600, 3-event hash chain, on-disk round-trip, hash reproducibility using shared helpers, reopen recovery, reopen rejection on malformed last line, concurrent-write serialization, single-writer-per-path invariant, idempotent close + post-close rejection, schema rejection without on-disk side effects.

Jeremy made me do it
-claude