### PR TITLE
feat(supervisor): SessionSupervisor.deactivate + handle state transitions (ccsc-xa3.4)

### DIFF
--- a/server.test.ts
+++ b/server.test.ts
@@ -2586,9 +2586,8 @@ describe('createSessionSupervisor.activate', () => {
     expect(handle.state).toBe('active')
   })
 
-  test('deactivate/shutdown are staged stubs that reject with bead pointers', async () => {
+  test('shutdown is a staged stub that rejects with a bead pointer', async () => {
     const sup = makeSupervisor()
-    await expect(sup.deactivate(key)).rejects.toThrow(/xa3\.14/)
     await expect(sup.shutdown()).rejects.toThrow(/xa3\.14/)
   })
 
@@ -2774,6 +2773,134 @@ describe('createSessionSupervisor.quiesce', () => {
 
     handle.endWork('abort-me')
     await drain
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SessionSupervisor.deactivate (ccsc-xa3.4)
+// ---------------------------------------------------------------------------
+
+describe('createSessionSupervisor.deactivate', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let logged: Array<{ event: string; fields: Record<string, unknown> }>
+
+  const key = { channel: 'C_DA', thread: 'T1.0' }
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'supervisor-deactivate-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    logged = []
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  function makeSupervisor() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createSessionSupervisor } = require('./supervisor.ts') as typeof import('./supervisor.ts')
+    return createSessionSupervisor({
+      stateRoot: tmpRoot,
+      log: (event, fields) => {
+        logged.push({ event, fields })
+      },
+      clock: () => 1_700_000_000_000,
+    })
+  }
+
+  test('deactivate on an unknown key is a silent no-op and emits no log', async () => {
+    const sup = makeSupervisor()
+    await expect(sup.deactivate(key)).resolves.toBeUndefined()
+    expect(logged.filter((l) => l.event === 'session.deactivate')).toHaveLength(0)
+  })
+
+  test('deactivate on an active (not quiesced) key rejects with a programmer-error message', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(key, 'U_OWNER')
+    expect(handle.state).toBe('active')
+
+    await expect(sup.deactivate(key)).rejects.toThrow(
+      /must be quiesced first/,
+    )
+    // State must not be mutated by the rejected call.
+    expect(handle.state).toBe('active')
+    // Live map must still contain the handle.
+    await expect(sup.activate(key)).resolves.toBe(handle)
+  })
+
+  test('deactivate after quiesce transitions to deactivating, removes from live map, emits log', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(key, 'U_OWNER')
+    await sup.quiesce(key)
+    expect(handle.state).toBe('quiescing')
+
+    await sup.deactivate(key)
+
+    expect(handle.state).toBe('deactivating')
+    const deactivateLogs = logged.filter((l) => l.event === 'session.deactivate')
+    expect(deactivateLogs).toHaveLength(1)
+    expect(deactivateLogs[0]!.fields).toEqual({
+      channel: key.channel,
+      thread: key.thread,
+    })
+  })
+
+  test('post-deactivate activate() re-reads from disk and returns a fresh handle', async () => {
+    const sup = makeSupervisor()
+    const first = await sup.activate(key, 'U_OWNER')
+    await sup.quiesce(key)
+    await sup.deactivate(key)
+
+    // A new activate() must NOT return the deactivated handle — it
+    // must reload from disk and produce a new live entry.
+    const second = await sup.activate(key)
+    expect(second).not.toBe(first)
+    expect(second.state).toBe('active')
+    expect(second.session.ownerId).toBe('U_OWNER')
+  })
+
+  test('deactivate persists the session file (atomic writer) before releasing', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(key, 'U_OWNER')
+    await sup.quiesce(key)
+    await sup.deactivate(key)
+
+    // Reload directly from disk and verify the persisted body matches
+    // the handle snapshot at deactivation time.
+    const { sessionPath, loadSession } = await import('./lib.ts')
+    const path = sessionPath(tmpRoot, key)
+    const fromDisk = await loadSession(tmpRoot, path)
+    expect(fromDisk.ownerId).toBe('U_OWNER')
+    expect(fromDisk.key).toEqual(key)
+    expect(fromDisk.createdAt).toBe(handle.session.createdAt)
+  })
+
+  test('deactivate is idempotent-ish: second call on a released key is a no-op', async () => {
+    const sup = makeSupervisor()
+    await sup.activate(key, 'U_OWNER')
+    await sup.quiesce(key)
+    await sup.deactivate(key)
+
+    // Second deactivate: handle is no longer in the live map, so the
+    // call resolves without error (Nonexistent-key no-op branch).
+    await expect(sup.deactivate(key)).resolves.toBeUndefined()
+    // No duplicate log line.
+    expect(logged.filter((l) => l.event === 'session.deactivate')).toHaveLength(1)
+  })
+
+  test('deactivate rejects on quarantined handles — human action required', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(key, 'U_OWNER')
+    await sup.quiesce(key)
+
+    // Force quarantine via the package-private transition — simulates a
+    // failure path that ccsc-xa3.8 (reaper) will produce organically.
+    // Cast through unknown to reach the internal method without
+    // widening the public SessionHandle interface for tests.
+    const h = handle as unknown as { markQuarantined(): void }
+    h.markQuarantined()
+
+    await expect(sup.deactivate(key)).rejects.toThrow(/quarantined/)
   })
 })
 

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -402,13 +402,75 @@ export function createSessionSupervisor(
       return handle.beginQuiesce()
     },
 
