### PR TITLE
feat(outbound): widen assertOutboundAllowed to (channel, thread_ts) (ccsc-xa3.6)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -636,18 +636,46 @@ export function assertSendable(
 // ---------------------------------------------------------------------------
 
 /**
- * Throws if `chatId` is neither an opted-in channel nor a previously-delivered
- * channel (DM that passed the inbound gate this session).
+ * Composite key for the delivered-threads set. `\0` is not a legal
+ * character in Slack channel or thread_ts values, so it is a safe
+ * separator that won't collide with real IDs. `undefined` thread_ts
+ * (top-level channel post) collapses to the empty string slot — it
+ * is its OWN delivery slot, distinct from any threaded reply.
+ */
+export function deliveredThreadKey(
+  channel: string,
+  threadTs: string | undefined,
+): string {
+  return `${channel}\0${threadTs ?? ''}`
+}
+
+/**
+ * Throws if `(chatId, threadTs)` names a (channel, thread) pair that
+ * has not previously delivered inbound AND `chatId` is not an
+ * opted-in channel.
+ *
+ * Channel-level opt-in (`access.channels[chatId]`) is an operator-
+ * scoped bypass: if an operator has explicitly trusted a channel
+ * then any thread in that channel is reply-eligible. Thread-level
+ * delivery is the granular path: once a thread has delivered
+ * inbound it becomes reply-eligible, independent of its siblings.
+ *
+ * Security rationale (ccsc-xa3.5 + ccsc-xa3.6): two sessions in the
+ * same channel but different threads must not share outbound
+ * authority. A tool call dispatched in thread A cannot post into
+ * thread B unless B has independently delivered. This closes the
+ * cross-thread leak documented by the xa3.5 failing fixture.
  */
 export function assertOutboundAllowed(
   chatId: string,
+  threadTs: string | undefined,
   access: Access,
-  deliveredChannels: ReadonlySet<string>,
+  deliveredThreads: ReadonlySet<string>,
 ): void {
   if (access.channels[chatId]) return
-  if (deliveredChannels.has(chatId)) return
+  if (deliveredThreads.has(deliveredThreadKey(chatId, threadTs))) return
   throw new Error(
-    `Outbound gate: channel ${chatId} is not in the allowlist or opted-in channels.`,
+    `Outbound gate: (channel ${chatId}, thread ${threadTs ?? '<top-level>'}) is not in the allowlist or delivered-threads set.`,
   )
 }
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -598,84 +598,116 @@ describe('parseSendableRoots', () => {
 // ---------------------------------------------------------------------------
 
 describe('assertOutboundAllowed', () => {
-  test('allows opted-in channels', () => {
+  test('allows opted-in channels regardless of thread', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
     const access = makeAccess({
       channels: { C_OPT: { requireMention: false, allowFrom: [] } },
     })
-    expect(() => assertOutboundAllowed('C_OPT', access, new Set())).not.toThrow()
+    // Channel opt-in subsumes thread-level checks: an opted-in
+    // channel authorizes any thread in that channel.
+    expect(() =>
+      assertOutboundAllowed('C_OPT', 'T1', access, new Set()),
+    ).not.toThrow()
+    expect(() =>
+      assertOutboundAllowed('C_OPT', undefined, access, new Set()),
+    ).not.toThrow()
+    // Spot-check that the helper shape matches what the server uses
+    // for the delivered-threads Set.
+    expect(deliveredThreadKey('C_OPT', 'T1')).toBe('C_OPT\0T1')
+    expect(deliveredThreadKey('C_OPT', undefined)).toBe('C_OPT\0')
   })
 
-  test('allows delivered channels', () => {
+  test('allows delivered (channel, thread) pairs', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
     const access = makeAccess()
-    const delivered = new Set(['D_DELIVERED'])
-    expect(() => assertOutboundAllowed('D_DELIVERED', access, delivered)).not.toThrow()
+    const delivered = new Set([deliveredThreadKey('D_DELIVERED', 'T1')])
+    expect(() =>
+      assertOutboundAllowed('D_DELIVERED', 'T1', access, delivered),
+    ).not.toThrow()
+  })
+
+  test('allows delivered top-level (undefined thread) posts', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
+    const access = makeAccess()
+    const delivered = new Set([deliveredThreadKey('C_TOP', undefined)])
+    expect(() =>
+      assertOutboundAllowed('C_TOP', undefined, access, delivered),
+    ).not.toThrow()
   })
 
   test('blocks unknown channels', () => {
     const access = makeAccess()
-    expect(() => assertOutboundAllowed('C_RANDO', access, new Set())).toThrow('Outbound gate')
+    expect(() =>
+      assertOutboundAllowed('C_RANDO', 'T1', access, new Set()),
+    ).toThrow('Outbound gate')
   })
 
-  test('blocks channels not in either list', () => {
+  test('blocks channels not in either list', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
     const access = makeAccess({
       channels: { C_OTHER: { requireMention: false, allowFrom: [] } },
     })
-    const delivered = new Set(['D_DIFFERENT'])
-    expect(() => assertOutboundAllowed('C_ATTACKER', access, delivered)).toThrow('Outbound gate')
+    const delivered = new Set([deliveredThreadKey('D_DIFFERENT', 'T1')])
+    expect(() =>
+      assertOutboundAllowed('C_ATTACKER', 'T1', access, delivered),
+    ).toThrow('Outbound gate')
+  })
+
+  test('blocks thread B when only thread A delivered in the same channel (ccsc-xa3.6)', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
+    const access = makeAccess()
+    // Thread T_A delivered inbound; T_B never did. Both live in the
+    // same (non-opted-in) channel. An outbound to T_B must throw —
+    // closes the cross-thread leak documented by the xa3.5 fixture.
+    const delivered = new Set([deliveredThreadKey('C_SHARED', 'T_A')])
+    expect(() =>
+      assertOutboundAllowed('C_SHARED', 'T_A', access, delivered),
+    ).not.toThrow()
+    expect(() =>
+      assertOutboundAllowed('C_SHARED', 'T_B', access, delivered),
+    ).toThrow(/thread T_B/)
+  })
+
+  test('blocks top-level post when only a thread has delivered', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
+    const access = makeAccess()
+    const delivered = new Set([deliveredThreadKey('C_SHARED', 'T1')])
+    // Top-level slot is distinct from any thread slot. Delivering
+    // on T1 does not authorize a top-level post.
+    expect(() =>
+      assertOutboundAllowed('C_SHARED', undefined, access, delivered),
+    ).toThrow(/top-level/)
   })
 })
 
 // ---------------------------------------------------------------------------
-// Thread isolation — outbound gate (ccsc-xa3.5 failing fixture)
+// Thread isolation — outbound gate (ccsc-xa3.5 landed → ccsc-xa3.6 fixed)
 // ---------------------------------------------------------------------------
 //
-// Documents the cross-thread leak that the current channel-only
-// `assertOutboundAllowed` signature does not prevent. Two sessions in
-// the same channel, different threads — a tool call dispatched in
-// thread A can craft a completion targeted at thread B and the
-// outbound gate will let it through because the gate only knows
-// channels, not threads.
-//
-// The ideal, documented in session-state-machine.md §207 ("per-thread
-// session isolation"), is that an outbound whose thread_ts was never
-// delivered to must be refused. Reaching that ideal requires:
-//
-//   - ccsc-xa3.6 — widen `assertOutboundAllowed` from (chatId, access,
-//     deliveredChannels) to a (channel, thread_ts, access,
-//     deliveredThreads) tuple so the guard can see threads.
-//   - ccsc-xa3.7 — widen the permission-pairing key from `requestId`
-//     to `(thread_ts, requestId)` so approvals in one thread cannot
-//     authorize a reply in another.
-//
-// This fixture is `test.failing` — bun runs it, expects it to fail,
-// and flags regression if it ever passes. When xa3.6 lands the fixture
-// flips to a regular `test` with the new signature. Keeping it red
-// today is the TDD signal the bead asked for.
+// Originally a `test.failing` fixture (ccsc-xa3.5) documenting the
+// cross-thread leak in the channel-only `assertOutboundAllowed`
+// signature. ccsc-xa3.6 widened the guard to a (channel, thread_ts,
+// access, deliveredThreads) tuple, so the invariant is now enforced
+// and this flips to a regular `test`.
 
-describe('thread isolation — outbound gate (ccsc-xa3.5)', () => {
-  test.failing(
-    'replies to an undelivered thread must be refused even when the channel did deliver',
-    () => {
-      const access = makeAccess()
-      // Simulate the reality xa3.5 is describing: channel C_SHARED had
-      // inbound delivery on thread T_A. Nothing has ever delivered on
-      // T_B — it's simply another thread a human could reply to in the
-      // same channel. A tool call originating in T_A must not be able
-      // to post into T_B.
-      const deliveredChannels = new Set(['C_SHARED'])
+describe('thread isolation — outbound gate (ccsc-xa3.5 → xa3.6)', () => {
+  test('replies to an undelivered thread are refused even when a sibling thread delivered', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
+    const access = makeAccess()
+    // Thread T_A delivered inbound on channel C_SHARED. T_B never
+    // did. A tool call in T_A must not be able to post into T_B.
+    const deliveredThreads = new Set([deliveredThreadKey('C_SHARED', 'T_A')])
 
-      // Ideal behavior: the outbound guard throws because T_B has no
-      // delivered history. Current signature has no thread parameter,
-      // so the call returns void — this assertion fails today, which
-      // is exactly the failing fixture this bead asks for. When xa3.6
-      // widens the signature, this test gets rewritten to pass the
-      // (channel, thread_ts) pair, `test.failing` drops to `test`, and
-      // the invariant becomes enforced.
-      expect(() => {
-        assertOutboundAllowed('C_SHARED', access, deliveredChannels)
-      }).toThrow(/thread/)
-    },
-  )
+    // T_A: allowed.
+    expect(() =>
+      assertOutboundAllowed('C_SHARED', 'T_A', access, deliveredThreads),
+    ).not.toThrow()
+
+    // T_B: blocked.
+    expect(() =>
+      assertOutboundAllowed('C_SHARED', 'T_B', access, deliveredThreads),
+    ).toThrow(/thread T_B/)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -735,35 +767,40 @@ describe('outbound gate coverage for read/edit/react/download', () => {
   test('blocks react on unknown channel', () => {
     const access = makeAccess()
     expect(() =>
-      assertOutboundAllowed('C_RANDOM', access, new Set()),
+      assertOutboundAllowed('C_RANDOM', 'T1', access, new Set()),
     ).toThrow('Outbound gate')
   })
 
   test('blocks edit_message on unknown channel', () => {
     const access = makeAccess()
     expect(() =>
-      assertOutboundAllowed('C_RANDOM', access, new Set()),
+      assertOutboundAllowed('C_RANDOM', 'T1', access, new Set()),
     ).toThrow('Outbound gate')
   })
 
   test('blocks fetch_messages on unknown channel', () => {
     const access = makeAccess()
     expect(() =>
-      assertOutboundAllowed('C_RANDOM', access, new Set()),
+      assertOutboundAllowed('C_RANDOM', 'T1', access, new Set()),
     ).toThrow('Outbound gate')
   })
 
   test('blocks download_attachment on unknown channel', () => {
     const access = makeAccess()
     expect(() =>
-      assertOutboundAllowed('C_RANDOM', access, new Set()),
+      assertOutboundAllowed('C_RANDOM', 'T1', access, new Set()),
     ).toThrow('Outbound gate')
   })
 
-  test('allows these calls on a delivered DM channel', () => {
+  test('allows these calls on a delivered (channel, thread) pair', async () => {
+    const { deliveredThreadKey } = await import('./lib.ts')
     const access = makeAccess()
-    const delivered = new Set(['D_ALICE'])
-    expect(() => assertOutboundAllowed('D_ALICE', access, delivered)).not.toThrow()
+    const delivered = new Set([deliveredThreadKey('D_ALICE', undefined)])
+    // DMs deliver at the top level (no thread_ts) by default; gate
+    // allows top-level outbound when top-level delivered.
+    expect(() =>
+      assertOutboundAllowed('D_ALICE', undefined, access, delivered),
+    ).not.toThrow()
   })
 })
 

--- a/server.ts
+++ b/server.ts
@@ -506,8 +506,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     case 'fetch_messages': {
       const channel: string = args.channel
       const threadTs: string | undefined = args.thread_ts
-      assertOutboundAllowed(channel, threadTs)
       const limit = Math.min(args.limit || 20, 100)
+      assertOutboundAllowed(channel, threadTs)
 
       let messages: any[]
       if (threadTs) {

--- a/server.ts
+++ b/server.ts
@@ -35,6 +35,7 @@ import {
   parseSendableRoots,
   validateSendableRoots,
   assertOutboundAllowed as libAssertOutboundAllowed,
+  deliveredThreadKey as libDeliveredThreadKey,
   isSlackFileUrl,
   chunkText,
   sanitizeFilename,
@@ -205,8 +206,11 @@ function assertSendable(filePath: string): void {
 // Security — outbound gate
 // ---------------------------------------------------------------------------
 
-// Track channels that passed inbound gate (session-lifetime cache)
-const deliveredChannels = new Set<string>()
+// Track (channel, thread) pairs that passed inbound gate — session-
+// lifetime cache, keyed via `deliveredThreadKey(channel, thread_ts)`.
+// Replaces the pre-xa3.6 channel-only set so the outbound gate can
+// enforce thread-level isolation per session-state-machine.md §207.
+const deliveredThreads = new Set<string>()
 
 // Dedupe events across `message` and `app_mention` subscriptions. Keyed on
 // (channel, ts). See isDuplicateEvent in lib.ts for rationale.
@@ -216,8 +220,11 @@ const seenEvents = new Map<string, number>()
 let lastActiveChannel = ''
 let lastActiveThread: string | undefined
 
-function assertOutboundAllowed(chatId: string): void {
-  libAssertOutboundAllowed(chatId, getAccess(), deliveredChannels)
+function assertOutboundAllowed(
+  chatId: string,
+  threadTs: string | undefined,
+): void {
+  libAssertOutboundAllowed(chatId, threadTs, getAccess(), deliveredThreads)
 }
 
 // ---------------------------------------------------------------------------
@@ -412,7 +419,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       const threadTs: string | undefined = args.thread_ts
       const files: string[] | undefined = args.files
 
-      assertOutboundAllowed(chatId)
+      assertOutboundAllowed(chatId, threadTs)
 
       const access = getAccess()
       const limit = access.textChunkLimit || DEFAULT_CHUNK_LIMIT
@@ -459,7 +466,12 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     // react
     // -----------------------------------------------------------------------
     case 'react': {
-      assertOutboundAllowed(args.chat_id)
+      // react operates on a specific message ts; the "thread" it
+      // engages with is whatever thread that message lives in.
+      // Callers that know the parent thread pass `thread_ts`; when
+      // omitted, fall back to channel-level opt-in or top-level
+      // delivery by passing undefined.
+      assertOutboundAllowed(args.chat_id, args.thread_ts)
       await web.reactions.add({
         channel: args.chat_id,
         timestamp: args.message_id,
@@ -474,7 +486,10 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     // edit_message
     // -----------------------------------------------------------------------
     case 'edit_message': {
-      assertOutboundAllowed(args.chat_id)
+      // Editing a message engages with the thread that message lives
+      // in. Callers that know the thread pass `thread_ts`; otherwise
+      // the gate falls back to channel-level opt-in or top-level.
+      assertOutboundAllowed(args.chat_id, args.thread_ts)
       await web.chat.update({
         channel: args.chat_id,
         ts: args.message_id,
@@ -490,9 +505,9 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     // -----------------------------------------------------------------------
     case 'fetch_messages': {
       const channel: string = args.channel
-      assertOutboundAllowed(channel)
-      const limit = Math.min(args.limit || 20, 100)
       const threadTs: string | undefined = args.thread_ts
+      assertOutboundAllowed(channel, threadTs)
+      const limit = Math.min(args.limit || 20, 100)
 
       let messages: any[]
       if (threadTs) {
@@ -540,7 +555,10 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       const channel: string = args.chat_id
       const messageTs: string = args.message_id
 
-      assertOutboundAllowed(channel)
+      // Download engages with the thread the target message lives
+      // in. Callers that know the thread pass `thread_ts`; the gate
+      // falls back to channel-level opt-in or top-level otherwise.
+      assertOutboundAllowed(channel, args.thread_ts)
 
       // Fetch the specific message to get file info
       const res = await web.conversations.replies({
@@ -649,7 +667,11 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
   const targetChannel = lastActiveChannel || Object.keys(access.channels || {})[0]
   if (!targetChannel) return
 
-  assertOutboundAllowed(targetChannel)
+  // Permission prompts post into the last active (channel, thread) pair
+  // so approvals surface in the same thread the tool call originated
+  // from. Falls back to top-level only when we're using an opted-in
+  // channel with no active thread (lastActiveThread === undefined).
+  assertOutboundAllowed(targetChannel, lastActiveThread)
 
   pruneStalePermissions()
   pendingPermissions.set(params.request_id, {
@@ -891,13 +913,16 @@ async function handleMessage(event: unknown): Promise<void> {
         })
       }
 
-      // Track this channel as delivered (for outbound gate)
+      // Track this (channel, thread) pair as delivered (for outbound
+      // gate). A thread-level key so replies cannot leak across
+      // threads in the same channel (ccsc-xa3.6).
       const channelId = ev['channel'] as string
-      deliveredChannels.add(channelId)
+      const incomingThreadTs = ev['thread_ts'] as string | undefined
+      deliveredThreads.add(libDeliveredThreadKey(channelId, incomingThreadTs))
 
       // Track last active channel for permission relay
       lastActiveChannel = channelId
-      lastActiveThread = ev['thread_ts'] as string | undefined
+      lastActiveThread = incomingThreadTs
 
       // Check for permission reply before normal delivery
       const msgText = ((ev['text'] as string) || '').trim()


### PR DESCRIPTION
## Summary

Closes the cross-thread outbound leak documented by the xa3.5 failing fixture. Two sessions in the same channel but different threads no longer share outbound authority.

**Security-critical**: this is the outbound gate layer. Any change here needs scrutiny.

## Contract change

Old: \`assertOutboundAllowed(chatId, access, deliveredChannels)\` — channel-only check.

New: \`assertOutboundAllowed(chatId, threadTs, access, deliveredThreads)\` — (channel, thread) tuple check.

- Channel-level opt-in (\`access.channels[chatId]\`) remains as the operator bypass; authorizes any thread in that channel.
- Otherwise the guard requires the specific \`(channel, thread_ts)\` pair to be in \`deliveredThreads\` (populated by the inbound \`deliver\` case).
- Top-level posts (\`thread_ts === undefined\`) have their OWN distinct slot — delivering on a thread does not authorize top-level replies.

New exported helper \`deliveredThreadKey(channel, threadTs)\` is the canonical key shape. Uses \`\0\` (illegal in Slack IDs) as separator.

## Server wiring

- \`deliveredChannels: Set<string>\` → \`deliveredThreads: Set<string>\` keyed by \`deliveredThreadKey()\`.
- All five outbound tool call sites (reply, react, edit_message, fetch_messages, download_attachment) pass \`thread_ts\` to the gate.
- Permission-relay handler passes \`lastActiveThread\` so approval prompts surface in the originating thread.

## Tests

- Existing \`assertOutboundAllowed\` and \"outbound gate coverage\" describe blocks updated to the widened signature.
- Added: opted-in-channel subsumption across threads, thread-scoped delivered allow, top-level delivered allow, sibling-thread rejection (the xa3.5 invariant), top-level-vs-thread distinctness.
- **xa3.5 failing fixture flipped from \`test.failing\` to a regular passing \`test\`** — the cross-thread leak is now closed and the test enforces it.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 355 pass / 0 fail (+3 net new tests; flipped fixture)

Closes bead ccsc-xa3.6 (32-B.6). Unblocks ccsc-xa3.7 (permission-pairing key widening).

Jeremy made me do it
-claude