### PR TITLE
feat(supervisor): idle reaper + SLACK_SESSION_IDLE_MS resolver (ccsc-xa3.8)

### DIFF
--- a/server.test.ts
+++ b/server.test.ts
@@ -2905,6 +2905,193 @@ describe('createSessionSupervisor.deactivate', () => {
 })
 
 // ---------------------------------------------------------------------------
+// resolveIdleMs + SessionSupervisor.reapIdle (ccsc-xa3.8)
+// ---------------------------------------------------------------------------
+
+describe('resolveIdleMs', () => {
+  test('returns DEFAULT_IDLE_MS (4h) when env var is unset', async () => {
+    const { resolveIdleMs, DEFAULT_IDLE_MS } = await import('./supervisor.ts')
+    expect(resolveIdleMs({})).toBe(DEFAULT_IDLE_MS)
+    expect(DEFAULT_IDLE_MS).toBe(4 * 60 * 60 * 1000)
+  })
+
+  test('returns DEFAULT_IDLE_MS when env var is empty / non-numeric / negative', async () => {
+    const { resolveIdleMs, DEFAULT_IDLE_MS } = await import('./supervisor.ts')
+    expect(resolveIdleMs({ SLACK_SESSION_IDLE_MS: '' })).toBe(DEFAULT_IDLE_MS)
+    expect(resolveIdleMs({ SLACK_SESSION_IDLE_MS: 'abc' })).toBe(DEFAULT_IDLE_MS)
+    expect(resolveIdleMs({ SLACK_SESSION_IDLE_MS: '-100' })).toBe(DEFAULT_IDLE_MS)
+    expect(resolveIdleMs({ SLACK_SESSION_IDLE_MS: '0' })).toBe(DEFAULT_IDLE_MS)
+    expect(resolveIdleMs({ SLACK_SESSION_IDLE_MS: 'Infinity' })).toBe(DEFAULT_IDLE_MS)
+  })
+
+  test('honors a valid positive integer in ms', async () => {
+    const { resolveIdleMs } = await import('./supervisor.ts')
+    expect(resolveIdleMs({ SLACK_SESSION_IDLE_MS: '60000' })).toBe(60000)
+    expect(resolveIdleMs({ SLACK_SESSION_IDLE_MS: '3600000' })).toBe(3600000)
+  })
+
+  test('floors fractional values', async () => {
+    const { resolveIdleMs } = await import('./supervisor.ts')
+    expect(resolveIdleMs({ SLACK_SESSION_IDLE_MS: '1500.9' })).toBe(1500)
+  })
+})
+
+describe('createSessionSupervisor.reapIdle', () => {
+  let rawRoot: string
+  let tmpRoot: string
+  let logged: Array<{ event: string; fields: Record<string, unknown> }>
+  let clockNow: number
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'supervisor-reap-'))
+    tmpRoot = realpathSync.native(rawRoot)
+    logged = []
+    clockNow = 1_700_000_000_000
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  function makeSupervisor(idleMs: number) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createSessionSupervisor } = require('./supervisor.ts') as typeof import('./supervisor.ts')
+    return createSessionSupervisor({
+      stateRoot: tmpRoot,
+      log: (event, fields) => {
+        logged.push({ event, fields })
+      },
+      clock: () => clockNow,
+      idleMs,
+    })
+  }
+
+  type DrainHandle = import('./supervisor.ts').SessionHandle & {
+    beginWork(requestId: string): AbortController
+    endWork(requestId: string): void
+    readonly inFlight: Map<string, AbortController>
+  }
+
+  test('no-op when live map is empty', async () => {
+    const sup = makeSupervisor(60_000)
+    await sup.reapIdle()
+    expect(logged.filter((l) => l.event === 'session.reap_tick')).toHaveLength(0)
+  })
+
+  test('leaves sessions within the idle window untouched', async () => {
+    const sup = makeSupervisor(60_000)
+    const handle = await sup.activate({ channel: 'C_R1', thread: 'T' }, 'U1')
+    expect(handle.session.lastActiveAt).toBe(clockNow)
+
+    // Advance clock but not past the idle threshold.
+    clockNow += 30_000
+    await sup.reapIdle()
+
+    expect(handle.state).toBe('active')
+    expect(logged.filter((l) => l.event === 'session.reap_tick')).toHaveLength(0)
+  })
+
+  test('reaps sessions past the idle threshold through quiesce → deactivate', async () => {
+    const sup = makeSupervisor(60_000)
+    const handle = await sup.activate({ channel: 'C_R2', thread: 'T' }, 'U1')
+
+    // Push clock past the threshold.
+    clockNow += 120_000
+    await sup.reapIdle()
+
+    // Handle must have moved through the full lifecycle — ends at
+    // 'deactivating' (terminal from the caller's view; the live map
+    // removal is the true "gone" signal).
+    expect(handle.state).toBe('deactivating')
+
+    const events = logged.map((l) => l.event)
+    expect(events).toContain('session.reap_tick')
+    expect(events).toContain('session.quiesce')
+    expect(events).toContain('session.deactivate')
+
+    // A fresh activate() must reload from disk, not return the reaped
+    // handle.
+    const fresh = await sup.activate({ channel: 'C_R2', thread: 'T' })
+    expect(fresh).not.toBe(handle)
+    expect(fresh.state).toBe('active')
+  })
+
+  test('skips sessions with in-flight work, even when past the threshold', async () => {
+    const sup = makeSupervisor(60_000)
+    const handle = (await sup.activate(
+      { channel: 'C_R3', thread: 'T' },
+      'U1',
+    )) as DrainHandle
+    handle.beginWork('tool-call-1')
+
+    clockNow += 120_000
+    await sup.reapIdle()
+
+    // In-flight guard: handle must still be active, no reap events.
+    expect(handle.state).toBe('active')
+    expect(handle.inFlight.has('tool-call-1')).toBe(true)
+    expect(logged.filter((l) => l.event === 'session.reap_tick')).toHaveLength(0)
+    expect(logged.filter((l) => l.event === 'session.deactivate')).toHaveLength(0)
+
+    // Clean up so afterEach doesn't leave dangling AbortControllers.
+    handle.endWork('tool-call-1')
+  })
+
+  test('skips handles whose state is not active (quiescing / quarantined)', async () => {
+    const sup = makeSupervisor(60_000)
+    const quiescingHandle = await sup.activate(
+      { channel: 'C_R4a', thread: 'T' },
+      'U1',
+    )
+    const quarantinedHandle = await sup.activate(
+      { channel: 'C_R4b', thread: 'T' },
+      'U2',
+    )
+
+    // Manually drive into non-active states without going through the
+    // full quiesce() helper (which would resolve immediately with no
+    // in-flight work and let deactivate run).
+    ;(quiescingHandle as unknown as { _state: string })._state = 'quiescing'
+    ;(quarantinedHandle as unknown as { markQuarantined(): void }).markQuarantined()
+
+    clockNow += 120_000
+    await sup.reapIdle()
+
+    expect(quiescingHandle.state).toBe('quiescing')
+    expect(quarantinedHandle.state).toBe('quarantined')
+    expect(logged.filter((l) => l.event === 'session.reap_tick')).toHaveLength(0)
+  })
+
+  test('reaps multiple eligible sessions in a single tick', async () => {
+    const sup = makeSupervisor(60_000)
+    const h1 = await sup.activate({ channel: 'C_A', thread: 'T' }, 'U1')
+    const h2 = await sup.activate({ channel: 'C_B', thread: 'T' }, 'U2')
+    const h3 = await sup.activate({ channel: 'C_C', thread: 'T' }, 'U3')
+
+    clockNow += 120_000
+    await sup.reapIdle()
+
+    expect(h1.state).toBe('deactivating')
+    expect(h2.state).toBe('deactivating')
+    expect(h3.state).toBe('deactivating')
+
+    const reapTicks = logged.filter((l) => l.event === 'session.reap_tick')
+    expect(reapTicks).toHaveLength(1)
+    expect(reapTicks[0]!.fields['candidates']).toBe(3)
+  })
+
+  test('honors a custom idleMs (short window for tests)', async () => {
+    const sup = makeSupervisor(500)
+    const handle = await sup.activate({ channel: 'C_SHORT', thread: 'T' }, 'U1')
+
+    // 1000ms >> 500ms threshold
+    clockNow += 1000
+    await sup.reapIdle()
+
+    expect(handle.state).toBe('deactivating')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // JournalEvent schema — 000-docs/audit-journal-architecture.md §19-59
 // ---------------------------------------------------------------------------
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -3083,7 +3083,7 @@ describe('createSessionSupervisor.reapIdle', () => {
     const sup = makeSupervisor(500)
     const handle = await sup.activate({ channel: 'C_SHORT', thread: 'T' }, 'U1')
 
-    // 1000ms >> 500ms threshold
+    // 1000ms elapsed > 500ms idle timeout
     clockNow += 1000
     await sup.reapIdle()
 

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -206,6 +206,28 @@ export interface SessionSupervisor {
    *  `activate()` call rejects. A new supervisor instance is required
    *  to resume, and it will rebuild state from disk. */
   shutdown(): Promise<void>
+
+  /** One pass of the idle reaper. Finds every `active` handle whose
+   *  `session.lastActiveAt` is older than `idleMs` and has no in-flight
+   *  work, then drives it through quiesce → deactivate.
+   *
+   *  Contract:
+   *    - Never reaps a handle with `inFlight.size > 0` (session-state-
+   *      machine.md §265 — the idle TTL check runs before quiesce and
+   *      does not pre-empt in-flight work).
+   *    - Never reaps a handle whose state is not `active`. Quiescing /
+   *      deactivating / quarantined handles are on their own edge of
+   *      the FSM; the reaper stays out of their way.
+   *    - Errors on a single session do not stop the tick. The reaper
+   *      logs the failure and moves on so one quarantined handle can't
+   *      starve the rest of the population.
+   *    - Pure relative to wall-clock — tests inject a `clock` to drive
+   *      the threshold deterministically.
+   *
+   *  Timer wiring lives in `server.ts`: this function is the reapable
+   *  unit so the server can decide tick frequency, or a test can call
+   *  it directly. */
+  reapIdle(): Promise<void>
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +259,30 @@ export interface SupervisorOptions {
    *  `Date.now`. Injected for deterministic tests of `createdAt` and
    *  `lastActiveAt`. */
   clock?: () => number
+  /** Idle threshold for the reaper, in milliseconds. A session is
+   *  eligible for reaping when `clock() - session.lastActiveAt >
+   *  idleMs`. Default: 4 hours (14_400_000 ms). Matches the
+   *  `SLACK_SESSION_IDLE_MS` env var documented in
+   *  session-state-machine.md §119. */
+  idleMs?: number
+}
+
+/** Default idle threshold: 4 hours in ms. Documented in
+ *  session-state-machine.md §119. */
+export const DEFAULT_IDLE_MS = 4 * 60 * 60 * 1000
+
+/** Parse `SLACK_SESSION_IDLE_MS` from an env record and return a valid
+ *  idle threshold in ms. Falls back to `DEFAULT_IDLE_MS` when the var
+ *  is unset, empty, non-numeric, negative, or non-finite. Pure; no
+ *  process.env access — caller passes the env map. */
+export function resolveIdleMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env['SLACK_SESSION_IDLE_MS']
+  if (raw === undefined || raw === '') return DEFAULT_IDLE_MS
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_IDLE_MS
+  return Math.floor(parsed)
 }
 
 /** Default structured log writer: one newline-delimited JSON object per
@@ -269,6 +315,7 @@ export function createSessionSupervisor(
 ): SessionSupervisor {
   const log = opts.log ?? defaultLog
   const clock = opts.clock ?? Date.now
+  const idleMs = opts.idleMs ?? DEFAULT_IDLE_MS
   const { stateRoot } = opts
 
   // Live handles, keyed by the stringified SessionKey. Use a composite
@@ -480,6 +527,51 @@ export function createSessionSupervisor(
           'SessionSupervisor.shutdown: not yet implemented (ccsc-xa3.14)',
         ),
       )
+    },
+
+    async reapIdle(): Promise<void> {
+      const now = clock()
+      const threshold = now - idleMs
+
+      // Snapshot candidate keys first so we don't iterate the live map
+      // while mutating it through deactivate(). Capture only what the
+      // filter allows; the quiesce/deactivate pair per candidate runs
+      // on the snapshot list.
+      const candidates: SessionKey[] = []
+      for (const handle of live.values()) {
+        if (handle.state !== 'active') continue
+        if (handle.inFlight.size > 0) continue
+        if (handle.session.lastActiveAt > threshold) continue
+        candidates.push(handle.key)
+      }
+
+      if (candidates.length === 0) return
+
+      log('session.reap_tick', {
+        idleMs,
+        threshold,
+        candidates: candidates.length,
+      })
+
+      // Sequential rather than parallel: keeps log ordering predictable
+      // and keeps contention on the filesystem (one atomic rename at a
+      // time) down on reapers that drain dozens of sessions at once.
+      // For a developer install the population is small; the parallel
+      // win is not worth the log-interleaving loss.
+      for (const key of candidates) {
+        try {
+          await this.quiesce(key)
+          await this.deactivate(key)
+        } catch (err) {
+          // One quarantined or racing handle must not starve the rest
+          // of the tick. Log and continue.
+          log('session.reap_error', {
+            channel: key.channel,
+            thread: key.thread,
+            error: errorMessage(err),
+          })
+        }
+      }
     },
   }
 }


### PR DESCRIPTION
## Summary

Adds \`SessionSupervisor.reapIdle()\` per \`000-docs/session-state-machine.md\` §119 and §265. Companion leaf to PR #78 (deactivate) — together they close sub-epic ccsc-xa3.14.

## Behavior

One reap pass finds every \`active\` handle whose \`session.lastActiveAt\` is older than \`idleMs\` and has no in-flight work, then drives it through \`quiesce()\` → \`deactivate()\` (the strict FSM teardown path — no Active → Nonexistent shortcut per §153-155).

**Snapshot-time filters:**
- State must be \`active\` — quiescing/deactivating/quarantined handles are on their own edges.
- \`inFlight.size === 0\` — in-flight tool calls are not pre-empted; they drain on their own and become reap-eligible next tick.
- \`lastActiveAt > threshold\` skips.

**Resilience:** per-session errors do not stop the tick. The reaper logs \`session.reap_error\` and moves on so one bad handle can't starve the rest of the population.

**Timer wiring deliberately NOT included** — \`reapIdle()\` is the reapable unit; \`server.ts\` chooses tick frequency in a later bead. Tests drive the reaper deterministically via injected clock.

## Env resolver

\`resolveIdleMs(env)\` — pure parser for \`SLACK_SESSION_IDLE_MS\` with \`DEFAULT_IDLE_MS = 4h\` fallback for unset/empty/non-numeric/non-positive/non-finite values. Floors fractional ms.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 351 pass / 0 fail (+11 new tests)
- resolveIdleMs: default, invalid fallback, valid integer, fractional
- reapIdle: empty-map no-op, within-window untouched, past-threshold full lifecycle, in-flight skip, non-active state skip, multi-candidate single tick, custom idleMs honored

Closes bead ccsc-xa3.8 (32-B.8).

Jeremy made me do it
-claude