### PR TITLE
docs: post-merge Gemini cleanup across lib.ts + supervisor.ts

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -326,27 +326,6 @@ export interface SessionSummary {
  *  external tooling. */
 export const LIST_SESSIONS_MAX = 1000
 
-/** Enumerate every session file under `stateRoot/sessions/` and
- *  return a summary per (channel, thread) pair. Pure read; never
- *  mutates, never creates, never deletes.
- *
- *  Contract (ccsc-xa3.9):
- *    - Returns `SessionSummary[]` with NO body (`data` field) — the
- *      operator sees lifecycle metadata only.
- *    - Sorted by `lastActiveAt` descending so the most recently
- *      active thread is row 0. Stable for ties (insertion order).
- *    - Hard-capped at `LIST_SESSIONS_MAX` rows. Truncation is
- *      silent at this layer; the MCP tool wrapper is responsible
- *      for telling the operator they hit the cap.
- *    - Tolerant to a missing `sessions/` dir — returns `[]` for a
- *      fresh install.
- *    - Tolerant to unparseable or malformed files — logs to
- *      `process.stderr` and skips. A single corrupt thread does
- *      not take down the enumeration.
- *    - Realpath guards every file and channel dir against the state
- *      root so a symlink inside `sessions/` cannot surface a file
- *      from elsewhere on disk.
- */
 /** Read and validate one thread file, returning its summary or null
  *  if the file is missing, unparseable, outside the state root, or
  *  missing load-bearing fields. Log-and-skip on parse error so a
@@ -451,6 +430,27 @@ function collectChannelSummaries(
   }
 }
 
+/** Enumerate every session file under `stateRoot/sessions/` and
+ *  return a summary per (channel, thread) pair. Pure read; never
+ *  mutates, never creates, never deletes.
+ *
+ *  Contract (ccsc-xa3.9):
+ *    - Returns `SessionSummary[]` with NO body (`data` field) — the
+ *      operator sees lifecycle metadata only.
+ *    - Sorted by `lastActiveAt` descending so the most recently
+ *      active thread is row 0. Stable for ties (insertion order).
+ *    - Hard-capped at `LIST_SESSIONS_MAX` rows. Truncation is
+ *      silent at this layer; the MCP tool wrapper is responsible
+ *      for telling the operator they hit the cap.
+ *    - Tolerant to a missing `sessions/` dir — returns `[]` for a
+ *      fresh install.
+ *    - Tolerant to unparseable or malformed files — logs to
+ *      `process.stderr` and skips. A single corrupt thread does
+ *      not take down the enumeration.
+ *    - Realpath guards every file and channel dir against the state
+ *      root so a symlink inside `sessions/` cannot surface a file
+ *      from elsewhere on disk.
+ */
 export function listSessions(stateRoot: string): SessionSummary[] {
   const resolvedRoot = realpathSync.native(resolve(stateRoot))
   const sessionsDir = join(resolvedRoot, 'sessions')

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -273,8 +273,14 @@ export const DEFAULT_IDLE_MS = 4 * 60 * 60 * 1000
 
 /** Parse `SLACK_SESSION_IDLE_MS` from an env record and return a valid
  *  idle threshold in ms. Falls back to `DEFAULT_IDLE_MS` when the var
- *  is unset, empty, non-numeric, negative, or non-finite. Pure; no
- *  process.env access — caller passes the env map. */
+ *  is unset, empty, non-numeric, negative, or non-finite.
+ *
+ *  Pure *relative to the `env` argument*: parsing the record is
+ *  deterministic and side-effect-free. The default parameter value
+ *  reads `process.env` as an ergonomic fallback so the call site in
+ *  server.ts boot can write `resolveIdleMs()` without repeating the
+ *  env lookup. Tests pass an explicit record to keep the function
+ *  deterministic at the test boundary. */
 export function resolveIdleMs(
   env: Record<string, string | undefined> = process.env,
 ): number {


### PR DESCRIPTION
## Summary

Audit swept the 11 PRs merged today; found 5 unresolved Gemini review threads where \`--admin\` merge landed without resolving the comment. Two are real doc fixes; three are style/opinion nits that I'm declining with documented reasoning.

## Fixes applied

- **lib.ts (from PR #84)**: \`listSessions\` JSDoc was orphaned during the extract-helpers refactor. Moved back onto \`listSessions\`.
- **supervisor.ts (from PR #79)**: \`resolveIdleMs\` JSDoc said \"pure; no process.env access\" while the default parameter value IS \`process.env\`. Rewrote to \"pure relative to the env argument\" and documented why the default reads env.

## Declined with reasoning

| PR | Severity | Finding | Decision |
|----|----------|---------|----------|
| #76 | 🟡 M | One-liner assumes cwd=project | Accepted operator expectation; doc context already shows repo-rooted invocation |
| #81 | 🟢 L | Hoist dynamic imports in describe block | Inconsistent with surrounding test patterns |
| #82 | 🟢 L | Drop \`as string \\| undefined\` + \`\\|\\| undefined\` | Assertion narrows \`body: any\`; \`\\|\\| undefined\` normalizes \`\"\"\` to the canonical empty-thread slot |

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 370 pass / 0 fail (no behavior change)

Jeremy made me do it
-claude