### PR TITLE
fix(journal): broken-flag guard + schema parse ordering (S2, S3)

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -458,9 +458,40 @@ export class JournalWriter {
   }
 
   private async _doWrite(input: WriteInput): Promise<JournalEvent> {
+    // S2: guard broken state at the top of _doWrite so calls that were
+    // already enqueued before the break are also rejected. The enqueue-time
+    // check in writeEvent() catches fresh calls; this check catches calls
+    // that raced in before broken was set and are now draining the queue.
+    if (this.broken) {
+      throw new Error(
+        `JournalWriter is broken after a prior write failure: ${this.broken.message}`,
+      )
+    }
     if (this.fh === null) {
       throw new Error('JournalWriter._doWrite: writer closed mid-queue')
     }
+
+    // S3: validate caller-supplied fields BEFORE redaction/truncation and
+    // BEFORE hash computation. A ZodError on bad input must propagate
+    // without advancing seq/lastHash and without touching this.broken —
+    // bad input is a caller bug, not a writer failure; the writer remains
+    // usable for the next call. Ordering invariant: validate → redact →
+    // truncate → build partial → hash → post-hash sanity parse → write.
+    //
+    // We validate only the caller-supplied fields (WriteInput) here.
+    // The writer-assigned framing fields (v, ts, seq, prevHash, hash) are
+    // not yet available, so we cannot parse the full JournalEvent shape.
+    // The post-hash JournalEvent.parse below remains as a cheap sanity
+    // check that the writer assembled the full event correctly.
+    const WriteInputShape = JournalEvent.omit({
+      v: true,
+      ts: true,
+      seq: true,
+      prevHash: true,
+      hash: true,
+    })
+    WriteInputShape.parse(input)
+
     // Redact token-shaped values BEFORE hashing so the on-disk bytes,
     // the hash chain, and the journal the operator inspects all agree.
     // Surgical per audit-journal-architecture.md §183-184: only `input`
@@ -487,9 +518,10 @@ export class JournalWriter {
     const hash = sha256Hex(this.lastHash + canonicalJson(partial))
     const event: JournalEvent = { ...partial, hash }
 
-    // Validate through the schema at the boundary. Catches caller-
-    // supplied fields that violate the strict schema (unknown keys,
-    // malformed types) before they land on disk and desync the chain.
+    // Post-hash sanity check: the full assembled event must pass the strict
+    // JournalEvent schema. This is a belt-and-suspenders check after the
+    // pre-hash WriteInput validation above — it catches writer-side bugs
+    // (e.g. a framing field assembled incorrectly) rather than caller bugs.
     JournalEvent.parse(event)
 
     const line = JSON.stringify(event) + '\n'

--- a/server.test.ts
+++ b/server.test.ts
@@ -3980,6 +3980,136 @@ describe('JournalWriter', () => {
       await w.close()
     }
   })
+
+  // -------------------------------------------------------------------------
+  // S2 + S3 regression tests (ccsc-z09)
+  // -------------------------------------------------------------------------
+
+  test('S2: queue-after-broken — second enqueued call rejects with broken-state error', async () => {
+    // Two calls fired concurrently. The first will hit a broken file
+    // descriptor (closed before writing). The second is already in the
+    // queue. After the first fails and sets this.broken, the second
+    // must NOT succeed — it must also reject with the "JournalWriter is
+    // broken" message, not silently write a valid event.
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+
+    // Force-close the underlying file handle without going through
+    // w.close() so the writer's fh is left non-null but the fd is dead.
+    // writeEvent still enqueues normally; the fh.write() inside _doWrite
+    // will throw, setting this.broken.
+    const fhAny = (w as unknown as Record<string, unknown>).fh as {
+      close: () => Promise<void>
+    }
+    await fhAny.close()
+
+    // Fire two writes without awaiting between them so both land in the
+    // queue before the first one resolves. Use allSettled so neither
+    // rejection is "unhandled" while the other is being awaited.
+    const [r1, r2] = await Promise.allSettled([
+      w.writeEvent(sysBoot),
+      w.writeEvent({ kind: 'session.activate' }),
+    ])
+
+    // First write must fail (dead fd).
+    expect(r1.status).toBe('rejected')
+
+    // Second write, draining after the first has set this.broken, must
+    // also reject specifically with the broken-state message — not
+    // succeed, and not throw a raw I/O error.
+    expect(r2.status).toBe('rejected')
+    if (r2.status === 'rejected') {
+      expect(String(r2.reason)).toMatch(/JournalWriter is broken/)
+    }
+  })
+
+  test('S3: ZodError is retryable — bad input does not mark writer broken', async () => {
+    // A caller supplying an invalid event kind gets a ZodError.
+    // That is a caller mistake, not a write-layer failure. The writer
+    // must NOT set this.broken; a subsequent valid writeEvent must
+    // succeed and headHash must not change after the bad call.
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      const hashBefore = w.headHash
+
+      // Bad input — invalid kind is rejected by the pre-hash schema check.
+      await expect(
+        w.writeEvent({ kind: 'bad.kind.that.does.not.exist' as never }),
+      ).rejects.toThrow()
+
+      // headHash must be unchanged — the bad call must not have advanced
+      // the hash chain.
+      expect(w.headHash).toBe(hashBefore)
+
+      // Writer is NOT broken — the next valid call must succeed.
+      const ev = await w.writeEvent(sysBoot)
+      expect(ev.seq).toBe(1)
+      expect(ev.prevHash).toBe(stableAnchor)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('S3: ZodError does not advance nextSequenceNumber', async () => {
+    // seq must not increment when the caller supplies bad input.
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      expect(w.nextSequenceNumber).toBe(1)
+
+      await expect(
+        w.writeEvent({ kind: 'not.valid' as never }),
+      ).rejects.toThrow()
+
+      // Seq must still be 1 — the bad call must not have consumed a
+      // sequence number before failing.
+      expect(w.nextSequenceNumber).toBe(1)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('S2: fs.write error marks broken — next writeEvent rejects with broken-state error', async () => {
+    // A genuine I/O failure (write syscall throws) must flip this.broken.
+    // All subsequent writeEvent calls — whether already queued or new —
+    // must reject with the "JournalWriter is broken" message.
+    const { JournalWriter } = await import('./journal.ts')
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+
+    // Sabotage the fd so the first write throws an I/O error.
+    const fhAny = (w as unknown as Record<string, unknown>).fh as {
+      close: () => Promise<void>
+    }
+    await fhAny.close()
+
+    // First write — hits the dead fd, sets this.broken.
+    await expect(w.writeEvent(sysBoot)).rejects.toThrow()
+
+    // A second call, arriving after the first has already marked broken,
+    // must also reject with the broken-state message (not a different
+    // error), confirming the enqueue-time guard works for new calls
+    // after a failure.
+    await expect(
+      w.writeEvent({ kind: 'session.activate' }),
+    ).rejects.toThrow(/JournalWriter is broken/)
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of the v0.5.1 Batch 1 multi-agent orchestration — PRs #86 (S1), #87 (S4) in flight; #88 (docs) merged.

## Summary

Two correctness bugs in `journal.ts` found in the plan review:

**S2 — broken guard leaks in-flight queued calls**
`writeEvent()` checked `this.broken` at enqueue time but calls already in the queue could still execute `_doWrite()` after a failing write. Fix: add `if (this.broken) throw this.broken` at the **top** of `_doWrite()`, before the `fh === null` check. This ensures every queue-draining call hits the broken guard, not just new arrivals.

**S3 — schema parse ran after hash computation**
`JournalEvent.parse(event)` was called after building `partial` and computing `hash`. A `ZodError` on caller-supplied input would propagate without setting `this.broken`, but the ordering violated the "fail-loud writer" contract: the hash had already been computed over potentially invalid data. Fix: validate the `WriteInput` shape (all caller fields minus the writer-assigned framing fields) **before** redaction/truncation/hash. The post-hash `JournalEvent.parse(event)` is retained as a cheap sanity check that the writer assembled the full event correctly. An inline comment documents the ordering invariant.

## Tests added (`server.test.ts`)

Four regression tests for `ccsc-z09`:

1. **Queue-after-broken rejects** — two concurrent `writeEvent` calls; first fails (dead fd); second must reject with `"JournalWriter is broken..."`, not succeed.
2. **ZodError is retryable** — bad input produces a `ZodError` rejection; next `writeEvent` with valid input succeeds; writer NOT broken; `headHash` unchanged after bad attempt.
3. **ZodError does not advance seq** — `nextSequenceNumber` unchanged before and after bad input.
4. **fs.write error DOES mark broken** — close fd, next `writeEvent` rejects with broken-state error; second sequential call after that also rejects with `"JournalWriter is broken"`.

## References

- `000-docs/audit-journal-architecture.md` — §190-210 (ordering invariants), §148-151 (single-writer invariant)
- Closes `ccsc-z09`

Jeremy made me do it
-claude