### PR TITLE
feat(journal): --audit-log-file flag + SLACK_AUDIT_LOG env (ccsc-5pi.6, Epic 30-A)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -913,3 +913,66 @@ export function isDuplicateEvent(
   seen.set(key, now + ttlMs)
   return false
 }
+
+// ---------------------------------------------------------------------------
+// Audit journal path resolution (ccsc-5pi.6)
+// ---------------------------------------------------------------------------
+
+/** Result of resolving the audit-log destination from CLI + env. `path`
+ *  is null when no journal is configured — in that case server.ts
+ *  never opens a writer and callers get a no-op journal surface.
+ *  `source` tracks where the path came from for diagnostic logging so
+ *  an operator can tell whether a surprise path came from a stale env
+ *  var or an invocation flag. */
+export interface JournalPathResolution {
+  path: string | null
+  source: 'flag' | 'env' | null
+}
+
+/** Resolve the audit-log path from argv + env. Pure. CLI flag wins
+ *  over env var; env var wins over unset. Both an empty `--audit-log-file`
+ *  and an empty `SLACK_AUDIT_LOG` are treated as "not set" (a leading
+ *  `=` with no value is almost always a shell mistake, not an intent
+ *  to journal to the current directory's root).
+ *
+ *  Forms accepted:
+ *    - `--audit-log-file PATH`       (space-separated)
+ *    - `--audit-log-file=PATH`       (equals form)
+ *
+ *  The returned path is NOT resolved against the filesystem — that
+ *  happens when `JournalWriter.open()` runs during bootstrap. Keeping
+ *  this helper pure lets tests assert the resolution order without
+ *  touching disk.
+ */
+export function resolveJournalPath(
+  argv: ReadonlyArray<string>,
+  env: Readonly<Record<string, string | undefined>>,
+): JournalPathResolution {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg === '--audit-log-file') {
+      const next = argv[i + 1]
+      if (typeof next === 'string' && next.length > 0) {
+        return { path: next, source: 'flag' }
+      }
+      // `--audit-log-file` with no value or an empty value is a
+      // shell/launcher mistake. Fall through to env; don't silently
+      // enable journaling at an unexpected path.
+      continue
+    }
+    if (arg.startsWith('--audit-log-file=')) {
+      const val = arg.slice('--audit-log-file='.length)
+      if (val.length > 0) {
+        return { path: val, source: 'flag' }
+      }
+      continue
+    }
+  }
+
+  const envPath = env['SLACK_AUDIT_LOG']
+  if (typeof envPath === 'string' && envPath.length > 0) {
+    return { path: envPath, source: 'env' }
+  }
+
+  return { path: null, source: null }
+}

--- a/lib.ts
+++ b/lib.ts
@@ -952,12 +952,26 @@ export function resolveJournalPath(
     const arg = argv[i]!
     if (arg === '--audit-log-file') {
       const next = argv[i + 1]
-      if (typeof next === 'string' && next.length > 0) {
+      // Reject values that look like another flag (start with `-`).
+      // Scenarios:
+      //   - `--audit-log-file --debug` — operator forgot the path;
+      //     don't silently journal to a file literally named
+      //     `--debug`.
+      //   - `--audit-log-file -` — stdin convention; never a sensible
+      //     audit destination.
+      // A filename that genuinely starts with `-` is an
+      // operator-side edge case resolved by passing `./-name` through
+      // the shell or by using the `--audit-log-file=-name` equals
+      // form (which keeps the literal).
+      if (
+        typeof next === 'string' &&
+        next.length > 0 &&
+        !next.startsWith('-')
+      ) {
         return { path: next, source: 'flag' }
       }
-      // `--audit-log-file` with no value or an empty value is a
-      // shell/launcher mistake. Fall through to env; don't silently
-      // enable journaling at an unexpected path.
+      // Missing / empty / flag-shaped value: fall through. Don't
+      // silently enable journaling at an unexpected path.
       continue
     }
     if (arg.startsWith('--audit-log-file=')) {

--- a/server.test.ts
+++ b/server.test.ts
@@ -3823,4 +3823,32 @@ describe('resolveJournalPath', () => {
       ),
     ).toEqual({ path: '/first', source: 'flag' })
   })
+
+  test('space-separated flag rejects a flag-shaped value and falls through', () => {
+    // `--audit-log-file --debug` is an operator mistake — forgot the
+    // path. Do not journal to a file literally named `--debug`.
+    expect(
+      resolveJournalPath(
+        ['--audit-log-file', '--debug'],
+        { SLACK_AUDIT_LOG: '/from/env' },
+      ),
+    ).toEqual({ path: '/from/env', source: 'env' })
+
+    // Same for a bare `-`, which is the stdin convention and never a
+    // sensible audit destination.
+    expect(resolveJournalPath(['--audit-log-file', '-'], {})).toEqual({
+      path: null,
+      source: null,
+    })
+  })
+
+  test('equals form preserves literal values that start with a hyphen', () => {
+    // Escape hatch for the rare filename that genuinely starts with
+    // `-` — operator can use the equals form to bypass the
+    // flag-shape heuristic.
+    expect(resolveJournalPath(['--audit-log-file=-weird.log'], {})).toEqual({
+      path: '-weird.log',
+      source: 'flag',
+    })
+  })
 })

