### PR TITLE
feat(journal): per-field truncation (ccsc-5pi.5, Epic 30-A)

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -570,11 +570,10 @@ export function canonicalJson(value: unknown): string {
   if (Array.isArray(value)) {
     return '[' + value.map(canonicalJson).join(',') + ']'
   }
-  if (typeof value === 'object') {
-    const obj = value as Record<string, unknown>
-    const keys = Object.keys(obj).sort()
+  if (isRecord(value)) {
+    const keys = Object.keys(value).sort()
     const pairs = keys.map(
-      (k) => JSON.stringify(k) + ':' + canonicalJson(obj[k]),
+      (k) => JSON.stringify(k) + ':' + canonicalJson(value[k]),
     )
     return '{' + pairs.join(',') + '}'
   }
@@ -591,6 +590,16 @@ export function canonicalJson(value: unknown): string {
  *  in this module share one implementation. */
 export function sha256Hex(input: string | Uint8Array): string {
   return createHash('sha256').update(input).digest('hex')
+}
+
+/** Narrow `value` to a plain object shape. Rejects arrays, null, and
+ *  primitives. Used by `canonicalJson`, `redact`, and `truncate` so
+ *  the `value as Record<string, unknown>` casts that previously
+ *  followed `typeof value === 'object' && value !== null` become
+ *  compiler-checked narrowings instead of trust-me-bro assertions.
+ *  Not exported — these helpers are the only callers. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 // ---------------------------------------------------------------------------
@@ -658,15 +667,14 @@ export function redact(value: unknown): unknown {
     }
     return changed ? out : value
   }
-  if (typeof value === 'object' && value !== null) {
+  if (isRecord(value)) {
     // Plain object fast-path. We do not try to detect class instances
     // here because the journal event shape is JSON — class instances
     // round-tripping through JSON.stringify would have lost their
     // prototype anyway.
-    const obj = value as Record<string, unknown>
     let changed = false
     const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(obj)) {
+    for (const [k, v] of Object.entries(value)) {
       const next = redact(v)
       if (next !== v) changed = true
       out[k] = next
@@ -765,9 +773,8 @@ export function truncate(
     }
     return changed ? out : value
   }
-  if (typeof value === 'object' && value !== null) {
-    const obj = value as Record<string, unknown>
-    const entries = Object.entries(obj)
+  if (isRecord(value)) {
+    const entries = Object.entries(value)
     let changed = false
     const out: Record<string, unknown> = {}
     for (const [k, v] of entries) {

--- a/journal.ts
+++ b/journal.ts
@@ -462,12 +462,19 @@ export class JournalWriter {
     // token into one of those is a caller bug, not a redactor gap.
     const redactedInput = redactEventFields(input)
 
+    // Truncate AFTER redaction so a half-truncated token never appears
+    // on disk (audit-journal-architecture.md §206). Hard-cap per field
+    // at TRUNCATION_LIMIT_DEFAULT; an over-limit string becomes a
+    // marker + gets a sibling `<field>.len` entry so forensics can see
+    // the original size without reading the raw payload.
+    const truncatedInput = truncateEventFields(redactedInput)
+
     const partial: PartialJournalEvent = {
       v: 1,
       ts: this.now().toISOString(),
       seq: this.nextSeq,
       prevHash: this.lastHash,
-      ...redactedInput,
+      ...truncatedInput,
     }
     const hash = sha256Hex(this.lastHash + canonicalJson(partial))
     const event: JournalEvent = { ...partial, hash }
@@ -693,6 +700,123 @@ export function redactEventFields(input: WriteInput): WriteInput {
   }
   if (hasInput) {
     out.input = redact(input.input) as Record<string, unknown>
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Truncation — bound journal record size (ccsc-5pi.5)
+// ---------------------------------------------------------------------------
+
+/** Per-field character cap for journal records. Strings longer than
+ *  this get replaced with the truncation marker form:
+ *
+ *    `<first TRUNCATION_LIMIT_DEFAULT chars>[... truncated N chars]`
+ *
+ *  2048 chars is the doc-specified default (audit-journal-architecture.md
+ *  §200-210). Large enough to capture structured JSON error bodies and
+ *  typical tool-call args; small enough to keep the journal bounded
+ *  even under a burst of oversized payloads. */
+export const TRUNCATION_LIMIT_DEFAULT = 2048
+
+/** Truncate a single string to `max` characters, returning it unchanged
+ *  if already short enough. The marker preserves the original length
+ *  inline so a reader can tell the payload was oversized without
+ *  needing the sibling-field bookkeeping. */
+function truncateString(s: string, max: number): string {
+  if (s.length <= max) return s
+  const omitted = s.length - max
+  return `${s.slice(0, max)}[... truncated ${omitted} chars]`
+}
+
+/** Deep-walk `value`, bounding every string to `max` characters. For
+ *  object keys whose value was truncated, a sibling `<key>.len` entry
+ *  is added at the same object level recording the original character
+ *  count. The sibling key pattern matches audit-journal-architecture.md
+ *  §208-210. Arrays are walked but do not get sibling length entries
+ *  (arrays don't have named keys — the truncation marker itself
+ *  carries the size signal in that case).
+ *
+ *  Pure: returns the same reference when nothing was truncated.
+ *
+ *  Edge cases:
+ *    - If a sibling `<key>.len` key already exists on the object, it
+ *      is overwritten. Collisions with real data are not expected —
+ *      callers don't put dotted keys in event payloads — and silent
+ *      overwrite is preferable to a throw in the hot path.
+ *    - Non-string primitives (numbers, booleans, null) pass through.
+ *    - Unsupported container types (Maps, Sets, class instances) pass
+ *      through by reference. Pre-flatten those at the caller. */
+export function truncate(
+  value: unknown,
+  max: number = TRUNCATION_LIMIT_DEFAULT,
+): unknown {
+  if (typeof value === 'string') {
+    const t = truncateString(value, max)
+    return t === value ? value : t
+  }
+  if (Array.isArray(value)) {
+    let changed = false
+    const out: unknown[] = new Array(value.length)
+    for (let i = 0; i < value.length; i++) {
+      const next = truncate(value[i], max)
+      if (next !== value[i]) changed = true
+      out[i] = next
+    }
+    return changed ? out : value
+  }
+  if (typeof value === 'object' && value !== null) {
+    const obj = value as Record<string, unknown>
+    const entries = Object.entries(obj)
+    let changed = false
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of entries) {
+      if (typeof v === 'string' && v.length > max) {
+        out[k] = truncateString(v, max)
+        out[`${k}.len`] = v.length
+        changed = true
+      } else {
+        const next = truncate(v, max)
+        if (next !== v) changed = true
+        out[k] = next
+      }
+    }
+    return changed ? out : value
+  }
+  return value
+}
+
+/** Writer-integration helper. Mirrors `redactEventFields`: truncates
+ *  only `input` and `reason`, leaves everything else untouched. Called
+ *  by the writer after redaction so the hash is computed over the
+ *  bounded form.
+ *
+ *  Why scope it? `reason` and `input` are the realistic oversized-
+ *  payload surfaces; other fields are short identifiers. Truncating
+ *  `toolName` or `ruleId` would be more confusing than helpful. A
+ *  pathological caller who stuffs 100 KiB into `correlationId` will
+ *  surface that loudly rather than being quietly truncated — which
+ *  matches the redaction policy on the same fields. */
+export function truncateEventFields(
+  input: WriteInput,
+  max: number = TRUNCATION_LIMIT_DEFAULT,
+): WriteInput {
+  const hasReason = typeof input.reason === 'string'
+  const hasInput = input.input !== undefined
+
+  if (!hasReason && !hasInput) return input
+
+  const out: WriteInput = { ...input }
+  if (hasReason) {
+    const original = input.reason as string
+    // `reason` is a top-level string field governed by the strict
+    // JournalEvent schema; we cannot add a sibling `reason.len` key
+    // there (the schema would reject it). For this field the marker
+    // itself carries the original-length signal inline.
+    out.reason = truncateString(original, max)
+  }
+  if (hasInput) {
+    out.input = truncate(input.input, max) as Record<string, unknown>
   }
   return out
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -3513,3 +3513,241 @@ describe('JournalWriter redaction integration', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// Truncation — ccsc-5pi.5
+// ---------------------------------------------------------------------------
+
+describe('truncate', () => {
+  test('returns short strings unchanged', async () => {
+    const { truncate } = await import('./journal.ts')
+    expect(truncate('hello', 100)).toBe('hello')
+  })
+
+  test('truncates long strings with an inline [... truncated N chars] marker', async () => {
+    const { truncate } = await import('./journal.ts')
+    const long = 'a'.repeat(3000)
+    const out = truncate(long, 100) as string
+    expect(out.startsWith('a'.repeat(100))).toBe(true)
+    expect(out.endsWith('[... truncated 2900 chars]')).toBe(true)
+    // The truncated output is itself bounded — the marker adds a
+    // fixed-size suffix so the record stays usefully small.
+    expect(out.length).toBeLessThan(200)
+  })
+
+  test('recurses into arrays and truncates oversize elements', async () => {
+    const { truncate } = await import('./journal.ts')
+    const arr = ['short', 'x'.repeat(100), 42]
+    const out = truncate(arr, 20) as unknown[]
+    expect(out[0]).toBe('short')
+    expect(out[1]).toMatch(/^x{20}\[\.\.\. truncated 80 chars\]$/)
+    expect(out[2]).toBe(42)
+  })
+
+  test('adds <key>.len sibling when an object field is truncated', async () => {
+    const { truncate } = await import('./journal.ts')
+    const obj = { body: 'x'.repeat(5000), note: 'short' }
+    const out = truncate(obj, 200) as Record<string, unknown>
+    expect(typeof out.body).toBe('string')
+    expect((out.body as string).endsWith('[... truncated 4800 chars]')).toBe(true)
+    expect(out['body.len']).toBe(5000)
+    // Untruncated siblings do not get a .len entry.
+    expect(out.note).toBe('short')
+    expect('note.len' in out).toBe(false)
+  })
+
+  test('recurses deep into nested objects', async () => {
+    const { truncate } = await import('./journal.ts')
+    const obj = {
+      envelope: {
+        headers: { 'content-type': 'text/plain' },
+        body: 'y'.repeat(300),
+      },
+    }
+    const out = truncate(obj, 100) as {
+      envelope: {
+        headers: Record<string, unknown>
+        body: string
+        'body.len': number
+      }
+    }
+    expect(out.envelope.body.endsWith('[... truncated 200 chars]')).toBe(true)
+    expect(out.envelope['body.len']).toBe(300)
+    expect(out.envelope.headers).toEqual({ 'content-type': 'text/plain' })
+  })
+
+  test('returns same reference when nothing was truncated (allocation optimization)', async () => {
+    const { truncate } = await import('./journal.ts')
+    const obj = { a: 'short', b: [1, 2, 'also short'] }
+    expect(truncate(obj, 100)).toBe(obj)
+  })
+
+  test('pure: does not mutate its argument', async () => {
+    const { truncate } = await import('./journal.ts')
+    const obj = { body: 'z'.repeat(5000) }
+    const snapshot = JSON.stringify(obj)
+    truncate(obj, 100)
+    expect(JSON.stringify(obj)).toBe(snapshot)
+  })
+
+  test('non-string primitives pass through', async () => {
+    const { truncate } = await import('./journal.ts')
+    expect(truncate(null, 10)).toBeNull()
+    expect(truncate(42, 10)).toBe(42)
+    expect(truncate(true, 10)).toBe(true)
+  })
+
+  test('default limit is 2048', async () => {
+    const { truncate, TRUNCATION_LIMIT_DEFAULT } = await import('./journal.ts')
+    expect(TRUNCATION_LIMIT_DEFAULT).toBe(2048)
+    // A string just under the default passes through unchanged; one
+    // just over gets truncated.
+    expect(truncate('a'.repeat(2048))).toBe('a'.repeat(2048))
+    const out = truncate('a'.repeat(2049)) as string
+    expect(out).toMatch(/\[\.\.\. truncated 1 chars\]$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// JournalWriter ↔ truncation integration
+// ---------------------------------------------------------------------------
+
+describe('JournalWriter truncation integration', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let logPath: string
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'journal-trunc-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    logPath = join(tmpRoot, 'audit.log')
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  const stableAnchor = 'a'.repeat(64)
+
+  test('truncates oversize input.* fields and adds .len sibling', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    try {
+      const big = 'x'.repeat(5000)
+      const ev = await w.writeEvent({
+        kind: 'policy.deny',
+        input: { body: big, note: 'ok' },
+      })
+      const input = ev.input as Record<string, unknown>
+      expect(typeof input.body).toBe('string')
+      expect((input.body as string).length).toBeLessThan(2100)
+      expect((input.body as string).endsWith('[... truncated 2952 chars]')).toBe(true)
+      expect(input['body.len']).toBe(5000)
+      expect(input.note).toBe('ok')
+      // On-disk form agrees — the writer wrote the bounded version.
+      const disk = readFileSync(logPath, 'utf8')
+      expect(disk).not.toContain(big)
+      expect(disk).toContain('[... truncated 2952 chars]')
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('truncates oversize reason inline (no sibling — top-level schema is strict)', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    try {
+      const bigReason = 'r'.repeat(3000)
+      const ev = await w.writeEvent({
+        kind: 'gate.inbound.drop',
+        reason: bigReason,
+      })
+      expect((ev.reason as string).endsWith('[... truncated 952 chars]')).toBe(
+        true,
+      )
+      // The top-level JournalEvent is .strict(); a `reason.len` sibling
+      // would be rejected. The inline marker carries the length
+      // signal instead.
+      expect('reason.len' in ev).toBe(false)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('redaction then truncation: a half-truncated token never lands', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    try {
+      // Construct a payload that starts with normal content, hits the
+      // truncation boundary, and then contains a token after the
+      // boundary. Without redact-first-then-truncate, the writer
+      // could cut a token mid-string and leave partial secret bytes
+      // on disk. Doc §206 calls this out explicitly.
+      const prefix = 'x'.repeat(2040)
+      const token = 'sk-ant' + '-' + 'a'.repeat(30)
+      const big = prefix + token // crosses the 2048 boundary mid-token
+      const ev = await w.writeEvent({
+        kind: 'policy.deny',
+        input: { body: big },
+      })
+      const bodyOut = (ev.input as { body: string }).body
+      // No partial `sk-` fragment should remain — the token was
+      // redacted BEFORE the truncate step so the whole thing is gone.
+      expect(bodyOut).not.toContain('sk-')
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('hash is computed over the truncated form (verifier can re-derive)', async () => {
+    const { JournalWriter, canonicalJson, sha256Hex } = await import(
+      './journal.ts'
+    )
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => new Date('2026-04-19T12:34:56.789Z'),
+    })
+    try {
+      const ev = await w.writeEvent({
+        kind: 'policy.deny',
+        input: { body: 'y'.repeat(5000) },
+      })
+      const { hash: _h, ...rest } = ev
+      void _h
+      expect(sha256Hex(stableAnchor + canonicalJson(rest))).toBe(ev.hash)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('does not truncate non-eligible fields (toolName, ruleId, correlationId)', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    try {
+      // Oversize values in non-eligible fields are passed through
+      // unchanged — matching the redaction policy. A caller who
+      // stuffs 5 KiB into correlationId gets the record written as-is
+      // (and the schema may reject it, which is the loud signal).
+      const longId = 'c'.repeat(3000)
+      const ev = await w.writeEvent({
+        kind: 'session.activate',
+        correlationId: longId,
+      })
+      expect(ev.correlationId).toBe(longId)
+    } finally {
+      await w.close()
+    }
+  })
+})

--- a/server.test.ts
+++ b/server.test.ts
@@ -3527,12 +3527,8 @@ describe('truncate', () => {
   test('truncates long strings with an inline [... truncated N chars] marker', async () => {
     const { truncate } = await import('./journal.ts')
     const long = 'a'.repeat(3000)
-    const out = truncate(long, 100) as string
-    expect(out.startsWith('a'.repeat(100))).toBe(true)
-    expect(out.endsWith('[... truncated 2900 chars]')).toBe(true)
-    // The truncated output is itself bounded — the marker adds a
-    // fixed-size suffix so the record stays usefully small.
-    expect(out.length).toBeLessThan(200)
+    const expected = 'a'.repeat(100) + '[... truncated 2900 chars]'
+    expect(truncate(long, 100)).toBe(expected)
   })
 
   test('recurses into arrays and truncates oversize elements', async () => {


### PR DESCRIPTION
## Summary

Fifth bead under Epic 30-A. Bounds journal record size per [\`000-docs/audit-journal-architecture.md\`](000-docs/audit-journal-architecture.md) §200-210.

### Surface

- \`truncate(value, max = 2048)\` — generic deep-walker. Strings over \`max\` become \`<first max chars>[... truncated N chars]\`. Objects whose values were truncated get a sibling \`<key>.len\` entry at the same level recording the original character count. Arrays walk through without sibling bookkeeping — the marker alone carries the size signal. Pure; returns same reference when nothing was truncated.
- \`truncateEventFields(input, max?)\` — writer-integration helper. Applies to \`input\` and \`reason\` only, mirroring the redaction scope. For \`reason\` (top-level strict schema), the inline marker carries the length; no sibling is emitted because the strict schema would reject an unknown key.
- \`TRUNCATION_LIMIT_DEFAULT = 2048\` — doc-specified default, exported.

### Writer integration

Order is **redact → truncate → hash → write** (doc §206). Consequence: a token straddling the truncation boundary is removed in the redact pass before truncate sees it, so a half-truncated secret never appears on disk. Verified by a dedicated test.

Hash chain still closes: verifier can recompute from the on-disk (redacted + truncated) bytes and match bit-for-bit. Also covered by a test.

### Design-doc vs bead drift

The bead description said sandwich-style (first 200 + … + last 200 when > 500 chars). The frozen doc specifies hard-cap at 2048 chars with an inline marker plus sibling \`.len\`. Following the doc per the design-is-authoritative rule. Sandwich variant can be filed as a future bead if the operator prefers that shape for forensic readability.

Closes bead \`ccsc-5pi.5\`.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` 283 pass / 0 fail / 609 expect() (up from 269)
- [x] 14 new tests covering: short-string pass-through, marker shape + correct omitted-count, array recursion, object sibling-key insertion, deep nesting, reference-equality optimization, mutation purity, non-string primitive pass-through, default-limit exposure. Plus 5 writer-integration tests: \`input.*\` truncation + sibling, \`reason\` inline truncation without sibling, redact-then-truncate half-token protection, hash over truncated form, non-eligible fields un-truncated.

Jeremy made me do it
-claude