-    deactivate(_key: SessionKey): Promise<void> {
-      // Under ccsc-xa3.14 (deactivate + reaper sub-epic).
-      return Promise.reject(
-        new Error(
-          'SessionSupervisor.deactivate: not yet implemented (ccsc-xa3.14)',
-        ),
-      )
+    async deactivate(key: SessionKey): Promise<void> {
+      const id = keyId(key)
+      const handle = live.get(id)
+      if (handle === undefined) {
+        // No live handle — nothing to release. Matches quiesce()'s
+        // Nonexistent-key no-op per session-state-machine.md §124.
+        // Do not log an empty-case line; a deactivate on an already-
+        // dropped key is a recovery idempotency guarantee, not an
+        // event worth correlating.
+        return
+      }
+
+      // Quarantined handles are out of scope per the interface contract
+      // (§197-198): only a human clears the quarantine flag. Fail loudly
+      // rather than silently release a handle that the supervisor has
+      // marked as needing SO attention.
+      if (handle.state === 'quarantined') {
+        throw new Error(
+          `deactivate: handle for ${JSON.stringify(key)} is quarantined; human action required`,
+        )
+      }
+
+      // Deactivation is only legal after a completed quiesce. Refusing
+      // the active path is how the supervisor enforces the "work has
+      // drained before release" invariant — session-state-machine.md
+      // §210 invariant 2. An active-state deactivate would race with
+      // in-flight update()/tool calls and violate the at-most-one-
+      // writer rule.
+      if (handle.state !== 'quiescing') {
+        throw new Error(
+          `deactivate: handle for ${JSON.stringify(key)} is in state '${handle.state}'; must be quiesced first`,
+        )
+      }
+
+      handle.markDeactivating()
+
+      // Defensive final persist. `saveSession` is atomic (tmp + rename
+      // under `wx`). In the current supervisor shape `session` never
+      // drifts from disk between update() calls (update() is still
+      // unwired and the one field mutated by the supervisor itself is
+      // `_state`, which is not persisted). Still, writing here makes
+      // deactivate the single "this file is now stable on disk" fence
+      // so future beads that add in-memory fields (e.g. lastActiveAt
+      // refresh in the reaper) don't leak drift at shutdown.
+      try {
+        await saveSession(handle.path, handle.session)
+      } catch (err) {
+        // A write failure at the deactivation boundary is not something
+        // we can recover from on this handle — the on-disk copy may or
+        // may not be the last-known-good. Transition to quarantine so
+        // the next activate() reloads from disk AND surfaces the
+        // failure to the SO. Bead-filing for quarantine lands with the
+        // reaper work (ccsc-xa3.8); for now the state change alone is
+        // the forensic trail.
+        handle.markQuarantined()
+        log('session.deactivate_error', {
+          channel: key.channel,
+          thread: key.thread,
+          error: errorMessage(err),
+        })
+        throw err
+      }
+
+      live.delete(id)
+
+      log('session.deactivate', {
+        channel: key.channel,
+        thread: key.thread,
+      })
     },
 
     shutdown(): Promise<void> {
@@ -489,6 +551,21 @@ class ConcreteHandle implements SessionHandle {
    *  that accepts the full FSM. */
   markActive(): void {
     this._state = 'active'
+  }
+
+  /** Transition from `quiescing` → `deactivating`. Only the supervisor
+   *  invokes this, and only after the drain promise has resolved.
+   *  Package-private by convention; external callers must go through
+   *  `SessionSupervisor.deactivate()`. */
+  markDeactivating(): void {
+    this._state = 'deactivating'
+  }
+
+  /** Transition to `quarantined`. Terminal from the supervisor's
+   *  perspective — only a human clears it. Called on save-path
+   *  failures that leave the on-disk state uncertain. */
+  markQuarantined(): void {
+    this._state = 'quarantined'
   }
 
   /** Begin a graceful drain. Transitions state `active` → `quiescing`


### PR DESCRIPTION
## Summary

Implements the deactivate path per \`000-docs/session-state-machine.md\` §124-128 and \`supervisor.ts\` interface contract §188-198. First leaf of Epic 32-B sub-epic ccsc-xa3.14 (Deactivate + idle reaper).

## Contract enforced

- Rejects on an \`active\` handle (\"must be quiesced first\") — upholds the work-drains-before-release invariant §210#2.
- Rejects on a \`quarantined\` handle (only a human clears it per §197-198).
- No-op on an unknown/already-released key (matches quiesce() Nonexistent semantics).
- Defensive final \`saveSession()\` (atomic tmp+rename) before releasing. On write failure the handle transitions to \`quarantined\` and emits a \`session.deactivate_error\` log line.
- Transitions \`quiescing\` → \`deactivating\`, removes from the live map, emits \`session.deactivate\` structured log.

## Changes

- \`supervisor.ts\`: deactivate() body + \`markDeactivating()\` / \`markQuarantined()\` package-private transitions on ConcreteHandle.
- \`server.test.ts\`: 7 new tests covering unknown-key no-op, active-state rejection, state flow, post-deactivate re-activation from disk, atomic persist verification, idempotent re-deactivate, quarantined rejection.
- Adjusts the previously-combined \"deactivate/shutdown are staged stubs\" test — only shutdown remains stubbed (lands with ccsc-xa3.8 reaper work).

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 340 pass / 0 fail (+6 net new tests)

Closes bead ccsc-xa3.4 (32-B.4).

Jeremy made me do it
-claude