--- a/server.test.ts
+++ b/server.test.ts
@@ -13,6 +13,7 @@ import {
   pruneExpired,
   generateCode,
   isDuplicateEvent,
+  resolveJournalPath,
   sessionPath,
   saveSession,
   loadSession,
@@ -3745,5 +3746,81 @@ describe('JournalWriter truncation integration', () => {
     } finally {
       await w.close()
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveJournalPath — ccsc-5pi.6
+// ---------------------------------------------------------------------------
+
+describe('resolveJournalPath', () => {
+  test('returns null when neither flag nor env is set', () => {
+    expect(resolveJournalPath([], {})).toEqual({ path: null, source: null })
+  })
+
+  test('picks up SLACK_AUDIT_LOG env var when no flag present', () => {
+    expect(
+      resolveJournalPath([], { SLACK_AUDIT_LOG: '/var/log/slack-audit.log' }),
+    ).toEqual({ path: '/var/log/slack-audit.log', source: 'env' })
+  })
+
+  test('picks up --audit-log-file space-separated form', () => {
+    expect(
+      resolveJournalPath(['--audit-log-file', '/tmp/a.log'], {}),
+    ).toEqual({ path: '/tmp/a.log', source: 'flag' })
+  })
+
+  test('picks up --audit-log-file=PATH equals form', () => {
+    expect(
+      resolveJournalPath(['--audit-log-file=/tmp/b.log'], {}),
+    ).toEqual({ path: '/tmp/b.log', source: 'flag' })
+  })
+
+  test('flag wins over env var when both are set', () => {
+    expect(
+      resolveJournalPath(
+        ['--audit-log-file', '/from/flag'],
+        { SLACK_AUDIT_LOG: '/from/env' },
+      ),
+    ).toEqual({ path: '/from/flag', source: 'flag' })
+  })
+
+  test('empty flag value falls through to env (shell mistake protection)', () => {
+    // `--audit-log-file` with no successor or `--audit-log-file=` both
+    // represent a launcher bug; don't silently enable journaling at
+    // an unexpected path. Fall through to env.
+    expect(
+      resolveJournalPath(['--audit-log-file'], { SLACK_AUDIT_LOG: '/from/env' }),
+    ).toEqual({ path: '/from/env', source: 'env' })
+    expect(
+      resolveJournalPath(['--audit-log-file='], { SLACK_AUDIT_LOG: '/from/env' }),
+    ).toEqual({ path: '/from/env', source: 'env' })
+  })
+
+  test('empty env var is treated as unset', () => {
+    expect(resolveJournalPath([], { SLACK_AUDIT_LOG: '' })).toEqual({
+      path: null,
+      source: null,
+    })
+  })
+
+  test('flag works mid-argv with unrelated args around it', () => {
+    expect(
+      resolveJournalPath(
+        ['--some-other', 'value', '--audit-log-file', '/a.log', '--debug'],
+        {},
+      ),
+    ).toEqual({ path: '/a.log', source: 'flag' })
+  })
+
+  test('first --audit-log-file wins when multiple are provided', () => {
+    // Operator presumably intended the first; later ones are stale
+    // from a launcher script concatenation.
+    expect(
+      resolveJournalPath(
+        ['--audit-log-file', '/first', '--audit-log-file', '/second'],
+        {},
+      ),
+    ).toEqual({ path: '/first', source: 'flag' })
   })
 })

--- a/server.ts
+++ b/server.ts
@@ -40,11 +40,13 @@ import {
   sanitizeDisplayName,
   gate as libGate,
   isDuplicateEvent,
+  resolveJournalPath,
   EVENT_DEDUP_TTL_MS,
   PERMISSION_REPLY_RE,
   type Access,
   type GateResult,
 } from './lib.ts'
+import { JournalWriter } from './journal.ts'
 
 // Re-export constants so they stay in one place (lib.ts)
 export { MAX_PENDING, MAX_PAIRING_REPLIES, PAIRING_EXPIRY_MS } from './lib.ts'
@@ -1033,6 +1035,12 @@ socket.on('app_mention', async ({ event, ack }) => {
 
 let shuttingDown = false
 
+// Audit journal handle (ccsc-5pi.6). Null when --audit-log-file /
+// SLACK_AUDIT_LOG is unset — journal writes become no-ops in that
+// case. Opened in main() once the state dir is ready; closed in
+// shutdown() after a final `system.shutdown` event.
+let journal: JournalWriter | null = null
+
 async function shutdown(reason: string, code = 0): Promise<void> {
   if (shuttingDown) return
   shuttingDown = true
@@ -1054,6 +1062,22 @@ async function shutdown(reason: string, code = 0): Promise<void> {
     await mcp.close()
   } catch { /* ignore */ }
 
+  // Write a final `system.shutdown` event before closing the journal
+  // so the chain terminates cleanly with operator-visible intent.
+  // Failures here are non-fatal — better to exit with an imperfect
+  // journal than to hang shutdown.
+  if (journal !== null) {
+    try {
+      await journal.writeEvent({ kind: 'system.shutdown', reason })
+    } catch (err) {
+      console.error('[slack] journal.writeEvent(system.shutdown) failed:', err)
+    }
+    try {
+      await journal.close()
+    } catch { /* ignore */ }
+    journal = null
+  }
+
   clearTimeout(forceExit)
   process.exit(code)
 }
@@ -1066,6 +1090,42 @@ process.on('SIGTERM', () => void shutdown('SIGTERM'))
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
+  // Open audit journal if --audit-log-file or SLACK_AUDIT_LOG is set.
+  // Opt-in per ccsc-5pi.6: absent configuration disables journaling
+  // entirely and every hook that would write an event becomes a
+  // no-op. Present but unwritable fails loud at boot so the operator
+  // sees the misconfig immediately rather than on the first tool
+  // call. CLI flag wins over env var — see resolveJournalPath() in
+  // lib.ts for the resolution contract.
+  const auditResolution = resolveJournalPath(
+    process.argv.slice(2),
+    process.env,
+  )
+  if (auditResolution.path !== null) {
+    const absPath = resolve(auditResolution.path)
+    try {
+      journal = await JournalWriter.open({ path: absPath })
+      console.error(
+        `[slack] audit journal enabled at ${absPath} (source: ${auditResolution.source})`,
+      )
+      // First event after open is the boot marker — gives the
+      // verifier a clean starting landmark and records the
+      // operational start of this process.
+      await journal.writeEvent({
+        kind: 'system.boot',
+        actor: 'system',
+        reason: `started from ${auditResolution.source} configuration`,
+      })
+    } catch (err) {
+      console.error(
+        `[slack] audit journal open failed at ${absPath}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      )
+      process.exit(1)
+    }
+  }
+
   // Resolve bot identity (user ID, bot ID, app ID) for mention detection
   // and self-echo filtering across payload variants and multi-workspace setups
   try {


### PR DESCRIPTION
## Summary

Sixth bead under Epic 30-A. Opt-in wiring of the JournalWriter into \`server.ts\` bootstrap — nothing more, nothing less.

### lib.ts

\`resolveJournalPath(argv, env)\` — pure resolver. Returns \`{ path, source }\` where source is \`'flag' | 'env' | null\`. CLI flag wins over env var; empty values on either are treated as unset so a \`--audit-log-file\` with a dropped argument cannot silently enable journaling at an unexpected path.

- Forms: \`--audit-log-file PATH\`, \`--audit-log-file=PATH\`, env \`SLACK_AUDIT_LOG\`.
- First matching \`--audit-log-file\` wins.

### server.ts

- Module-level \`journal: JournalWriter | null\`, initialized to null so every pre-open site (gate, policy, session — wired in sibling beads) is already correct as a no-op.
- \`main()\` resolves the path, resolves it against cwd, opens the writer, writes a \`system.boot\` event with the source in \`reason\` so operators can tell config provenance.
- Open failure is fatal (exit 1), matching the \`.env\` / SENDABLE_ROOTS posture.
- \`shutdown()\` writes a final \`system.shutdown\` event carrying the trigger (SIGTERM / SIGINT / stdin EOF / transport close), then closes. Errors during shutdown write are logged but non-fatal.

### Scope cuts

Event-emission at gate / policy / session call sites happens in sibling beads. This PR lands the framing.

Closes bead \`ccsc-5pi.6\`.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` 292 pass / 0 fail / 617 expect() (up from 283)
- [x] 9 new tests on \`resolveJournalPath\` — empty, env-only, flag space form, flag equals form, flag wins, empty-flag-falls-through, empty-env-as-unset, flag-in-middle-of-argv, first-wins on duplicates.
- Bootstrap wiring is manual-integration-test territory; the writer it invokes has its own test surface (ccsc-5pi.2).

Jeremy made me do it
-claude