### PR TITLE
feat(journal): per-write fsync + O_APPEND verification (ccsc-5pi.7, Epic 30-A)

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -399,10 +399,18 @@ export class JournalWriter {
       nextSeq = 1
     }
 
-    // Mode 0o600 on creation; 'a' flag sets O_APPEND|O_WRONLY|O_CREAT.
-    // POSIX guarantees O_APPEND writes land atomically at EOF even with
-    // concurrent writers — we still serialize via the queue for the
-    // hash chain, not for write safety.
+    // Mode 0o600 on creation; 'a' flag sets O_APPEND|O_WRONLY|O_CREAT
+    // per audit-journal-architecture.md §155-160. POSIX guarantees
+    // O_APPEND writes land atomically at EOF even with concurrent
+    // writers — the kernel seeks to EOF and writes in one step. We
+    // still serialize via the queue for the hash chain, not for
+    // write-safety.
+    //
+    // FileHandle (fs.open) rather than fs.createWriteStream because
+    // we need explicit `fh.sync()` after every write for durability;
+    // streams buffer and make that awkward. One event = one write =
+    // one fsync for this bead (ccsc-5pi.7). A higher-volume operator
+    // can relax to batch fsync in a future bead.
     const fh = await fsOpen(opts.path, 'a', 0o600)
     ACTIVE_PATHS.add(opts.path)
 
@@ -487,6 +495,14 @@ export class JournalWriter {
     const line = JSON.stringify(event) + '\n'
     try {
       await this.fh.write(line)
+      // fsync after every successful write (ccsc-5pi.7). Durability
+      // discipline for an audit journal: a crash between `write()`
+      // buffering the line and the kernel flushing it would leave
+      // the chain apparently intact in memory but missing tail
+      // events on disk. For a per-developer journal the per-write
+      // fsync cost is imperceptible; for a higher-volume operator a
+      // sibling bead can relax this to batch fsync.
+      await this.fh.sync()
     } catch (err) {
       this.broken = err instanceof Error ? err : new Error(String(err))
       throw this.broken
@@ -515,7 +531,10 @@ export class JournalWriter {
     return this.nextSeq
   }
 
-  /** Flush and release the file descriptor. Idempotent: calling
+  /** Release the file descriptor. No separate flush is required:
+   *  every successful `writeEvent()` has already `fh.sync()`'d the
+   *  line to stable storage per ccsc-5pi.7, so there is no
+   *  buffered-but-unsynced tail to lose. Idempotent — calling
    *  `close()` on an already-closed writer is a no-op. After close,
    *  `writeEvent()` rejects. */
   async close(): Promise<void> {

--- a/server.test.ts
+++ b/server.test.ts
@@ -3246,6 +3246,66 @@ describe('JournalWriter', () => {
     await expect(w.writeEvent(sysBoot)).rejects.toThrow(/closed/)
   })
 
+  test('open() uses O_APPEND: pre-existing content is preserved, writer appends at EOF', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    // Write a pre-existing valid event to the file *before* opening
+    // the writer. An append-semantic open must keep this line intact
+    // and treat it as the chain state to extend from. A
+    // naive-truncating open would clobber it.
+    const existingEvent = {
+      v: 1,
+      ts: '2026-04-19T10:00:00.000Z',
+      seq: 41,
+      kind: 'system.boot',
+      prevHash: stableAnchor,
+      hash: 'f'.repeat(64),
+    }
+    writeFileSync(logPath, JSON.stringify(existingEvent) + '\n', {
+      mode: 0o600,
+    })
+    const before = readFileSync(logPath, 'utf8')
+
+    const w = await JournalWriter.open({ path: logPath, now: () => fixedNow })
+    try {
+      const next = await w.writeEvent({ kind: 'session.activate' })
+      // seq continues from the recovered lastSeq+1 — proves we read
+      // the existing line rather than truncating.
+      expect(next.seq).toBe(42)
+      expect(next.prevHash).toBe('f'.repeat(64))
+    } finally {
+      await w.close()
+    }
+    const after = readFileSync(logPath, 'utf8')
+    // The pre-existing line is still there, character-for-character.
+    expect(after.startsWith(before)).toBe(true)
+    // And the new line followed it.
+    expect(after.length).toBeGreaterThan(before.length)
+    expect(after.split('\n').filter(Boolean)).toHaveLength(2)
+  })
+
+  test('every writeEvent fsyncs before resolving (durability)', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      // Verified indirectly: since a fresh fd has no sync-on-close
+      // guarantee for data on Linux, the fact that reading the file
+      // *immediately* after writeEvent sees the line at all is
+      // evidence the line hit page cache; the fsync guarantees it
+      // also hit disk. We can't easily observe "on disk" from a unit
+      // test, but we can at least assert the line is readable and
+      // parseable right after the write resolves.
+      const ev = await w.writeEvent({ kind: 'system.boot' })
+      const content = readFileSync(logPath, 'utf8')
+      expect(content.trim()).toBe(JSON.stringify(ev))
+    } finally {
+      await w.close()
+    }
+  })
+
   test('schema rejection at write time: invalid caller input does not land on disk', async () => {
     const { JournalWriter } = await import('./journal.ts')
     const w = await JournalWriter.open({


### PR DESCRIPTION
## Summary

Seventh bead under Epic 30-A. Durability discipline per [\`000-docs/audit-journal-architecture.md\`](000-docs/audit-journal-architecture.md) §155-160.

### Changes

- \`JournalWriter._doWrite\` now calls \`this.fh.sync()\` after every successful \`this.fh.write()\`. A crash between \`write()\` buffering and the kernel flushing would otherwise leave the chain apparently intact in memory but missing tail events on disk — exactly what an audit log cannot tolerate.
- The \`'a'\` flag on \`fs.open\` already gives \`O_APPEND|O_WRONLY|O_CREAT\` per the doc. Confirmed in a new test: a pre-existing valid event is preserved and the writer appends at EOF, extending \`lastHash\`/\`nextSeq\` from the recovered state.
- \`close()\` documented explicitly as not needing a separate flush since every prior write already synced.

### Design choice

Stays on \`FileHandle\` (\`fs.open\`) rather than \`fs.createWriteStream\`. Streams buffer and make per-write fsync awkward. For one-event-per-write semantics, FileHandle is the cleaner fit. Rotation (Epic 30-B) can revisit if batching becomes desirable later.

For a per-developer audit journal the per-write fsync cost is imperceptible. A sibling bead can relax to batched fsync once a real-world operator hits a perf wall.

Closes bead \`ccsc-5pi.7\`.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` 296 pass / 0 fail / 626 expect() (up from 294)
- [x] 2 new tests: O_APPEND preservation (pre-existing valid event retained, writer continues chain at seq+1) and post-writeEvent readability (line visible in file immediately after call resolves). Existing reopen-recovery coverage continues to indirectly exercise the O_APPEND + sync contract.

Jeremy made me do it
-claude