### PR TITLE
feat(journal): verifyJournal() + tamper detection (ccsc-5pi.10 + 5pi.8, Epic 30-A)

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -37,7 +37,7 @@
 
 import { z } from 'zod'
 import { createHash, randomBytes } from 'crypto'
-import { open as fsOpen, type FileHandle } from 'fs/promises'
+import { open as fsOpen, readFile, type FileHandle } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
 import type { SessionKey } from './lib'
 
@@ -845,4 +845,190 @@ export function truncateEventFields(
     out.input = truncate(input.input, max) as Record<string, unknown>
   }
   return out
+}
+
+// ---------------------------------------------------------------------------
+// Verifier — Schneier-Kelsey chain integrity check (ccsc-5pi.10)
+// ---------------------------------------------------------------------------
+
+/** Shape of a verification failure. All fields aside from `reason`
+ *  are best-effort — a parse error on the first line, for example,
+ *  has no `seq` or `ts` to surface. The operator reads `reason` for
+ *  the human explanation and uses `lineNumber` to locate the
+ *  offending entry. */
+export interface VerifyBreak {
+  /** 1-indexed line number where the break was detected. The first
+   *  real JSON line is line 1. */
+  lineNumber: number
+  /** Parsed `seq` of the offending event if it passed schema
+   *  validation, else null. */
+  seq: number | null
+  /** Parsed `ts` of the offending event if it passed schema
+   *  validation, else null. */
+  ts: string | null
+  /** One-line human summary: `"hash mismatch"`, `"version skew"`,
+   *  `"seq gap"`, `"prevHash mismatch"`, `"parse error: ..."`, etc. */
+  reason: string
+  /** Expected hash (or prevHash) when applicable. */
+  expected?: string
+  /** Actual hash (or prevHash) when applicable. */
+  actual?: string
+}
+
+/** Result of a full-file verification pass. `eventsVerified` counts
+ *  events that matched expectations strictly before a break — useful
+ *  for a truncation-tolerance story in follow-up tooling. */
+export type VerifyResult =
+  | { ok: true; eventsVerified: number }
+  | { ok: false; eventsVerified: number; break: VerifyBreak }
+
+/** Verify a journal file end-to-end per audit-journal-architecture.md
+ *  §237-261. Reads the file line-by-line, schema-validates each
+ *  record, and recomputes `sha256(prevHash || canonicalJson(event
+ *  sans hash))` for every event. Any mismatch is reported as a
+ *  `VerifyBreak`.
+ *
+ *  Invariants checked (in line order):
+ *    - Schema v1 and the full strict `JournalEvent` shape.
+ *    - `hash` matches the recomputed value bit-for-bit.
+ *    - `prevHash` matches the previous accepted event's `hash`
+ *      (first event's `prevHash` is trusted as the genesis value —
+ *      that's the `TRUSTED_ANCHOR` contract from §76-85; validating
+ *      the anchor is a caller concern for now).
+ *    - `seq` is strictly monotonic by +1 with no gaps.
+ *
+ *  The function never modifies the file (read-only contract).
+ *  Returns on the first break; a second broken event after a fixed
+ *  first break is outside the verify-and-report-one-location
+ *  semantic the doc describes. */
+export async function verifyJournal(path: string): Promise<VerifyResult> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch (err) {
+    return {
+      ok: false,
+      eventsVerified: 0,
+      break: {
+        lineNumber: 0,
+        seq: null,
+        ts: null,
+        reason: `read failed: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    }
+  }
+
+  const lines = raw.split('\n')
+  let prevAcceptedHash: string | null = null
+  let prevAcceptedSeq: number | null = null
+  let eventsVerified = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    // Tolerate a trailing empty line (from the writer's final
+    // newline). Empty lines mid-file would indicate structural
+    // damage; those are flagged.
+    if (line.length === 0) {
+      if (i === lines.length - 1) continue
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber: i + 1,
+          seq: prevAcceptedSeq,
+          ts: null,
+          reason: 'empty line in middle of journal (structural damage)',
+        },
+      }
+    }
+
+    const lineNumber = i + 1
+
+    let event: JournalEvent
+    try {
+      event = JournalEvent.parse(JSON.parse(line))
+    } catch (err) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: null,
+          ts: null,
+          reason: `parse/schema error: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      }
+    }
+
+    if (event.v !== 1) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: event.seq,
+          ts: event.ts,
+          reason: `version skew: expected 1, got ${String(event.v)}`,
+        },
+      }
+    }
+
+    if (prevAcceptedHash !== null && event.prevHash !== prevAcceptedHash) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: event.seq,
+          ts: event.ts,
+          reason: 'prevHash mismatch — chain break',
+          expected: prevAcceptedHash,
+          actual: event.prevHash,
+        },
+      }
+    }
+
+    if (prevAcceptedSeq !== null && event.seq !== prevAcceptedSeq + 1) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: event.seq,
+          ts: event.ts,
+          reason: `seq gap — expected ${prevAcceptedSeq + 1}, got ${event.seq}`,
+          expected: String(prevAcceptedSeq + 1),
+          actual: String(event.seq),
+        },
+      }
+    }
+
+    // Recompute the hash. This is the primary tamper check: any edit
+    // to the event body (kind, input, reason, anything) will change
+    // the canonical serialization and so the computed hash.
+    const { hash: stored, ...rest } = event
+    const recomputed = sha256Hex(event.prevHash + canonicalJson(rest))
+    if (recomputed !== stored) {
+      return {
+        ok: false,
+        eventsVerified,
+        break: {
+          lineNumber,
+          seq: event.seq,
+          ts: event.ts,
+          reason: 'hash mismatch — event body or prevHash was tampered',
+          expected: recomputed,
+          actual: stored,
+        },
+      }
+    }
+
+    prevAcceptedHash = event.hash
+    prevAcceptedSeq = event.seq
+    eventsVerified += 1
+  }
+
+  return { ok: true, eventsVerified }
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -3912,3 +3912,227 @@ describe('resolveJournalPath', () => {
     })
   })
 })
