### PR TITLE
fix(sendable): assertSendable state-root denylist (S1)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -775,6 +775,17 @@ export function assertSendable(
     throw new Error('Blocked: file does not exist or is not accessible')
   }
 
+  // Resolve the inbox once — used by both the state-dir denylist (to carve
+  // the inbox out of the state-root block) and the allowlist-roots check
+  // below.
+  const inboxReal = (() => {
+    try {
+      return realpathSync(resolve(inboxDir))
+    } catch {
+      return resolve(inboxDir)
+    }
+  })()
+
   // (1) State-dir denylist (S1). Production callers thread STATE_DIR through
   // from `server.ts`. This check runs BEFORE the allowlist so a state-dir
   // path that also happens to live under SLACK_SENDABLE_ROOTS is still
@@ -789,28 +800,13 @@ export function assertSendable(
         return resolve(stateRoot)
       }
     })()
-    const inboxRealForStateCheck = (() => {
-      try {
-        return realpathSync(resolve(inboxDir))
-      } catch {
-        return resolve(inboxDir)
-      }
-    })()
     if (
       isUnderRoot(real, stateRootReal) &&
-      !isUnderRoot(real, inboxRealForStateCheck)
+      !isUnderRoot(real, inboxReal)
     ) {
       throw new Error('Blocked: file path is under the state directory')
     }
   }
