### PR TITLE
fix(session): Zod schema validation in loadSession (S4)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -11,6 +11,7 @@
 import { resolve, sep, basename, join } from 'path'
 import { realpathSync, mkdirSync, readdirSync, readFileSync, statSync, existsSync } from 'fs'
 import { writeFile, chmod, rename, unlink, readFile } from 'fs/promises'
+import { z } from 'zod'
 
 // ---------------------------------------------------------------------------
 // Constants (re-exported so server.ts and tests share the same values)
@@ -123,6 +124,32 @@ export interface Session {
    *  32-A tests treat this field as an arbitrary object. */
   data: Record<string, unknown>
 }
+
+/** Zod schema mirroring the `Session` interface.
+ *
+ *  Used by `loadSession` to validate untrusted on-disk content before it
+ *  reaches the supervisor. `.strict()` means unknown top-level keys are
+ *  rejected — the writer controls this file; anything unexpected is
+ *  grounds for a Quarantined transition.
+ *
+ *  Export allows tests to build valid fixtures via `SessionSchema.parse()`
+ *  and gives `saveSession` a cheap sanity-check path in a future PR.
+ */
+export const SessionSchema = z
+  .object({
+    v: z.literal(1),
+    key: z
+      .object({
+        channel: z.string(),
+        thread: z.string(),
+      })
+      .strict(),
+    createdAt: z.number(),
+    lastActiveAt: z.number(),
+    ownerId: z.string(),
+    data: z.record(z.unknown()),
+  })
+  .strict()
 
 /** Component validator for session path segments.
  *
@@ -275,10 +302,10 @@ export async function saveSession(path: string, session: Session): Promise<void>
  *  - JSON.parse errors propagate unchanged. No silent recovery;
  *    malformed session files are loud failures.
  *
- *  This function does NOT schema-validate the parsed object against the
- *  `Session` shape. The writer (saveSession) is trusted to produce valid
- *  content; runtime schema validation is a separate concern (a Zod
- *  schema for Session would live with the type).
+ *  Schema-validates via `SessionSchema` (Zod, `.strict()`); malformed or
+ *  tampered files surface as a `ZodError` and cause the supervisor to
+ *  Quarantine the key. Unknown top-level fields are rejected — the writer
+ *  controls this file; anything unexpected is treated as corruption.
  *
  *  **Fail-closed posture.** Any throw here should drop the event (the
  *  supervisor Quarantines the key); it must never degrade to a partial
@@ -296,7 +323,8 @@ export async function loadSession(root: string, path: string): Promise<Session> 
     )
   }
   const raw = await readFile(resolvedFile, 'utf8')
-  return JSON.parse(raw) as Session
+  const parsed = JSON.parse(raw)
+  return SessionSchema.parse(parsed)
 }
 
 /** Minimal introspection record per session file. Intentionally NOT

--- a/server.test.ts
+++ b/server.test.ts
@@ -24,6 +24,7 @@ import {
   MAX_PENDING,
   MAX_PAIRING_REPLIES,
   PAIRING_EXPIRY_MS,
+  SessionSchema,
   type Access,
   type GateOptions,
   type Session,
@@ -1566,6 +1567,83 @@ describe('loadSession', () => {
     expect(loadedB.ownerId).toBe('U_B')
     expect(loadedA.key.thread).toBe('TA.0')
     expect(loadedB.key.thread).toBe('TB.0')
+  })
+
+  // -------------------------------------------------------------------------
+  // S4 trust-boundary tests: Zod schema validation in loadSession
+  // -------------------------------------------------------------------------
+
+  test('S4: valid session round-trips cleanly via saveSession + loadSession', async () => {
+    // Full round-trip through the real save/load path — confirms
+    // SessionSchema accepts the canonical shape written by saveSession.
+    const key = { channel: 'C_S4_RT', thread: '1700000000.000200' }
+    const p = sessionPath(tmpRoot, key)
+    const s = makeSession(key.channel, key.thread)
+
+    await saveSession(p, s)
+    const loaded = await loadSession(tmpRoot, p)
+
+    expect(loaded).toEqual(s)
+  })
+
+  test('S4: corrupt-type rejection — ownerId as number throws ZodError', async () => {
+    // ownerId: 42 (number) violates the string constraint. This is the
+    // attack described in the S4 plan: a tampered file with wrong types
+    // previously passed `as Session` and reached the supervisor silently.
+    const p = sessionPath(tmpRoot, { channel: 'C_S4_TYPE', thread: 'T1.0' })
+    const corrupt = {
+      v: 1,
+      key: { channel: 'C_S4_TYPE', thread: 'T1.0' },
+      createdAt: 1_700_000_000_000,
+      lastActiveAt: 1_700_000_001_000,
+      ownerId: 42, // wrong type
+      data: {},
+    }
+    writeFileSync(p, JSON.stringify(corrupt), { mode: 0o600 })
+
+    await expect(loadSession(tmpRoot, p)).rejects.toThrow()
+  })
+
+  test('S4: missing required field (channel inside key) throws ZodError', async () => {
+    const p = sessionPath(tmpRoot, { channel: 'C_S4_MISS', thread: 'T1.0' })
+    const missing = {
+      v: 1,
+      key: { thread: 'T1.0' }, // channel omitted
+      createdAt: 1_700_000_000_000,
+      lastActiveAt: 1_700_000_001_000,
+      ownerId: 'U_OWNER',
+      data: {},
+    }
+    writeFileSync(p, JSON.stringify(missing), { mode: 0o600 })
+
+    await expect(loadSession(tmpRoot, p)).rejects.toThrow()
+  })
+
+  test('S4: unknown top-level key throws ZodError (strict mode enforced)', async () => {
+    // .strict() on SessionSchema means any field not in the type contract
+    // is an error — guards against schema-drift where a new field is added
+    // to the writer but forgotten in the schema.
+    const p = sessionPath(tmpRoot, { channel: 'C_S4_UNK', thread: 'T1.0' })
+    const extraKey = {
+      v: 1,
+      key: { channel: 'C_S4_UNK', thread: 'T1.0' },
+      createdAt: 1_700_000_000_000,
+      lastActiveAt: 1_700_000_001_000,
+      ownerId: 'U_OWNER',
+      data: {},
+      injected: 'evil_payload', // unknown key
+    }
+    writeFileSync(p, JSON.stringify(extraKey), { mode: 0o600 })
+
+    await expect(loadSession(tmpRoot, p)).rejects.toThrow()
+  })
+
+  test('S4: non-JSON bytes throw before Zod validation (JSON.parse fires first)', async () => {
+    // Confirms JSON.parse still throws on garbage input — Zod never sees it.
+    const p = sessionPath(tmpRoot, { channel: 'C_S4_JSON', thread: 'T1.0' })
+    writeFileSync(p, '\x00\x01\x02 not json }{', { mode: 0o600 })
+
+    await expect(loadSession(tmpRoot, p)).rejects.toThrow()
   })
 })
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -43,6 +43,7 @@ import {
   existsSync,
   readdirSync,
 } from 'fs'
+import { writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join, sep } from 'path'
 
@@ -1599,7 +1600,7 @@ describe('loadSession', () => {
       ownerId: 42, // wrong type
       data: {},
     }
-    writeFileSync(p, JSON.stringify(corrupt), { mode: 0o600 })
+    await writeFile(p, JSON.stringify(corrupt), { mode: 0o600 })
 
     await expect(loadSession(tmpRoot, p)).rejects.toThrow()
   })
@@ -1614,7 +1615,7 @@ describe('loadSession', () => {
       ownerId: 'U_OWNER',
       data: {},
     }
-    writeFileSync(p, JSON.stringify(missing), { mode: 0o600 })
+    await writeFile(p, JSON.stringify(missing), { mode: 0o600 })
 
     await expect(loadSession(tmpRoot, p)).rejects.toThrow()
   })
@@ -1633,7 +1634,7 @@ describe('loadSession', () => {
       data: {},
       injected: 'evil_payload', // unknown key
     }
-    writeFileSync(p, JSON.stringify(extraKey), { mode: 0o600 })
+    await writeFile(p, JSON.stringify(extraKey), { mode: 0o600 })
 
     await expect(loadSession(tmpRoot, p)).rejects.toThrow()
   })
@@ -1641,7 +1642,7 @@ describe('loadSession', () => {
   test('S4: non-JSON bytes throw before Zod validation (JSON.parse fires first)', async () => {
     // Confirms JSON.parse still throws on garbage input — Zod never sees it.
     const p = sessionPath(tmpRoot, { channel: 'C_S4_JSON', thread: 'T1.0' })
-    writeFileSync(p, '\x00\x01\x02 not json }{', { mode: 0o600 })
+    await writeFile(p, '\x00\x01\x02 not json }{', { mode: 0o600 })
 
     await expect(loadSession(tmpRoot, p)).rejects.toThrow()
   })


### PR DESCRIPTION
Part of the v0.5.1 Batch 1 multi-agent orchestration — lib.ts also touched by PR #86 (S1) in disjoint function `assertSendable`.

## Summary

- `loadSession` previously returned `JSON.parse(raw) as Session` — a cast, not validation. A corrupt or tampered session file with wrong types (e.g. `ownerId: 42`) passed load silently and reached the supervisor, which trusts `ownerId: string` for audit attribution.
- Added `SessionSchema` (Zod, `.strict()`) mirroring the `Session` interface and exported it. Unknown top-level keys are rejected — the writer controls this file; anything unexpected is treated as corruption.
- Updated the doc comment that previously admitted "does NOT schema-validate" to reflect the new reality: ZodError propagates, supervisor Quarantines the key.

## Trust-boundary rationale

The session file is written by `saveSession` (trusted) but lives on disk at a path guarded only by realpath containment. An attacker who can write to the state directory can corrupt the file with wrong types. Without schema validation, `ownerId: 42` or a missing `channel` field would silently reach the supervisor as a partially-typed `Session`. With `SessionSchema.parse()`, any deviation from the contract throws before the supervisor sees the data.

## Tests

Five new tests in the `loadSession` describe block (`server.test.ts`):

1. **Valid round-trip** — `saveSession` → `loadSession` returns identical content (confirms `SessionSchema` accepts the canonical shape).
2. **Corrupt-type rejection** — `ownerId: 42` (number) throws.
3. **Missing required field** — `key.channel` omitted throws.
4. **Unknown top-level key** — extra field throws (`.strict()` enforced).
5. **Non-JSON bytes** — garbage input throws (`JSON.parse` fires before Zod).

Test delta: 370 → 375 (5 new, 0 failures).

Closes ccsc-6j2

Jeremy made me do it
-claude