+
+// ---------------------------------------------------------------------------
+// verifyJournal — ccsc-5pi.10 + happy-path E2E from ccsc-5pi.8
+// ---------------------------------------------------------------------------
+
+describe('verifyJournal', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let logPath: string
+  const fixedNow = new Date('2026-04-19T12:34:56.789Z')
+  const stableAnchor = 'a'.repeat(64)
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'journal-verify-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    logPath = join(tmpRoot, 'audit.log')
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  async function writeN(count: number, kind = 'session.activate' as const) {
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      for (let i = 0; i < count; i++) {
+        await w.writeEvent({
+          kind,
+          correlationId: `req-${i}`,
+        })
+      }
+    } finally {
+      await w.close()
+    }
+  }
+
+  test('ok over a clean 1000-event chain (end-to-end, ccsc-5pi.8)', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(1000)
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.eventsVerified).toBe(1000)
+    }
+  })
+
+  test('ok over a small clean chain (3 events)', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(3)
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.eventsVerified).toBe(3)
+  })
+
+  test('detects a body edit: flipping a byte in entry 42 breaks its hash', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(100)
+    const content = readFileSync(logPath, 'utf8')
+    const lines = content.split('\n').filter(Boolean)
+    const target = lines[41]! // 0-indexed → seq 42 since writer starts at seq 1
+    const tampered = target.replace('"req-41"', '"req-ZZ"')
+    lines[41] = tampered
+    writeFileSync(logPath, lines.join('\n') + '\n', { mode: 0o600 })
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.eventsVerified).toBe(41) // 41 events verified before break
+      expect(result.break.lineNumber).toBe(42)
+      expect(result.break.seq).toBe(42)
+      expect(result.break.reason).toMatch(/hash mismatch/)
+      expect(result.break.expected).not.toBe(result.break.actual)
+    }
+  })
+
+  test('detects a hash-field edit: flipping one char of stored hash breaks verification', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(10)
+    const content = readFileSync(logPath, 'utf8')
+    const lines = content.split('\n').filter(Boolean)
+    // Parse entry 5, swap one hex char in its `hash`, re-serialize.
+    const parsed = JSON.parse(lines[4]!) as Record<string, unknown>
+    const badHash = (parsed.hash as string).replace(/^./, (c) =>
+      c === 'a' ? 'b' : 'a',
+    )
+    parsed.hash = badHash
+    lines[4] = JSON.stringify(parsed)
+    writeFileSync(logPath, lines.join('\n') + '\n', { mode: 0o600 })
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.break.lineNumber).toBe(5)
+      expect(result.break.reason).toMatch(/hash mismatch/)
+    }
+  })
+
+  test('detects a prevHash edit: breaks the chain at the next event', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(5)
+    const content = readFileSync(logPath, 'utf8')
+    const lines = content.split('\n').filter(Boolean)
+    // Swap prevHash of entry 3. Entry 3 itself will fail hash-mismatch
+    // first (recomputed hash includes prevHash in the preimage), so
+    // the verifier reports a break at entry 3, not 4.
+    const parsed = JSON.parse(lines[2]!) as Record<string, unknown>
+    parsed.prevHash = 'd'.repeat(64)
+    lines[2] = JSON.stringify(parsed)
+    writeFileSync(logPath, lines.join('\n') + '\n', { mode: 0o600 })
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.break.lineNumber).toBe(3)
+      // Either hash mismatch (since hash depends on prevHash) or
+      // prevHash mismatch — both are tamper signals.
+      expect(result.break.reason).toMatch(/hash mismatch|prevHash mismatch/)
+    }
+  })
+
+  test('detects a reorder: swapping two lines breaks prevHash continuity', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(5)
+    const content = readFileSync(logPath, 'utf8')
+    const lines = content.split('\n').filter(Boolean)
+    // Swap lines 2 and 3.
+    ;[lines[1], lines[2]] = [lines[2]!, lines[1]!]
+    writeFileSync(logPath, lines.join('\n') + '\n', { mode: 0o600 })
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      // First out-of-order line is line 2 (the swapped-in seq=3).
+      expect(result.break.lineNumber).toBe(2)
+    }
+  })
+
+  test('detects seq gap: deleting a middle line breaks monotonicity', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(5)
+    const content = readFileSync(logPath, 'utf8')
+    const lines = content.split('\n').filter(Boolean)
+    // Remove seq=3 entry. The next line has seq=4 but prevHash
+    // points to seq=3's hash, which no longer chains from seq=2.
+    lines.splice(2, 1)
+    writeFileSync(logPath, lines.join('\n') + '\n', { mode: 0o600 })
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      // Break surfaces at line 3 (formerly the seq=4 entry) via
+      // prevHash mismatch — hash of the removed seq=3 is what seq=4
+      // expected.
+      expect(result.break.lineNumber).toBe(3)
+    }
+  })
+
+  test('parse error: invalid JSON on a middle line is reported with line number', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(3)
+    const content = readFileSync(logPath, 'utf8')
+    const lines = content.split('\n').filter(Boolean)
+    lines[1] = 'NOT VALID JSON AT ALL'
+    writeFileSync(logPath, lines.join('\n') + '\n', { mode: 0o600 })
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.break.lineNumber).toBe(2)
+      expect(result.break.reason).toMatch(/parse\/schema error/)
+      expect(result.break.seq).toBeNull()
+    }
+  })
+
+  test('schema rejection: unknown EventKind surfaces as parse/schema error', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(2)
+    const content = readFileSync(logPath, 'utf8')
+    const lines = content.split('\n').filter(Boolean)
+    const parsed = JSON.parse(lines[0]!) as Record<string, unknown>
+    parsed.kind = 'not.a.real.kind'
+    lines[0] = JSON.stringify(parsed)
+    writeFileSync(logPath, lines.join('\n') + '\n', { mode: 0o600 })
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.break.reason).toMatch(/parse\/schema error/)
+    }
+  })
+
+  test('tolerates the writer-produced trailing newline', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    await writeN(3)
+    // Writer emits `JSON + "\n"` per event, so the file ends with a
+    // trailing newline that split('\n') turns into an empty string.
+    // The verifier must not flag that tail as structural damage.
+    const content = readFileSync(logPath, 'utf8')
+    expect(content.endsWith('\n')).toBe(true)
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+  })
+
+  test('empty file is vacuously ok (0 events verified)', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    writeFileSync(logPath, '', { mode: 0o600 })
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.eventsVerified).toBe(0)
+  })
+
+  test('missing file: reports a read error, not a crash', async () => {
+    const { verifyJournal } = await import('./journal.ts')
+    const result = await verifyJournal(join(tmpRoot, 'does-not-exist.log'))
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.break.reason).toMatch(/read failed/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Ships the Schneier-Kelsey chain verifier that [\`000-docs/audit-journal-architecture.md\`](000-docs/audit-journal-architecture.md) §237-261 describes. Covers two beads:

- **ccsc-5pi.10** — tamper-detection tests via chain verification.
- **ccsc-5pi.8** — happy-path E2E verification over a synthetic 1000-event log. Folds in naturally because the same verifier is the primitive both beads want.

### Surface

- \`verifyJournal(path): Promise<VerifyResult>\` — read-only. Returns \`{ ok: true, eventsVerified }\` on intact chains or \`{ ok: false, eventsVerified, break }\` where \`break\` carries \`lineNumber\`, \`seq\`, \`ts\`, \`reason\`, and (when relevant) \`expected\` / \`actual\` hashes.
- \`VerifyResult\` / \`VerifyBreak\` types exported for callers.

### Invariants checked in line order

1. Strict \`JournalEvent\` schema including \`v: 1\`.
2. \`prevHash\` matches the previous accepted event's \`hash\` (first event's \`prevHash\` is trusted as the genesis anchor — validating the anchor is a caller concern for now).
3. \`seq\` is strictly monotonic by +1.
4. Recomputed \`sha256(prevHash || canonicalJson(event sans hash))\` matches the stored \`hash\` bit-for-bit — primary tamper check.

Return-on-first-break matches the doc's "tamper at seq=N" semantic (§244-252); reporting every downstream anomaly after a confirmed break is out of scope — downstream bytes are untrusted.

Closes beads \`ccsc-5pi.10\` and \`ccsc-5pi.8\`.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` 308 pass / 0 fail / 658 expect() (up from 296)
- [x] 12 new tests: 3-event happy path, 1000-event happy path (ccsc-5pi.8), body tamper at seq 42, hash-field tamper, prevHash tamper, line reorder, seq gap, parse error on malformed JSON, schema rejection on unknown EventKind, writer trailing-newline tolerance, empty-file vacuous OK, missing-file read-error surface.

Jeremy made me do it
-claude