-
-  const inboxReal = (() => {
-    try {
-      return realpathSync(resolve(inboxDir))
-    } catch {
-      return resolve(inboxDir)
-    }
-  })()
 
   const roots: string[] = [inboxReal, ...allowlistRoots.map((r) => {
     try { return realpathSync(resolve(r)) } catch { return resolve(r) }

--- a/lib.ts
+++ b/lib.ts
@@ -729,12 +729,16 @@ export function validateSendableRoots(roots: readonly string[]): void {
  * Throws if `filePath` is not safe to hand to the Slack file-upload API.
  *
  * Policy (allowlist + denylist):
- *   1. The path must resolve (via realpath) to a location under at least one
+ *   1. If `stateRoot` is provided, the realpath of the file must NOT be under
+ *      the realpath of the state dir. This fires BEFORE the allowlist check
+ *      so an operator who configures SLACK_SENDABLE_ROOTS upstream of the
+ *      state dir still cannot exfiltrate state files (S1).
+ *   2. The path must resolve (via realpath) to a location under at least one
  *      root in `allowlistRoots`. `inboxDir` is ALWAYS implicitly included so
  *      downloaded attachments can be re-shared.
- *   2. The input path must not contain any `..` component.
- *   3. The basename must not match SENDABLE_BASENAME_DENY.
- *   4. No path component may match SENDABLE_PARENT_DENY_SINGLE, and no
+ *   3. The input path must not contain any `..` component.
+ *   4. The basename must not match SENDABLE_BASENAME_DENY.
+ *   5. No path component may match SENDABLE_PARENT_DENY_SINGLE, and no
  *      adjacent pair may match SENDABLE_PARENT_DENY_PAIRS.
  *
  * Error messages name WHICH check failed (for debugging) but never echo the
@@ -745,12 +749,13 @@ export function assertSendable(
   filePath: string,
   inboxDir: string,
   allowlistRoots: readonly string[] = [],
+  stateRoot?: string,
 ): void {
   if (typeof filePath !== 'string' || filePath.length === 0) {
     throw new Error('Blocked: file path is empty or not a string')
   }
 
-  // (2) Reject `..` BEFORE resolving — we never want to accept a path that
+  // (3) Reject `..` BEFORE resolving — we never want to accept a path that
   // the caller expressed with a traversal component, even if realpath would
   // flatten it. `resolve` collapses `..` so this must be checked on raw input.
   const rawParts = filePath.split(/[\\/]+/)
@@ -760,7 +765,7 @@ export function assertSendable(
     }
   }
 
-  // (1) Resolve via realpath to follow symlinks. If the path does not exist,
+  // (2) Resolve via realpath to follow symlinks. If the path does not exist,
   // we reject outright — there is nothing to upload anyway, and silently
   // falling back to lexical resolution would weaken the symlink check.
   let real: string
@@ -768,6 +773,35 @@ export function assertSendable(
     real = realpathSync(resolve(filePath))
   } catch {
     throw new Error('Blocked: file does not exist or is not accessible')
+  }
+
+  // (1) State-dir denylist (S1). Production callers thread STATE_DIR through
+  // from `server.ts`. This check runs BEFORE the allowlist so a state-dir
+  // path that also happens to live under SLACK_SENDABLE_ROOTS is still
+  // rejected. The inbox lives under the state dir, so we only enforce this
+  // guard for files that are NOT under the inbox (which is an explicitly
+  // sendable subdirectory).
+  if (stateRoot !== undefined && stateRoot.length > 0) {
+    const stateRootReal = (() => {
+      try {
+        return realpathSync(resolve(stateRoot))
+      } catch {
+        return resolve(stateRoot)
+      }
+    })()
+    const inboxRealForStateCheck = (() => {
+      try {
+        return realpathSync(resolve(inboxDir))
+      } catch {
+        return resolve(inboxDir)
+      }
+    })()
+    if (
+      isUnderRoot(real, stateRootReal) &&
+      !isUnderRoot(real, inboxRealForStateCheck)
+    ) {
+      throw new Error('Blocked: file path is under the state directory')
+    }
   }
 
   const inboxReal = (() => {
@@ -793,7 +827,7 @@ export function assertSendable(
     throw new Error('Blocked: file path is not under any allowlisted root')
   }
 
-  // (3) Basename denylist — evaluated on the real path's basename.
+  // (4) Basename denylist — evaluated on the real path's basename.
   const base = basename(real)
   for (const re of SENDABLE_BASENAME_DENY) {
     if (re.test(base)) {
@@ -801,7 +835,7 @@ export function assertSendable(
     }
   }
 
-  // (4) Parent-component denylist — evaluated on the real path.
+  // (5) Parent-component denylist — evaluated on the real path.
   const components = real.split(sep).filter((c) => c.length > 0)
   for (const comp of components) {
     if (SENDABLE_PARENT_DENY_SINGLE.has(comp)) {

--- a/server.test.ts
+++ b/server.test.ts
@@ -561,6 +561,103 @@ describe('assertSendable', () => {
 })
 
 // ---------------------------------------------------------------------------
+// assertSendable() — state-root denylist (S1)
+// ---------------------------------------------------------------------------
+//
+// CLAUDE.md + THREAT-MODEL.md declare that files under the state directory
+// (`.env`, `access.json`, `audit.log`, `sessions/`) must never be sendable,
+// even when an operator configures SLACK_SENDABLE_ROOTS to an ancestor of the
+// state dir. The `stateRoot` parameter realpath-resolves both sides so a
+// symlink from outside into the state dir still trips the guard.
+
+describe('assertSendable — state-root denylist', () => {
+  let root: string          // tmp root analogous to ~/.claude
+  let stateRoot: string     // tmp state dir (analogous to ~/.claude/channels/slack)
+  let inbox: string         // INBOX_DIR inside state dir
+  let sibling: string       // non-state directory used as allowlist entry
+
+  beforeAll(() => {
+    root = realpathSync.native(mkdtempSync(join(tmpdir(), 'slack-sendable-state-')))
+    stateRoot = join(root, 'state')
+    inbox = join(stateRoot, 'inbox')
+    sibling = join(root, 'other')
+
+    mkdirSync(inbox, { recursive: true })
+    mkdirSync(join(stateRoot, 'sessions', 'C123'), { recursive: true })
+    mkdirSync(sibling, { recursive: true })
+
+    writeFileSync(join(stateRoot, 'access.json'), '{}')
+    writeFileSync(join(stateRoot, 'audit.log'), 'hash-chain')
+    writeFileSync(join(stateRoot, 'sessions', 'C123', 'T456.json'), '{}')
+    writeFileSync(join(sibling, 'ok.txt'), 'fine')
+
+    // Symlink OUTSIDE state dir that points to a file INSIDE it. Used to
+    // verify the realpath flattening on the stateRoot side of the check.
+    try {
+      symlinkSync(
+        join(stateRoot, 'access.json'),
+        join(sibling, 'innocent.txt'),
+      )
+    } catch { /* some FSes don't support symlinks; test will skip */ }
+  })
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  test('blocks access.json when operator allowlists an ancestor of the state dir', () => {
+    // Operator misconfig: SLACK_SENDABLE_ROOTS includes the parent of the
+    // state dir. Without the stateRoot guard this would have succeeded.
+    expect(() =>
+      assertSendable(join(stateRoot, 'access.json'), inbox, [root], stateRoot),
+    ).toThrow('state directory')
+  })
+
+  test('blocks a file deep inside sessions/<channel>/<thread>.json', () => {
+    expect(() =>
+      assertSendable(
+        join(stateRoot, 'sessions', 'C123', 'T456.json'),
+        inbox,
+        [root],
+        stateRoot,
+      ),
+    ).toThrow('state directory')
+  })
+
+  test('blocks a symlink OUTSIDE the state dir that points INTO it', () => {
+    try {
+      require('fs').lstatSync(join(sibling, 'innocent.txt'))
+    } catch {
+      return
+    }
+    // The symlink sits in `sibling` (which is in the allowlist), but its
+    // realpath resolves inside the state dir. The guard must follow.
+    expect(() =>
+      assertSendable(
+        join(sibling, 'innocent.txt'),
+        inbox,
+        [root, sibling],
+        stateRoot,
+      ),
+    ).toThrow('state directory')
+  })
+
+  test('allows a sibling directory next to the state dir', () => {
+    expect(() =>
+      assertSendable(join(sibling, 'ok.txt'), inbox, [sibling], stateRoot),
+    ).not.toThrow()
+  })
+
+  test('legacy three-arg call (no stateRoot) preserves existing behavior', () => {
+    // Operator did NOT supply stateRoot. We keep the old allowlist semantics
+    // so existing callers / tests keep passing.
+    expect(() =>
+      assertSendable(join(sibling, 'ok.txt'), inbox, [sibling]),
+    ).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // parseSendableRoots()
 // ---------------------------------------------------------------------------
 

--- a/server.ts
+++ b/server.ts
@@ -202,7 +202,7 @@ function getAccess(): Access {
 // ---------------------------------------------------------------------------
 
 function assertSendable(filePath: string): void {
-  libAssertSendable(filePath, resolve(INBOX_DIR), SENDABLE_ROOTS)
+  libAssertSendable(filePath, resolve(INBOX_DIR), SENDABLE_ROOTS, STATE_DIR)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`CLAUDE.md` and [`000-docs/THREAT-MODEL.md`](../blob/main/000-docs/THREAT-MODEL.md) declare that files under the state directory (`.env`, `access.json`, `audit.log`, `sessions/`) must never be sendable through the Slack upload path. The code did not enforce this — `assertSendable()` only checked an allowlist plus a basename/parent denylist. An operator who set `SLACK_SENDABLE_ROOTS` to any ancestor of `~/.claude/channels/slack` (e.g. `~/.claude`) could exfiltrate `access.json` and `audit.log` through the `reply` tool. The `.env` regex happened to catch that one bare filename by basename; nothing else in the state dir was protected.

## Fix

`assertSendable()` in `lib.ts` gains an optional `stateRoot` parameter. When supplied, we realpath-resolve both the file and the state root and reject whenever the file resolves under the state root (unless it's under the inbox, which is explicitly sendable). The state-dir check runs **before** the allowlist check so an operator-supplied allowlist cannot override the state-root denylist.

`server.ts` threads `STATE_DIR` through the `libAssertSendable` wrapper. There is one wrapper and one real call site (the `reply` tool handler); both are now guarded.

## Threat model pointer

Covers exfiltration of state-directory artifacts that `000-docs/THREAT-MODEL.md` lists under the file-upload surface — aligns code with the doc contract called out in CLAUDE.md ("when a design doc and code disagree, the code is wrong").

## New tests

Added under `describe('assertSendable — state-root denylist', ...)` in `server.test.ts`:

- `blocks access.json when operator allowlists an ancestor of the state dir` — direct misconfig, the exact exploit described above.
- `blocks a file deep inside sessions/<channel>/<thread>.json` — per-thread session files.
- `blocks a symlink OUTSIDE the state dir that points INTO it` — realpath flattens the link before comparison.
- `allows a sibling directory next to the state dir` — does not over-block.
- `legacy three-arg call (no stateRoot) preserves existing behavior` — existing callers keep passing.

## Verification

- `bun run typecheck` clean.
- `bun test` — 375 pass / 0 fail (baseline ~370, +5 new).
- `grep -n "assertSendable(" server.ts` shows both call sites; the `libAssertSendable` wrapper passes `STATE_DIR` as the fourth argument.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test`
- [ ] CI Typecheck + test suite green on PR

Closes ccsc-nes

Jeremy made me do it
-claude