### PR TITLE
docs: sync README + Pages to v0.5.0 (kills 3-way drift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# claude-code-slack-channel v0.4.0
+# claude-code-slack-channel v0.5.0
 
-Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channels, just like you'd chat in the terminal.
+Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channels, just like you'd chat in the terminal. Per-thread session isolation, hash-chained tamper-evident audit journal, policy-gated tools, five-layer prompt-injection defense.
 
 [![CI](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml/badge.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jeremylongshore/claude-code-slack-channel/badge)](https://scorecard.dev/viewer/?uri=github.com/jeremylongshore/claude-code-slack-channel)
 
-**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.4.0)
+**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.0)
 
 > **Research Preview** — Channels require Claude Code v2.1.80+ and `claude.ai` login.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
-# claude-code-slack-channel v0.4.0
+# claude-code-slack-channel v0.5.0
 
-Two-way Slack channel for the Claude Code — chat from Slack DMs and channels, approve tool calls from your phone.
+Two-way Slack channel for Claude Code — chat from Slack DMs and channels, approve tool calls from your phone.
 
-A `claude/channel` implementation for Slack. Uses Socket Mode (outbound WebSocket, no public URL) to bridge Slack messages into a running Claude Code session via MCP stdio. Permission relay with Block Kit buttons lets you approve or deny Claude Code tool calls remotely. Seven defense layers prevent prompt injection, token exfiltration, and unauthorized access. Three runtime options: Bun, Node.js, Docker.
+A `claude/channel` implementation for Slack. Socket Mode (outbound WebSocket, no public URL) bridges Slack into a running Claude Code session via MCP stdio. Permission relay with Block Kit buttons, per-thread session isolation, hash-chained tamper-evident audit journal, policy-gated MCP tools, and a five-layer prompt-injection defense. Three runtime options: Bun, Node.js, Docker.
 
 [![CI](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml/badge.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jeremylongshore/claude-code-slack-channel/badge)](https://scorecard.dev/viewer/?uri=github.com/jeremylongshore/claude-code-slack-channel)
 
-**Links:** [GitHub](https://github.com/jeremylongshore/claude-code-slack-channel) · [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.4.0)
+**Links:** [GitHub](https://github.com/jeremylongshore/claude-code-slack-channel) · [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.0)
 
 ---
 
@@ -22,19 +22,19 @@ Anthropic shipped channels for Telegram and Discord, but not yet for Slack — t
 
 ### The Solution
 
-A two-file MCP server (~1000 lines in `server.ts` for stateful wiring, ~460 lines in `lib.ts` for pure functions) that connects Slack to Claude Code bidirectionally. Inbound messages arrive via Socket Mode (Slack's outbound WebSocket — no public URL, works behind any firewall). Outbound replies go through the Slack Web API. **Permission prompts** render as Block Kit messages with Allow/Deny/Details buttons — tap your phone to approve a tool call from anywhere.
+A two-file MCP server (`server.ts` ~1100 lines of stateful wiring, `lib.ts` ~915 lines of pure functions) that connects Slack to Claude Code bidirectionally. Inbound messages arrive via Socket Mode (Slack's outbound WebSocket — no public URL, works behind any firewall). Outbound replies go through the Slack Web API. **Permission prompts** render as Block Kit messages with Allow/Deny/Details buttons — tap your phone to approve a tool call from anywhere.
 
-Security is defense-in-depth: inbound gate drops ungated messages before MCP, outbound gate restricts replies, file exfiltration guard blocks state directory leaks, owner-only approval ensures only the session owner can approve tool calls, and system prompt hardening tells Claude to refuse manipulation attempts from messages.
+Security is defense-in-depth: inbound gate drops ungated messages before MCP, outbound gate restricts replies to delivered (channel, thread) pairs, file exfiltration guard blocks state-directory leaks (including sibling-path misconfigurations), system prompt hardening tells Claude to refuse manipulation attempts from messages, and tokens are locked down (0o600, atomic writes, never logged). Every security-relevant event appends to a hash-chained audit journal for tamper-evident forensics.
 
 ### Who / What / Where / When / Why
 
 | Aspect | Details |
 |--------|---------|
 | **Who** | Developers using Claude Code who collaborate via Slack |
-| **What** | MCP channel server — pushes Slack events into Claude Code sessions, replies back, relays permission prompts |
+| **What** | MCP channel server — pushes Slack events into Claude Code sessions, replies back, relays permission prompts, isolates state per thread |
 | **Where** | Runs locally (your machine), connects to Slack via Socket Mode WebSocket |
 | **When** | AFK coding — approve tool calls from your phone, review PRs from the couch, pair with Claude from any device with Slack |
-| **Why** | Only Slack channel for Claude Code. Permission relay with Block Kit. No public URL. Seven security layers. |
+| **Why** | Only Slack channel for Claude Code. Permission relay with Block Kit. No public URL. Five-layer prompt-injection defense. Tamper-evident audit journal. |
 
 ### Stack
 
@@ -44,16 +44,18 @@ Security is defense-in-depth: inbound gate drops ungated messages before MCP, ou
 | Protocol | MCP (stdio) | Standard Claude Code channel transport |
 | Connection | @slack/socket-mode v2 | Outbound WebSocket to Slack — no public URL |
 | API | @slack/web-api v7 | Send messages, upload files, add reactions, Block Kit interactions |
-| Validation | zod v3 | Schema validation for permission relay protocol |
-| Security | Custom gate + allowlist | 7-layer defense: inbound gate, outbound gate, owner-only approval, exfiltration guard, symlink resolution, mrkdwn escaping, token lockdown |
+| Validation | zod v3 | Schema validation for permission relay + audit journal |
+| Security | Custom gate + allowlist + policy engine | 5-layer defense: inbound gate, outbound gate, exfiltration guard, system prompt hardening, token lockdown |
+| Auditability | Hash-chained append-only journal | Tamper-evident log of every gate decision, policy evaluation, and session transition |
 
 ### Key Differentiators
 
 1. **Permission relay** — Approve/deny Claude Code tool calls remotely via Slack (Block Kit buttons or text fallback)
 2. **No public URL** — Socket Mode means outbound-only WebSocket, works behind firewalls and NAT
-3. **Defense-in-depth security** — 7 layers hardened via community security review (v0.3.0)
-4. **Three runtime options** — Bun (fastest), Node.js/npx (universal), Docker (isolated)
-5. **Upstream-ready** — matches `anthropics/claude-plugins-official` patterns exactly (MIT, same structure as Discord/Telegram)
+3. **Tamper-evident audit journal** — Every security-relevant event hash-chained on disk for forensics
+4. **Per-thread session isolation** — Each Slack thread gets its own state file, supervisor, and policy scope
+5. **Five-layer prompt-injection defense** — Hardened via community security review + frozen-lockfile dependencies
+6. **Three runtime options** — Bun (fastest), Node.js/npx (universal), Docker (isolated)
 
 ---
 
@@ -61,13 +63,15 @@ Security is defense-in-depth: inbound gate drops ungated messages before MCP, ou
 
 ### Executive Summary
 
-claude-code-slack-channel is a production-oriented MCP server that bridges Slack workspaces to Claude Code sessions. The implementation is split across `server.ts` (~1000 lines of stateful runtime wiring) and `lib.ts` (~460 lines of pure, testable functions). Two skill files handle configuration and access management. Four dependencies (`@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`) — no frameworks, no middleware, no build step for Bun.
+claude-code-slack-channel is a production-oriented MCP server that bridges Slack workspaces to Claude Code sessions. The implementation is split across `server.ts` (~1100 lines of stateful runtime wiring) and `lib.ts` (~915 lines of pure, testable functions), with `policy.ts`, `journal.ts`, and `supervisor.ts` providing the policy engine, audit log, and session state machine. Four runtime dependencies (`@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`) — no frameworks, no middleware, no build step for Bun.
 
-**v0.4.0** adds per-channel cross-bot message delivery via `allowBotIds` (#33 — @CaseyMargell). Multi-agent coordination: channels can opt in to receiving messages from specific peer bots (e.g., ops-monitor and engineering bots in `#incidents`). Default-safe — absent or empty `allowBotIds` preserves the "all bot messages dropped" behavior. Self-echo detection uses a triple-check (`bot_id`, `bot_profile.app_id`, `user`) to cover Slack payload variants. The test suite grew to 104 tests.
+**v0.5.0** lands the big-picture redesign: per-thread session isolation (`sessions/<channel>/<thread>.json`), hash-chained tamper-evident audit journal (`journal.ts`), policy engine with monotonicity invariant + shadow-rule linter (`policy.ts`), thread-scoped outbound gate, thread-scoped pairing key, and the `slack/list_sessions` MCP tool. Supervisor and reaper live in `supervisor.ts` as an instantiated library ready for wiring in v0.5.1. ~370 tests.
 
-**v0.3.1** is a patch release with two community bug fixes: clean MCP server shutdown on client disconnect (#7 — @jinsung-kang) and deduplication of dual-fire events when a message is both a `message` and `app_mention` (#8 — @CaseyMargell). The release also lands governance scaffolding (CODEOWNERS, SECURITY.md, CONTRIBUTING.md), Gemini PR review, CodeQL, and OpenSSF Scorecard.
+**v0.4.0** added per-channel cross-bot message delivery via `allowBotIds` (#33 — @CaseyMargell). Multi-agent coordination: channels can opt in to receiving messages from specific peer bots (e.g., ops-monitor and engineering bots in `#incidents`). Default-safe — absent or empty `allowBotIds` preserves the "all bot messages dropped" behavior. Self-echo detection uses a triple-check (`bot_id`, `bot_profile.app_id`, `user`) to cover Slack payload variants.
 
-**v0.3.0** hardened the security model via a seven-vulnerability review from @maui-99: restrictive file sendable policy with symlink resolution, outbound gate enforcement on all reply paths, display-name sanitization against prompt injection, atomic `access.json` writes with 0o600, Slack file URL validation, and frozen-lockfile dependency pinning. The test suite grew from 52 to 86 tests in v0.3.0, then to 95 tests in v0.3.1, then to 104 tests in v0.4.0.
+**v0.3.1** shipped two community bug fixes: clean MCP server shutdown on client disconnect (#7 — @jinsung-kang) and deduplication of dual-fire events (#8 — @CaseyMargell). Governance scaffolding (CODEOWNERS, SECURITY.md, CONTRIBUTING.md), Gemini PR review, CodeQL, and OpenSSF Scorecard.
+
+**v0.3.0** hardened the security model via a seven-vulnerability review from @maui-99: restrictive file sendable policy with symlink resolution, outbound gate enforcement on all reply paths, display-name sanitization against prompt injection, atomic `access.json` writes with 0o600, Slack file URL validation, and frozen-lockfile dependency pinning.
 
 ### Technology Stack
 
@@ -77,7 +81,7 @@ claude-code-slack-channel is a production-oriented MCP server that bridges Slack
 | Protocol | @modelcontextprotocol/sdk | 1.27.x | MCP server + stdio transport |
 | Connection | @slack/socket-mode | 2.0.x | Outbound WebSocket to Slack (no public URL) |
 | API | @slack/web-api | 7.15.x | Slack REST API (messages, files, reactions, interactions) |
-| Validation | zod | 3.25.x | Schema validation for permission relay |
+| Validation | zod | 3.25.x | Schema validation for permission relay + audit journal events |
 | Language | TypeScript | 5.9.x | Strict mode, type-checked |
 | Container | Docker (oven/bun:1-slim) | — | Optional isolated runtime |
 
@@ -86,7 +90,7 @@ claude-code-slack-channel is a production-oriented MCP server that bridges Slack
 ```
 Slack workspace (cloud)
     ↕ WebSocket (Socket Mode — outbound only, no public URL)
-server.ts + lib.ts (local MCP server, spawned by Claude Code)
+server.ts + lib.ts + policy.ts + journal.ts + supervisor.ts (local MCP server)
     ↕ stdio (MCP transport)
 Claude Code session
 ```
@@ -97,22 +101,22 @@ Socket Mode means **no public URL needed** — works behind firewalls, NAT, anyw
 
 | Layer | Function | Implementation |
 |-------|----------|----------------|
-| Inbound Gate | Drop unauthorized messages | `gate()` checks `allowFrom` and channel opt-in |
-| Outbound Gate | Restrict reply targets | `assertOutboundAllowed()` checks delivered channels |
-| Owner-Only Approval | Only session owner can approve tools | Button + text paths verify `access.allowFrom` |
-| File Exfiltration Guard | Block state file uploads | `assertSendable()`: allowlist roots + basename/parent denylist + symlink resolution |
-| mrkdwn Escaping | Prevent Slack injection | `escMrkdwn()` neutralizes `<`, `>`, `&` and sanitizes display names |
-| Slack URL Validation | Block token exfiltration via crafted URLs | `isSlackFileUrl()` validates host allowlist |
+| Inbound Gate | Drop unauthorized messages | `gate()` checks `allowFrom` and channel opt-in; bot messages dropped by default with per-channel `allowBotIds` opt-in |
+| Outbound Gate | Restrict reply targets | `assertOutboundAllowed()` gates on `(channel, thread_ts)` delivered pairs |
+| File Exfiltration Guard | Block state-directory uploads | `assertSendable()`: allowlist roots + basename/parent denylist + state-root denylist + symlink resolution |
+| System Prompt Hardening | Refuse manipulation in messages | Peer-bot messages flagged as same-risk as human |
 | Token Security | Protect credentials | 0o600 permissions, atomic writes, never logged |
+
+Every security-relevant event (gate drops, policy decisions, session transitions, pairing events) appends to a hash-chained audit journal (`audit.log`) with per-event fsync. A broken chain fails loud; `verifyJournal()` validates integrity at any time.
 
 ### Quality Metrics
 
 | Metric | Value |
 |--------|-------|
-| Test Coverage | 95 tests, security-critical functions |
+| Test Coverage | ~370 tests, security-critical functions |
 | TypeScript | Strict mode, zero errors |
 | Dependencies | 4 production deps |
-| Lines of Code | ~1460 total (server.ts ~1000 + lib.ts ~460) |
+| Lines of Code | ~2000 total (`server.ts` ~1100 + `lib.ts` ~915, plus `policy.ts` / `journal.ts` / `supervisor.ts`) |
 | CI | GitHub Actions — typecheck, test, CodeQL, Gemini review, OpenSSF Scorecard |
 | Default DM Policy | `allowlist` (restrictive) — explicit user approval required |
 
@@ -120,18 +124,20 @@ Socket Mode means **no public URL needed** — works behind firewalls, NAT, anyw
 
 **What's Working**
 - Full MCP server with `claude/channel` + `claude/channel/permission` capabilities
-- 7 tools: `reply`, `react`, `edit_message`, `fetch_messages`, `download_attachment`, permission approval paths
-- Complete security architecture: 7 defense layers, all unit-tested
-- Pairing flow with 6-char codes, 1-hour expiry, max 3 pending, max 2 replies
-- Channel opt-in with optional mention requirement and per-channel allowlists
+- Per-thread session isolation — each Slack thread gets its own state file and policy scope
+- Hash-chained tamper-evident audit journal with `verifyJournal()` integrity check
+- Policy engine with monotonicity invariant + shadow-rule linter
+- Thread-scoped outbound gate and thread-scoped pairing codes (6-char, 1-hour expiry)
+- `slack/list_sessions` MCP tool for operator introspection
+- Bot manifest scaffolding — advertisements are not grants
+- Channel opt-in with optional mention requirement and per-channel peer-bot allowlists
 - Static mode for restricted deployments (`SLACK_ACCESS_MODE=static`)
 - Three runtime options (Bun, Node.js, Docker)
-- Clean typecheck, 95 passing tests
 - Governance: CODEOWNERS, SECURITY.md, PR template, branch protection, Dependabot
 
-**Roadmap**
-- Dedup cache scaling improvements (tracked in #11)
-- Expanded test coverage for rare edge cases
+**Roadmap (v0.5.1)**
+- Wire supervisor + journal event emission into the server hot path (currently library-only)
+- `SessionHandle.update()` mutex-serialized state mutation
 - Upstream PR to `anthropics/claude-plugins-official`
 
 ### Quick Reference
@@ -139,8 +145,8 @@ Socket Mode means **no public URL needed** — works behind firewalls, NAT, anyw
 - **Repo:** [github.com/jeremylongshore/claude-code-slack-channel](https://github.com/jeremylongshore/claude-code-slack-channel)
 - **CI:** Passing (GitHub Actions — typecheck, test, CodeQL, Gemini review, Scorecard)
 - **License:** MIT
-- **Latest Release:** [v0.4.0](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.4.0) (2026-04-18)
-- **Test Coverage:** 104 tests covering security-critical functions
+- **Latest Release:** [v0.5.0](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.0)
+- **Test Coverage:** ~370 tests covering security-critical functions
 - **Docs:** [Anthropic Channels Reference](https://docs.anthropic.com/en/docs/claude-code/channels) · [Plugin Spec](https://docs.anthropic.com/en/docs/claude-code/plugins)
 
 ### Contributors


### PR DESCRIPTION
## Summary

Fixes public-facing drift that external readers were calling out:

| Surface | Was | Now |
|---------|-----|-----|
| Gist (`2bef9c6...`) | v0.3.1, 7 layers, ~1000/~460 LoC, 95 tests | synced (via `gh gist edit`, after merge) |
| `docs/index.md` (Pages) | v0.4.0, 7 layers, 104 tests | **v0.5.0, 5 layers, ~370 tests** |
| `README.md` | v0.4.0, release link to v0.4.0 | **v0.5.0, release link to v0.5.0** |
| `package.json` / tag | v0.5.0 | truth (unchanged) |

## What changed

- Title and release-notes link: `v0.4.0` → `v0.5.0`.
- Line counts: `server.ts` ~1000 → ~1100, `lib.ts` ~460 → ~915.
- Defense layers: `Seven` → `Five` — drops `mrkdwn escaping` and `symlink resolution` as separate layers (they're techniques inside the exfil guard / display path per `CLAUDE.md`). Matches the five listed in `CLAUDE.md §Security Architecture`.
- Test count: `~104` → `~370`.
- Adds the v0.5.0 feature surface in the one-pager + operator audit:
  - Per-thread session isolation (`sessions/<channel>/<thread>.json`)
  - Hash-chained tamper-evident audit journal (`journal.ts`, Epic 30-A)
  - Policy engine with monotonicity + shadow-rule linter (`policy.ts`, Epic 29-A)
  - Thread-scoped outbound gate (ccsc-xa3.6)
  - Thread-scoped pairing key (ccsc-xa3.7)
  - `slack/list_sessions` MCP tool (ccsc-xa3.9)
  - Bot manifest scaffolding (Epic 31-A)
- Adds v0.5.1 roadmap note (wire supervisor + journal events into hot path).

## Gist

Gist `2bef9c6...` will be updated with the same content as `docs/index.md` immediately after this merges. No code change required — `gh gist edit` handles it.

## Test plan

- [x] `bun run typecheck` clean (no code touched)
- [x] Visual diff: README + Pages + Gist will be identical on the one-pager facts
- [ ] Post-merge: Pages rebuilds from `/docs` on main; verify `jeremylongshore.github.io/claude-code-slack-channel/` shows v0.5.0
- [ ] Post-merge: gist synced via `gh gist edit`

Jeremy made me do it
-claude