### PR TITLE
feat(journal): record TRUSTED_ANCHOR in first system.boot event body (ccsc-lfx)

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -611,6 +611,22 @@ export function sha256Hex(input: string | Uint8Array): string {
   return createHash('sha256').update(input).digest('hex')
 }
 
+/** Generate a fresh per-chain `TRUSTED_ANCHOR` per audit-journal-
+ *  architecture.md §76-85. The returned string is a 64-char lowercase
+ *  hex digest of 32 random bytes — matches `Sha256Hex` so it can be
+ *  passed directly as `initialPrevHash` to `JournalWriter.open()`
+ *  AND recorded in the first `system.boot` event's body.
+ *
+ *  Callers must do both: pass it to the writer (so the first event's
+ *  `prevHash` pins it) and include it in the event body (so a reader
+ *  can recover the anchor from the file alone). The chain then
+ *  commits to the anchor in two places, meaning an attacker who
+ *  edits the anchor in either location breaks the first event's hash
+ *  verification. */
+export function createBootAnchor(): string {
+  return sha256Hex(randomBytes(32))
+}
+
 /** Narrow `value` to a plain object shape. Rejects arrays, null, and
  *  primitives. Used by `canonicalJson`, `redact`, and `truncate` so
  *  the `value as Record<string, unknown>` casts that previously

--- a/server.test.ts
+++ b/server.test.ts
@@ -4331,3 +4331,157 @@ describe('verifyJournal', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// TRUSTED_ANCHOR recorded in the first system.boot event body (ccsc-lfx)
+// ---------------------------------------------------------------------------
+//
+// Doc §76-85: the per-chain random anchor is pinned as the first
+// event's prevHash AND recorded in that event's body so a verifier
+// can recover it from the file alone.
+
+describe('createBootAnchor', () => {
+  test('returns a 64-char lowercase hex string', async () => {
+    const { createBootAnchor } = await import('./journal.ts')
+    const a = createBootAnchor()
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  test('two successive calls yield different anchors', async () => {
+    const { createBootAnchor } = await import('./journal.ts')
+    const a = createBootAnchor()
+    const b = createBootAnchor()
+    expect(a).not.toBe(b)
+  })
+
+  test('anchor passes the JournalEvent.prevHash Sha256Hex shape', async () => {
+    const { createBootAnchor, JournalEvent } = await import('./journal.ts')
+    const anchor = createBootAnchor()
+    // Synthesize a plausible first-event object and run it through the
+    // strict schema to confirm the anchor is an acceptable prevHash.
+    const event = {
+      v: 1,
+      ts: '2026-04-19T12:00:00.000Z',
+      seq: 1,
+      kind: 'system.boot',
+      actor: 'system',
+      prevHash: anchor,
+      hash: '0'.repeat(64),
+    }
+    expect(() => JournalEvent.parse(event)).not.toThrow()
+  })
+})
+
+describe('boot-event anchor pinning (ccsc-lfx integration)', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let logPath: string
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'journal-anchor-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    logPath = join(tmpRoot, 'audit.log')
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  test('fresh chain: anchor used as prevHash AND appears in body', async () => {
+    const { JournalWriter, createBootAnchor } = await import('./journal.ts')
+    const trustedAnchor = createBootAnchor()
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: trustedAnchor,
+    })
+    try {
+      const ev = await w.writeEvent({
+        kind: 'system.boot',
+        actor: 'system',
+        reason: 'fresh-chain bootstrap',
+        input: { trustedAnchor },
+      })
+      // prevHash pins the anchor.
+      expect(ev.prevHash).toBe(trustedAnchor)
+      // Body records the anchor so a verifier can recover it.
+      expect(ev.input).toEqual({ trustedAnchor })
+    } finally {
+      await w.close()
+    }
+
+    // Re-read the line from disk — both pin and record must survive
+    // serialization.
+    const disk = readFileSync(logPath, 'utf8')
+    const parsed = JSON.parse(disk.trim())
+    expect(parsed.prevHash).toBe(trustedAnchor)
+    expect(parsed.input.trustedAnchor).toBe(trustedAnchor)
+  })
+
+  test('verifyJournal accepts a chain whose first event records its anchor', async () => {
+    const { JournalWriter, createBootAnchor, verifyJournal } = await import(
+      './journal.ts'
+    )
+    const trustedAnchor = createBootAnchor()
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: trustedAnchor,
+    })
+    try {
+      await w.writeEvent({
+        kind: 'system.boot',
+        actor: 'system',
+        reason: 'fresh-chain bootstrap',
+        input: { trustedAnchor },
+      })
+      await w.writeEvent({
+        kind: 'gate.inbound.deliver',
+        actor: 'system',
+        outcome: 'allow',
+        reason: 'first real event',
+      })
+    } finally {
+      await w.close()
+    }
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.eventsVerified).toBe(2)
+  })
+
+  test('tampering with the anchor-in-body breaks first-event hash', async () => {
+    const { JournalWriter, createBootAnchor, verifyJournal } = await import(
+      './journal.ts'
+    )
+    const trustedAnchor = createBootAnchor()
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: trustedAnchor,
+    })
+    try {
+      await w.writeEvent({
+        kind: 'system.boot',
+        actor: 'system',
+        input: { trustedAnchor },
+      })
+    } finally {
+      await w.close()
+    }
+
+    // Edit the trustedAnchor value inside input without touching
+    // prevHash or hash. The event's hash was computed over the
+    // original body, so the verifier's recomputation must mismatch.
+    const raw = readFileSync(logPath, 'utf8')
+    const tampered = raw.replace(
+      `"trustedAnchor":"${trustedAnchor}"`,
+      `"trustedAnchor":"${'0'.repeat(64)}"`,
+    )
+    expect(tampered).not.toBe(raw)
+    writeFileSync(logPath, tampered, 'utf8')
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.break.seq).toBe(1)
+      expect(result.break.reason).toMatch(/hash mismatch/)
+    }
+  })
+})

--- a/server.ts
+++ b/server.ts
@@ -25,6 +25,7 @@ import {
   chmodSync,
   existsSync,
   renameSync,
+  statSync,
 } from 'fs'
 import {
   defaultAccess,
@@ -46,7 +47,7 @@ import {
   type Access,
   type GateResult,
 } from './lib.ts'
-import { JournalWriter } from './journal.ts'
+import { JournalWriter, createBootAnchor } from './journal.ts'
 
 // Re-export constants so they stay in one place (lib.ts)
 export { MAX_PENDING, MAX_PAIRING_REPLIES, PAIRING_EXPIRY_MS } from './lib.ts'
@@ -1104,17 +1105,45 @@ async function main(): Promise<void> {
   if (auditResolution.path !== null) {
     const absPath = resolve(auditResolution.path)
     try {
-      journal = await JournalWriter.open({ path: absPath })
+      // TRUSTED_ANCHOR per audit-journal-architecture.md §76-85: on a
+      // fresh chain, generate a per-chain random value, pin it as the
+      // first event's prevHash AND record it in that event's body.
+      // Recording it in the body lets a verifier recover the anchor
+      // from the file alone; pinning it as prevHash makes any
+      // post-hoc edit to the recorded value break the first event's
+      // hash verification. On an existing chain the anchor is already
+      // frozen in line 1 — we don't know it, don't need to, and must
+      // not overwrite it. `initialPrevHash` is ignored by the writer
+      // when the file is non-empty, so passing the anchor is only
+      // meaningful on a fresh open; the body field is likewise
+      // skipped on an existing chain (the boot event we're about to
+      // write is just a `system.reload`-flavored restart marker).
+      // Empty-but-touch'd files are treated as fresh by the writer
+      // (it seeds from `initialPrevHash` when the file has zero
+      // newline-delimited events), so match that rule here.
+      const isFreshChain =
+        !existsSync(absPath) || statSync(absPath).size === 0
+      const trustedAnchor = isFreshChain ? createBootAnchor() : null
+      journal = await JournalWriter.open({
+        path: absPath,
+        ...(trustedAnchor !== null ? { initialPrevHash: trustedAnchor } : {}),
+      })
       console.error(
         `[slack] audit journal enabled at ${absPath} (source: ${auditResolution.source})`,
       )
       // First event after open is the boot marker — gives the
       // verifier a clean starting landmark and records the
-      // operational start of this process.
+      // operational start of this process. On a fresh chain it
+      // also carries the `trustedAnchor` payload; on a resumed
+      // chain the body is kept minimal (the anchor lives in line 1
+      // of the existing file).
       await journal.writeEvent({
         kind: 'system.boot',
         actor: 'system',
         reason: `started from ${auditResolution.source} configuration`,
+        ...(trustedAnchor !== null
+          ? { input: { trustedAnchor } }
+          : {}),
       })
     } catch (err) {
       console.error(


### PR DESCRIPTION
## Summary

Doc §76-85 of \`000-docs/audit-journal-architecture.md\` requires the per-chain random anchor to live in two places: pinned as the first event's \`prevHash\` AND recorded in that event's body so a verifier reading the file alone can recover it. The writer was already generating a random anchor for \`prevHash\` but the server never wrote it into the boot event body — this PR closes that doc-compliance gap.

Gap surfaced during Epic 30-A rollup after merging PR #76 (ccsc-5pi.11). Filed as ccsc-lfx so Epic 30-A (ccsc-5pi) could close cleanly rather than sit on a known deviation from the frozen design.

## Changes

- \`journal.ts\`: export \`createBootAnchor()\` returning a 64-char lowercase hex string matching the \`Sha256Hex\` schema.
- \`server.ts\`: on a fresh chain (file absent OR zero bytes), generate an anchor, pass it as \`initialPrevHash\`, AND include it in the boot event's \`input.trustedAnchor\`. On a resumed chain, skip both — the anchor lives in line 1 of the existing file.
- \`server.test.ts\`: 6 new tests covering anchor shape + uniqueness + schema acceptance, fresh-chain pin-and-record round-trip, verifyJournal acceptance, and tamper-detection for edits to the anchor-in-body field.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 333 pass / 0 fail (+6 new tests)

Closes bead ccsc-lfx (30-A.17). After this merges, all 12 Epic 30-A leaf beads land.

Jeremy made me do it
-claude