### PR TITLE
feat(tools): slack/list_sessions MCP tool (ccsc-xa3.9)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -347,6 +347,110 @@ export const LIST_SESSIONS_MAX = 1000
  *      root so a symlink inside `sessions/` cannot surface a file
  *      from elsewhere on disk.
  */
+/** Read and validate one thread file, returning its summary or null
+ *  if the file is missing, unparseable, outside the state root, or
+ *  missing load-bearing fields. Log-and-skip on parse error so a
+ *  single corrupt file can't poison the enumeration. */
+function readThreadSummary(
+  channel: string,
+  entry: string,
+  resolvedChannelDir: string,
+  resolvedRoot: string,
+): SessionSummary | null {
+  if (!entry.endsWith('.json')) return null
+  if (entry.startsWith('.')) return null
+
+  const threadFile = join(resolvedChannelDir, entry)
+  let resolvedThreadFile: string
+  try {
+    resolvedThreadFile = realpathSync.native(threadFile)
+  } catch {
+    return null
+  }
+  if (!isUnderRoot(resolvedThreadFile, resolvedRoot)) return null
+
+  let raw: string
+  try {
+    raw = readFileSync(resolvedThreadFile, 'utf8')
+  } catch {
+    return null
+  }
+
+  let parsed: Partial<Session>
+  try {
+    parsed = JSON.parse(raw) as Partial<Session>
+  } catch (err) {
+    process.stderr.write(
+      `[listSessions] skipping unparseable file ${threadFile}: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    )
+    return null
+  }
+
+  if (
+    typeof parsed.createdAt !== 'number' ||
+    typeof parsed.lastActiveAt !== 'number' ||
+    typeof parsed.ownerId !== 'string'
+  ) {
+    return null
+  }
+
+  return {
+    channel,
+    thread: entry.slice(0, -'.json'.length),
+    createdAt: parsed.createdAt,
+    lastActiveAt: parsed.lastActiveAt,
+    ownerId: parsed.ownerId,
+  }
+}
+
+/** Enumerate all thread files under one channel directory, appending
+ *  valid summaries to `out`. Returns when `out` hits the cap so the
+ *  outer loop stops too. */
+function collectChannelSummaries(
+  channel: string,
+  resolvedSessionsDir: string,
+  resolvedRoot: string,
+  out: SessionSummary[],
+): void {
+  const channelDir = join(resolvedSessionsDir, channel)
+  let chanStat: ReturnType<typeof statSync>
+  try {
+    chanStat = statSync(channelDir)
+  } catch {
+    return
+  }
+  if (!chanStat.isDirectory()) return
+
+  let resolvedChannelDir: string
+  try {
+    resolvedChannelDir = realpathSync.native(channelDir)
+  } catch {
+    return
+  }
+  if (!isUnderRoot(resolvedChannelDir, resolvedRoot)) return
+
+  let threadEntries: string[]
+  try {
+    threadEntries = readdirSync(resolvedChannelDir)
+  } catch {
+    return
+  }
+
+  for (const entry of threadEntries) {
+    const summary = readThreadSummary(
+      channel,
+      entry,
+      resolvedChannelDir,
+      resolvedRoot,
+    )
+    if (summary === null) continue
+    out.push(summary)
+    if (out.length >= LIST_SESSIONS_MAX) return
+  }
+}
+
 export function listSessions(stateRoot: string): SessionSummary[] {
   const resolvedRoot = realpathSync.native(resolve(stateRoot))
   const sessionsDir = join(resolvedRoot, 'sessions')
@@ -364,90 +468,12 @@ export function listSessions(stateRoot: string): SessionSummary[] {
 
   const out: SessionSummary[] = []
 
-  const channelEntries = readdirSync(resolvedSessionsDir)
-  for (const channel of channelEntries) {
-    // Skip the migration sentinel and anything that isn't a directory
+  for (const channel of readdirSync(resolvedSessionsDir)) {
+    // Skip the migration sentinel and any other top-level dotfile
     // (pre-0.5.0 flat files should have been migrated by now; if one
     // lingers, it's ignored — the list is best-effort introspection).
     if (channel.startsWith('.')) continue
-    const channelDir = join(resolvedSessionsDir, channel)
-    let chanStat: ReturnType<typeof statSync>
-    try {
-      chanStat = statSync(channelDir)
-    } catch {
-      continue
-    }
-    if (!chanStat.isDirectory()) continue
-
-    let resolvedChannelDir: string
-    try {
-      resolvedChannelDir = realpathSync.native(channelDir)
-    } catch {
-      continue
-    }
-    if (!isUnderRoot(resolvedChannelDir, resolvedRoot)) continue
-
-    let threadEntries: string[]
-    try {
-      threadEntries = readdirSync(resolvedChannelDir)
-    } catch {
-      continue
-    }
-
-    for (const entry of threadEntries) {
-      if (!entry.endsWith('.json')) continue
-      if (entry.startsWith('.')) continue
-      const threadFile = join(resolvedChannelDir, entry)
-
-      let resolvedThreadFile: string
-      try {
-        resolvedThreadFile = realpathSync.native(threadFile)
-      } catch {
-        continue
-      }
-      if (!isUnderRoot(resolvedThreadFile, resolvedRoot)) continue
-
-      let raw: string
-      try {
-        raw = readFileSync(resolvedThreadFile, 'utf8')
-      } catch {
-        continue
-      }
-
-      let parsed: Partial<Session>
-      try {
-        parsed = JSON.parse(raw) as Partial<Session>
-      } catch (err) {
-        // Log and skip — one malformed file doesn't poison the list.
-        process.stderr.write(
-          `[listSessions] skipping unparseable file ${threadFile}: ${
-            err instanceof Error ? err.message : String(err)
-          }\n`,
-        )
-        continue
-      }
-
-      // Defensive: require the load-bearing fields before surfacing
-      // the row. A file with partial shape is the forensic concern
-      // of loadSession(); here it just gets skipped.
-      if (
-        typeof parsed.createdAt !== 'number' ||
-        typeof parsed.lastActiveAt !== 'number' ||
-        typeof parsed.ownerId !== 'string'
-      ) {
-        continue
-      }
-
-      out.push({
-        channel,
-        thread: entry.slice(0, -'.json'.length),
-        createdAt: parsed.createdAt,
-        lastActiveAt: parsed.lastActiveAt,
-        ownerId: parsed.ownerId,
-      })
-
-      if (out.length >= LIST_SESSIONS_MAX) break
-    }
+    collectChannelSummaries(channel, resolvedSessionsDir, resolvedRoot, out)
     if (out.length >= LIST_SESSIONS_MAX) break
   }
 

--- a/lib.ts
+++ b/lib.ts
@@ -9,7 +9,7 @@
  */
 
 import { resolve, sep, basename, join } from 'path'
-import { realpathSync, mkdirSync, readdirSync, statSync, existsSync } from 'fs'
+import { realpathSync, mkdirSync, readdirSync, readFileSync, statSync, existsSync } from 'fs'
 import { writeFile, chmod, rename, unlink, readFile } from 'fs/promises'
 
 // ---------------------------------------------------------------------------
@@ -297,6 +297,166 @@ export async function loadSession(root: string, path: string): Promise<Session> 
   }
   const raw = await readFile(resolvedFile, 'utf8')
   return JSON.parse(raw) as Session
+}
+
+/** Minimal introspection record per session file. Intentionally NOT
+ *  the full `Session` shape — `data` may carry user messages, tool
+ *  outputs, or other content that could contain secrets, and
+ *  `list_sessions` is meant to give the operator a thread inventory
+ *  without exposing body state. */
+export interface SessionSummary {
+  channel: string
+  thread: string
+  /** Epoch-ms when the session was first created. */
+  createdAt: number
+  /** Epoch-ms of the most recent persisted activity. Operators use
+   *  this to find idle threads worth reaping. */
+  lastActiveAt: number
+  /** Slack user ID recorded as the session owner. Already operator-
+   *  visible via Slack itself, so surfacing it here is not a leak
+   *  but it IS a PII-adjacent identifier — do not project it further
+   *  without review. */
+  ownerId: string
+}
+
+/** Hard upper bound on rows returned by `listSessions()`. Prevents a
+ *  pathological state dir from producing an unbounded MCP tool
+ *  response. An operator with more than this many live threads is
+ *  outside the intended single-developer use case and can narrow via
+ *  external tooling. */
+export const LIST_SESSIONS_MAX = 1000
+
+/** Enumerate every session file under `stateRoot/sessions/` and
+ *  return a summary per (channel, thread) pair. Pure read; never
+ *  mutates, never creates, never deletes.
+ *
+ *  Contract (ccsc-xa3.9):
+ *    - Returns `SessionSummary[]` with NO body (`data` field) — the
+ *      operator sees lifecycle metadata only.
+ *    - Sorted by `lastActiveAt` descending so the most recently
+ *      active thread is row 0. Stable for ties (insertion order).
+ *    - Hard-capped at `LIST_SESSIONS_MAX` rows. Truncation is
+ *      silent at this layer; the MCP tool wrapper is responsible
+ *      for telling the operator they hit the cap.
+ *    - Tolerant to a missing `sessions/` dir — returns `[]` for a
+ *      fresh install.
+ *    - Tolerant to unparseable or malformed files — logs to
+ *      `process.stderr` and skips. A single corrupt thread does
+ *      not take down the enumeration.
+ *    - Realpath guards every file and channel dir against the state
+ *      root so a symlink inside `sessions/` cannot surface a file
+ *      from elsewhere on disk.
+ */
+export function listSessions(stateRoot: string): SessionSummary[] {
+  const resolvedRoot = realpathSync.native(resolve(stateRoot))
+  const sessionsDir = join(resolvedRoot, 'sessions')
+  if (!existsSync(sessionsDir)) return []
+
+  const resolvedSessionsDir = realpathSync.native(sessionsDir)
+  if (!isUnderRoot(resolvedSessionsDir, resolvedRoot)) {
+    // Symlink pointing outside the root. Fail closed — an operator
+    // has mis-configured the state tree; do not enumerate an
+    // attacker-chosen directory.
+    throw new Error(
+      `listSessions: sessions/ resolves outside state root: ${JSON.stringify(sessionsDir)}`,
+    )
+  }
+
+  const out: SessionSummary[] = []
+
+  const channelEntries = readdirSync(resolvedSessionsDir)
+  for (const channel of channelEntries) {
+    // Skip the migration sentinel and anything that isn't a directory
+    // (pre-0.5.0 flat files should have been migrated by now; if one
+    // lingers, it's ignored — the list is best-effort introspection).
+    if (channel.startsWith('.')) continue
+    const channelDir = join(resolvedSessionsDir, channel)
+    let chanStat: ReturnType<typeof statSync>
+    try {
+      chanStat = statSync(channelDir)
+    } catch {
+      continue
+    }
+    if (!chanStat.isDirectory()) continue
+
+    let resolvedChannelDir: string
+    try {
+      resolvedChannelDir = realpathSync.native(channelDir)
+    } catch {
+      continue
+    }
+    if (!isUnderRoot(resolvedChannelDir, resolvedRoot)) continue
+
+    let threadEntries: string[]
+    try {
+      threadEntries = readdirSync(resolvedChannelDir)
+    } catch {
+      continue
+    }
+
+    for (const entry of threadEntries) {
+      if (!entry.endsWith('.json')) continue
+      if (entry.startsWith('.')) continue
+      const threadFile = join(resolvedChannelDir, entry)
+
+      let resolvedThreadFile: string
+      try {
+        resolvedThreadFile = realpathSync.native(threadFile)
+      } catch {
+        continue
+      }
+      if (!isUnderRoot(resolvedThreadFile, resolvedRoot)) continue
+
+      let raw: string
+      try {
+        raw = readFileSync(resolvedThreadFile, 'utf8')
+      } catch {
+        continue
+      }
+
+      let parsed: Partial<Session>
+      try {
+        parsed = JSON.parse(raw) as Partial<Session>
+      } catch (err) {
+        // Log and skip — one malformed file doesn't poison the list.
+        process.stderr.write(
+          `[listSessions] skipping unparseable file ${threadFile}: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        )
+        continue
+      }
+
+      // Defensive: require the load-bearing fields before surfacing
+      // the row. A file with partial shape is the forensic concern
+      // of loadSession(); here it just gets skipped.
+      if (
+        typeof parsed.createdAt !== 'number' ||
+        typeof parsed.lastActiveAt !== 'number' ||
+        typeof parsed.ownerId !== 'string'
+      ) {
+        continue
+      }
+
+      out.push({
+        channel,
+        thread: entry.slice(0, -'.json'.length),
+        createdAt: parsed.createdAt,
+        lastActiveAt: parsed.lastActiveAt,
+        ownerId: parsed.ownerId,
+      })
+
+      if (out.length >= LIST_SESSIONS_MAX) break
+    }
+    if (out.length >= LIST_SESSIONS_MAX) break
+  }
+
+  // Stable sort by lastActiveAt desc: most recently active first.
+  // Array.prototype.sort is stable in V8/Node 12+, so equal
+  // lastActiveAt values keep their enumeration order.
+  out.sort((a, b) => b.lastActiveAt - a.lastActiveAt)
+
+  return out
 }
 
 /** Filename used as the thread-slot for migrated pre-0.5.0 session files.

--- a/server.test.ts
+++ b/server.test.ts
@@ -1738,8 +1738,6 @@ describe('listSessions', () => {
     const { listSessions } = await import('./lib.ts')
     const outside = mkdtempSync(join(tmpdir(), 'list-sessions-out-'))
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { symlinkSync } = require('fs') as typeof import('fs')
       symlinkSync(outside, join(tmpRoot, 'sessions'), 'dir')
 
       expect(() => listSessions(tmpRoot)).toThrow(

--- a/server.test.ts
+++ b/server.test.ts
@@ -1570,6 +1570,188 @@ describe('loadSession', () => {
 })
 
 // ---------------------------------------------------------------------------
+// listSessions — ccsc-xa3.9 introspection tool
+// ---------------------------------------------------------------------------
+
+describe('listSessions', () => {
+  let rawRoot: string
+  let tmpRoot: string
+
+  const writeSessionFile = (
+    channel: string,
+    thread: string,
+    overrides: Partial<Session> = {},
+  ): void => {
+    const dir = join(tmpRoot, 'sessions', channel)
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+    const full: Session = {
+      v: 1,
+      key: { channel, thread },
+      createdAt: 1_700_000_000_000,
+      lastActiveAt: 1_700_000_000_000,
+      ownerId: 'U_OWNER',
+      data: { turns: [] },
+      ...overrides,
+    }
+    writeFileSync(join(dir, `${thread}.json`), JSON.stringify(full), {
+      mode: 0o600,
+    })
+  }
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'list-sessions-'))
+    tmpRoot = realpathSync.native(rawRoot)
+  })
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  test('empty: returns [] when sessions/ does not exist', async () => {
+    const { listSessions } = await import('./lib.ts')
+    expect(listSessions(tmpRoot)).toEqual([])
+  })
+
+  test('single session: returns one summary with metadata and NO body', async () => {
+    const { listSessions } = await import('./lib.ts')
+    writeSessionFile('C1', 'T1.0', {
+      createdAt: 1_700_000_000_000,
+      lastActiveAt: 1_700_000_500_000,
+      ownerId: 'U_ALICE',
+      data: { turns: [{ role: 'user', content: 'secret-ish content' }] },
+    })
+
+    const out = listSessions(tmpRoot)
+    expect(out).toHaveLength(1)
+    const row = out[0]!
+    expect(row.channel).toBe('C1')
+    expect(row.thread).toBe('T1.0')
+    expect(row.createdAt).toBe(1_700_000_000_000)
+    expect(row.lastActiveAt).toBe(1_700_000_500_000)
+    expect(row.ownerId).toBe('U_ALICE')
+    // Body field MUST NOT be surfaced — the sensitive-data invariant.
+    expect(Object.keys(row)).not.toContain('data')
+    expect((row as unknown as Record<string, unknown>)['data']).toBeUndefined()
+  })
+
+  test('sorts by lastActiveAt descending', async () => {
+    const { listSessions } = await import('./lib.ts')
+    writeSessionFile('C1', 'T_OLD', { lastActiveAt: 1_700_000_000_000 })
+    writeSessionFile('C1', 'T_NEW', { lastActiveAt: 1_700_001_000_000 })
+    writeSessionFile('C1', 'T_MID', { lastActiveAt: 1_700_000_500_000 })
+
+    const out = listSessions(tmpRoot)
+    expect(out.map((r) => r.thread)).toEqual(['T_NEW', 'T_MID', 'T_OLD'])
+  })
+
+  test('handles multiple channels and multiple threads each', async () => {
+    const { listSessions } = await import('./lib.ts')
+    writeSessionFile('C_A', 'T1', { lastActiveAt: 10 })
+    writeSessionFile('C_A', 'T2', { lastActiveAt: 20 })
+    writeSessionFile('C_B', 'T1', { lastActiveAt: 15 })
+
+    const out = listSessions(tmpRoot)
+    expect(out).toHaveLength(3)
+    expect(out[0]).toMatchObject({ channel: 'C_A', thread: 'T2' })
+    expect(out[1]).toMatchObject({ channel: 'C_B', thread: 'T1' })
+    expect(out[2]).toMatchObject({ channel: 'C_A', thread: 'T1' })
+  })
+
+  test('skips unparseable files without crashing the enumeration', async () => {
+    const { listSessions } = await import('./lib.ts')
+    writeSessionFile('C1', 'T_GOOD', { lastActiveAt: 100 })
+    mkdirSync(join(tmpRoot, 'sessions', 'C_BAD'), {
+      recursive: true,
+      mode: 0o700,
+    })
+    writeFileSync(join(tmpRoot, 'sessions', 'C_BAD', 'T.json'), '{not json')
+
+    const out = listSessions(tmpRoot)
+    expect(out).toHaveLength(1)
+    expect(out[0]!.thread).toBe('T_GOOD')
+  })
+
+  test('skips files missing load-bearing fields', async () => {
+    const { listSessions } = await import('./lib.ts')
+    writeSessionFile('C1', 'T_OK', { lastActiveAt: 100 })
+    mkdirSync(join(tmpRoot, 'sessions', 'C_PART'), {
+      recursive: true,
+      mode: 0o700,
+    })
+    writeFileSync(
+      join(tmpRoot, 'sessions', 'C_PART', 'T.json'),
+      JSON.stringify({ v: 1, key: { channel: 'C_PART', thread: 'T' } }),
+    )
+
+    const out = listSessions(tmpRoot)
+    expect(out).toHaveLength(1)
+    expect(out[0]!.channel).toBe('C1')
+  })
+
+  test('skips hidden files and non-JSON entries', async () => {
+    const { listSessions } = await import('./lib.ts')
+    writeSessionFile('C1', 'T_OK', { lastActiveAt: 100 })
+    const chanDir = join(tmpRoot, 'sessions', 'C1')
+    writeFileSync(join(chanDir, '.hidden.json'), '{}')
+    writeFileSync(join(chanDir, 'README.txt'), 'not a session')
+
+    const out = listSessions(tmpRoot)
+    expect(out).toHaveLength(1)
+  })
+
+  test('skips the .migrated marker and other top-level dotfiles', async () => {
+    const { listSessions } = await import('./lib.ts')
+    writeSessionFile('C1', 'T_OK', { lastActiveAt: 100 })
+    writeFileSync(join(tmpRoot, 'sessions', '.migrated'), '')
+    writeFileSync(join(tmpRoot, 'sessions', '.DS_Store'), '')
+
+    const out = listSessions(tmpRoot)
+    expect(out).toHaveLength(1)
+  })
+
+  test('caps at LIST_SESSIONS_MAX rows', async () => {
+    const { listSessions, LIST_SESSIONS_MAX } = await import('./lib.ts')
+    const target = LIST_SESSIONS_MAX + 5
+    mkdirSync(join(tmpRoot, 'sessions', 'C_BULK'), {
+      recursive: true,
+      mode: 0o700,
+    })
+    for (let i = 0; i < target; i++) {
+      const thread = `T${i.toString().padStart(5, '0')}`
+      writeFileSync(
+        join(tmpRoot, 'sessions', 'C_BULK', `${thread}.json`),
+        JSON.stringify({
+          v: 1,
+          key: { channel: 'C_BULK', thread },
+          createdAt: 1_000_000 + i,
+          lastActiveAt: 1_000_000 + i,
+          ownerId: 'U_X',
+          data: {},
+        }),
+      )
+    }
+
+    const out = listSessions(tmpRoot)
+    expect(out).toHaveLength(LIST_SESSIONS_MAX)
+  })
+
+  test('realpath guard: sessions/ symlinked outside state root throws', async () => {
+    const { listSessions } = await import('./lib.ts')
+    const outside = mkdtempSync(join(tmpdir(), 'list-sessions-out-'))
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { symlinkSync } = require('fs') as typeof import('fs')
+      symlinkSync(outside, join(tmpRoot, 'sessions'), 'dir')
+
+      expect(() => listSessions(tmpRoot)).toThrow(
+        /resolves outside state root/,
+      )
+    } finally {
+      rmSync(outside, { recursive: true, force: true })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
 // migrateFlatSessions — 000-docs/session-state-machine.md §71-81
 //
 // One-shot boot-time migration from flat pre-0.5.0 layout

--- a/server.ts
+++ b/server.ts
@@ -37,6 +37,8 @@ import {
   assertOutboundAllowed as libAssertOutboundAllowed,
   deliveredThreadKey as libDeliveredThreadKey,
   permissionPairingKey as permKey,
+  listSessions as libListSessions,
+  LIST_SESSIONS_MAX,
   isSlackFileUrl,
   chunkText,
   sanitizeFilename,
@@ -399,6 +401,15 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['chat_id', 'message_id'],
       },
     },
+    {
+      name: 'list_sessions',
+      description:
+        'List active per-thread sessions on this host: (channel, thread, ownerId, createdAt, lastActiveAt). Does NOT return session body/conversation state — operators get a thread inventory only.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {},
+      },
+    },
   ],
 }))
 
@@ -606,6 +617,37 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
             text: paths.length
               ? `Downloaded ${paths.length} file(s):\n${paths.join('\n')}`
               : 'Failed to download any files.',
+          },
+        ],
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // list_sessions — introspection (ccsc-xa3.9)
+    // -----------------------------------------------------------------------
+    case 'list_sessions': {
+      // Pure read from the state dir. Returns lifecycle metadata
+      // only — session bodies (data field) are deliberately excluded
+      // so the operator gets an inventory without exposing
+      // conversation content that could carry secrets. See
+      // lib.listSessions for the full contract and
+      // LIST_SESSIONS_MAX for the hard-cap behavior.
+      const summaries = libListSessions(STATE_DIR)
+      const truncated = summaries.length >= LIST_SESSIONS_MAX
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                count: summaries.length,
+                max: LIST_SESSIONS_MAX,
+                truncated,
+                sessions: summaries,
+              },
+              null,
+              2,
+            ),
           },
         ],
       }


### PR DESCRIPTION
## Summary

Operator introspection: new MCP tool \`list_sessions\` returns a bounded inventory of active per-thread sessions on this host. Metadata only — session bodies are deliberately excluded since they may carry user messages or tool outputs with secrets.

## Design

### \`lib.ts\`

- New \`SessionSummary\` type: \`{ channel, thread, createdAt, lastActiveAt, ownerId }\`. **NO \`data\` field** — enforces the sensitive-data invariant.
- New \`listSessions(stateRoot)\` pure function:
  - Realpath-guards \`sessions/\` and each thread file against the state root (symlink outside → fail-closed).
  - Skips dotfiles, non-JSON entries, unparseable files (logged to stderr, one bad file doesn't poison the list).
  - Requires load-bearing fields (\`createdAt\`, \`lastActiveAt\`, \`ownerId\`) before surfacing a row.
  - Sorted by \`lastActiveAt\` desc — most recently active thread is row 0.
  - Hard-capped at \`LIST_SESSIONS_MAX = 1000\` rows.

### \`server.ts\`

- Registers \`list_sessions\` MCP tool with empty input schema.
- Handler returns JSON \`{ count, max, truncated, sessions }\` so operators know when they hit the cap.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 370 pass / 0 fail (+10 new tests)

Tests cover: empty dir, single-session body exclusion, sort order, multi-channel/multi-thread, unparseable-file skip, missing-field skip, dotfile skip, \`.migrated\` marker skip, \`LIST_SESSIONS_MAX\` truncation, realpath guard rejection.

Closes bead ccsc-xa3.9 (32-B.9).

Jeremy made me do it
-claude