### PR TITLE
feat(permissions): thread-scoped pairing key (ccsc-xa3.7)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -650,6 +650,23 @@ export function deliveredThreadKey(
 }
 
 /**
+ * Composite key for the pending-permissions map (ccsc-xa3.7). Pairs a
+ * thread_ts with a request_id so an approval posted in thread A
+ * cannot satisfy a permission request issued from thread B. Uses
+ * `\0` as the separator — illegal in both Slack thread_ts (which is
+ * `"<unix>.<frac>"`) and in request_ids (Claude Code's 5 lowercase
+ * letters), so no collision with legitimate input is possible.
+ * `undefined` thread collapses to empty-string — distinct from any
+ * threaded slot per the same rule the outbound gate uses.
+ */
+export function permissionPairingKey(
+  threadTs: string | undefined,
+  requestId: string,
+): string {
+  return `${threadTs ?? ''}\0${requestId}`
+}
+
+/**
  * Throws if `(chatId, threadTs)` names a (channel, thread) pair that
  * has not previously delivered inbound AND `chatId` is not an
  * opted-in channel.

--- a/server.test.ts
+++ b/server.test.ts
@@ -711,6 +711,77 @@ describe('thread isolation — outbound gate (ccsc-xa3.5 → xa3.6)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// permissionPairingKey — ccsc-xa3.7
+// ---------------------------------------------------------------------------
+//
+// The pending-permissions map in server.ts is keyed on the composite
+// (thread_ts, request_id) pair so an approval posted in thread A
+// cannot satisfy a request that was issued from thread B. These tests
+// pin the key shape and collision behavior.
+
+describe('permissionPairingKey', () => {
+  test('returns distinct keys for different threads with the same requestId', async () => {
+    const { permissionPairingKey } = await import('./lib.ts')
+    const a = permissionPairingKey('T_A', 'abcde')
+    const b = permissionPairingKey('T_B', 'abcde')
+    expect(a).not.toBe(b)
+  })
+
+  test('returns the same key for equal (thread, requestId) pairs', async () => {
+    const { permissionPairingKey } = await import('./lib.ts')
+    expect(permissionPairingKey('T1.0', 'qrstu')).toBe(
+      permissionPairingKey('T1.0', 'qrstu'),
+    )
+  })
+
+  test('distinguishes undefined thread (top-level) from any threaded slot', async () => {
+    const { permissionPairingKey } = await import('./lib.ts')
+    const topLevel = permissionPairingKey(undefined, 'abcde')
+    const threaded = permissionPairingKey('T1.0', 'abcde')
+    const emptyThread = permissionPairingKey('', 'abcde')
+    expect(topLevel).not.toBe(threaded)
+    // An empty-string thread_ts should canonicalize to the same slot
+    // as undefined (both represent "no thread") — this prevents a
+    // crafted empty string from slipping into a different slot than
+    // a genuinely top-level message.
+    expect(topLevel).toBe(emptyThread)
+  })
+
+  test('separator prevents collisions that a naive concat would hit', async () => {
+    const { permissionPairingKey } = await import('./lib.ts')
+    // A naive `${thread}${requestId}` would collide these two: the
+    // first is thread="abc" + req="de", the second is thread="ab" +
+    // req="cde". Both stringify to "abcde". With the \0 separator
+    // each gets a distinct key.
+    const a = permissionPairingKey('abc', 'de')
+    const b = permissionPairingKey('ab', 'cde')
+    expect(a).not.toBe(b)
+  })
+
+  test('Map round-trip: set then get on the same (thread, requestId) retrieves, cross-thread does not', async () => {
+    const { permissionPairingKey } = await import('./lib.ts')
+    // Simulates the server.ts pendingPermissions.set/get flow
+    // (ccsc-xa3.7) with a minimal mock shape.
+    const map = new Map<string, { tool_name: string }>()
+    const issuedThread = 'T_ISSUE'
+    const requestId = 'mnopq'
+
+    map.set(permissionPairingKey(issuedThread, requestId), {
+      tool_name: 'bash',
+    })
+
+    // Same thread → retrieves the entry.
+    expect(map.get(permissionPairingKey(issuedThread, requestId))).toEqual({
+      tool_name: 'bash',
+    })
+    // Different thread, same requestId → cannot reach the entry.
+    expect(map.get(permissionPairingKey('T_OTHER', requestId))).toBeUndefined()
+    // Top-level slot, same requestId → cannot reach the entry.
+    expect(map.get(permissionPairingKey(undefined, requestId))).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // isSlackFileUrl() — gate for download_attachment
 // ---------------------------------------------------------------------------
 

--- a/server.ts
+++ b/server.ts
@@ -36,6 +36,7 @@ import {
   validateSendableRoots,
   assertOutboundAllowed as libAssertOutboundAllowed,
   deliveredThreadKey as libDeliveredThreadKey,
+  permissionPairingKey as permKey,
   isSlackFileUrl,
   chunkText,
   sanitizeFilename,
@@ -624,8 +625,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 // Track pending permission request details for "See more" button expansion.
 // Each entry includes a timestamp for TTL-based cleanup (5-minute expiry).
+//
+// Keyed by `permKey(threadTs, requestId)` — the composite form (ccsc-
+// xa3.7) so an approval posted in thread A cannot satisfy a permission
+// prompt that was issued from thread B. requestId alone would collide
+// across threads when Claude Code happened to reuse the 5-letter space
+// (it's a 6.4M-id alphabet — collisions are rare but not impossible)
+// AND, more importantly, the pair blocks a crafted cross-thread reply
+// from authorizing a different thread's tool call even when the
+// requestIds genuinely differ. The composite key closes that gap.
 const PERM_TTL_MS = 5 * 60 * 1000
-const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; createdAt: number }>()
+const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; threadTs: string | undefined; createdAt: number }>()
 
 function pruneStalePermissions(): void {
   const cutoff = Date.now() - PERM_TTL_MS
@@ -674,10 +684,16 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
   assertOutboundAllowed(targetChannel, lastActiveThread)
 
   pruneStalePermissions()
-  pendingPermissions.set(params.request_id, {
+  // Pin the request to the thread it was issued from. The button /
+  // text-reply resolvers must present the SAME thread_ts to look the
+  // entry up — see ccsc-xa3.7 for the cross-thread authorization gap
+  // this closes.
+  const issuedThreadTs = lastActiveThread
+  pendingPermissions.set(permKey(issuedThreadTs, params.request_id), {
     tool_name: params.tool_name,
     description: params.description,
     input_preview: params.input_preview,
+    threadTs: issuedThreadTs,
     createdAt: Date.now(),
   })
 
@@ -758,10 +774,19 @@ socket.on('interactive', async ({ body, ack }: { body: any; ack: () => Promise<v
 
     const channelId: string = body.channel?.id || ''
     const messageTs: string = body.message?.ts || ''
+    // Slack includes `thread_ts` on interactive payloads only when the
+    // message lives inside a thread. Top-level messages have no
+    // thread_ts on the message body. Normalize to undefined so the
+    // lookup key matches the request-time key exactly.
+    const interactionThreadTs: string | undefined =
+      (body.message?.thread_ts as string | undefined) || undefined
 
     if (verb === 'more') {
-      // Expand details — update the message to include input_preview
-      const details = pendingPermissions.get(requestId)
+      // Expand details — update the message to include input_preview.
+      // Scoped to the thread this button lives in; a request issued
+      // in a different thread with the same requestId (vanishingly
+      // rare collision) won't leak its preview here.
+      const details = pendingPermissions.get(permKey(interactionThreadTs, requestId))
       if (!details || !channelId || !messageTs) return
 
       // Use plain_text to prevent mrkdwn injection from tool input.
@@ -816,8 +841,12 @@ socket.on('interactive', async ({ body, ack }: { body: any; ack: () => Promise<v
       return
     }
 
-    // Allow or Deny — send verdict to Claude Code
-    const details = pendingPermissions.get(requestId)
+    // Allow or Deny — send verdict to Claude Code. Lookup is scoped
+    // to (interaction thread, requestId) so a click in thread X
+    // cannot satisfy a request issued from thread Y even when the
+    // requestIds match (ccsc-xa3.7).
+    const key = permKey(interactionThreadTs, requestId)
+    const details = pendingPermissions.get(key)
     if (!details) {
       // Already resolved (by button or text reply) — update message and bail
       if (channelId && messageTs) {
@@ -841,7 +870,7 @@ socket.on('interactive', async ({ body, ack }: { body: any; ack: () => Promise<v
       method: 'notifications/claude/channel/permission',
       params: { request_id: requestId, behavior },
     })
-    pendingPermissions.delete(requestId)
+    pendingPermissions.delete(key)
 
     // Update message to show outcome (remove buttons)
     if (channelId && messageTs) {
@@ -932,8 +961,17 @@ async function handleMessage(event: unknown): Promise<void> {
 
         pruneStalePermissions()
 
-        // Skip if already resolved (e.g. by a button click)
-        if (!pendingPermissions.has(requestId)) {
+        // Scope the lookup to the thread the reply arrived from. A
+        // reply posted in thread X cannot satisfy a request issued
+        // from thread Y (ccsc-xa3.7). If the requestId exists but in
+        // a different thread we still reject — an honest SO who
+        // replies in the wrong thread gets an unambiguous rejection
+        // emoji rather than a silent cross-thread resolution.
+        const replyKey = permKey(incomingThreadTs, requestId)
+
+        // Skip if already resolved (e.g. by a button click) OR if the
+        // requestId is not pending in THIS thread.
+        if (!pendingPermissions.has(replyKey)) {
           try {
             await web.reactions.add({
               channel: channelId,
@@ -951,7 +989,7 @@ async function handleMessage(event: unknown): Promise<void> {
             behavior: permMatch[1].toLowerCase().startsWith('y') ? 'allow' : 'deny',
           },
         })
-        pendingPermissions.delete(requestId)
+        pendingPermissions.delete(replyKey)
         // Ack with a reaction so the user knows it was processed
         try {
           await web.reactions.add({

--- a/server.ts
+++ b/server.ts
@@ -635,7 +635,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 // from authorizing a different thread's tool call even when the
 // requestIds genuinely differ. The composite key closes that gap.
 const PERM_TTL_MS = 5 * 60 * 1000
-const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; threadTs: string | undefined; createdAt: number }>()
+const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; createdAt: number }>()
 
 function pruneStalePermissions(): void {
   const cutoff = Date.now() - PERM_TTL_MS
@@ -687,13 +687,12 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
   // Pin the request to the thread it was issued from. The button /
   // text-reply resolvers must present the SAME thread_ts to look the
   // entry up — see ccsc-xa3.7 for the cross-thread authorization gap
-  // this closes.
-  const issuedThreadTs = lastActiveThread
-  pendingPermissions.set(permKey(issuedThreadTs, params.request_id), {
+  // this closes. The thread itself is encoded in the key; no need
+  // to store it on the value.
+  pendingPermissions.set(permKey(lastActiveThread, params.request_id), {
     tool_name: params.tool_name,
     description: params.description,
     input_preview: params.input_preview,
-    threadTs: issuedThreadTs,
     createdAt: Date.now(),
   })
 


### PR DESCRIPTION
## Summary

Closes the cross-thread authorization gap in the permission relay. Companion to PR #81 (xa3.6 outbound gate widening) — together they enforce thread-level session isolation for the outbound layer.

**Before:** permission entries keyed by \`request_id\` alone. An approval button clicked in thread A, or a \"y abcde\" reply posted in thread A, would satisfy a permission request issued from thread B if the requestIds happened to match.

**After:** keyed by \`(thread_ts, request_id)\` via the new \`permissionPairingKey()\` helper. A click or text reply in the wrong thread is ignored (or gets the ❌ rejection emoji for text replies).

## Changes

- \`lib.ts\`: new \`permissionPairingKey(threadTs, requestId)\` exported helper. Uses \`\0\` separator (illegal in both Slack thread_ts and Claude Code's 5-letter request_ids). \`undefined\` thread collapses to empty string, distinct from any threaded slot.
- \`server.ts\`: all four permission touchpoints rekeyed — request intake, button \"more\", button allow/deny, text reply. Thread_ts extracted from \`body.message.thread_ts\` for button clicks, \`ev.thread_ts\` for text replies.
- Removed the temporary inline \`permKey()\` from server.ts; imported from lib.ts as \`permKey\` alias instead.

## Tests

5 new tests for \`permissionPairingKey\`:
- Distinct keys for different threads with the same requestId
- Equality on matching pairs
- Top-level (undefined thread) vs threaded slot distinction
- Undefined ↔ empty-string canonicalization (prevents a crafted empty string from slipping into a different slot)
- Separator prevents naive-concat collisions (\`\"abc\"+\"de\"\` vs \`\"ab\"+\"cde\"\`)
- Map round-trip showing cross-thread lookup returns undefined

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 360 pass / 0 fail (+5 new tests)

Closes bead ccsc-xa3.7 (32-B.7).

Jeremy made me do it
-claude