### PR TITLE
fix(mcp): per-tool Zod input schemas (S5)

### DIFF
--- a/server.test.ts
+++ b/server.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test'
+import { z } from 'zod'
 import {
   gate,
   assertSendable,
@@ -5583,5 +5584,296 @@ describe('SessionSupervisor quarantine (S6)', () => {
     // Both should complete without throwing.
     await expect(sup.reapIdle()).resolves.toBeUndefined()
     await expect(aggressiveSup.reapIdle()).resolves.toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// MCP tool input schemas (S5)
+//
+// Defense-in-depth: every MCP tool's argument payload is validated with a
+// per-tool Zod schema before dispatch in server.ts. Without these,
+// malformed tool calls reach the handler body and e.g.
+// `assertOutboundAllowed(undefined, ...)` / the Slack API gets undefined.
+//
+// These schemas are mirrored from `toolSchemas` in server.ts. Importing
+// server.ts directly would execute its top-level bootstrap (token load,
+// STATE_DIR mkdir, process.exit(1) on missing .env), so we duplicate the
+// shapes here deliberately and unit-test them in isolation. If a schema
+// in server.ts changes, update the copy below AND add a corresponding
+// test — the two must stay visibly in sync.
+// ---------------------------------------------------------------------------
+
+describe('MCP tool input schemas (S5)', () => {
+  const ReplyInput = z
+    .object({
+      chat_id: z.string().min(1),
+      text: z.string().min(1),
+      thread_ts: z.string().optional(),
+      files: z.array(z.string()).optional(),
+    })
+    .strict()
+
+  const ReactInput = z
+    .object({
+      chat_id: z.string().min(1),
+      message_id: z.string().min(1),
+      emoji: z.string().min(1),
+      thread_ts: z.string().optional(),
+    })
+    .strict()
+
+  const EditMessageInput = z
+    .object({
+      chat_id: z.string().min(1),
+      message_id: z.string().min(1),
+      text: z.string().min(1),
+      thread_ts: z.string().optional(),
+    })
+    .strict()
+
+  const FetchMessagesInput = z
+    .object({
+      channel: z.string().min(1),
+      limit: z.number().int().positive().optional(),
+      thread_ts: z.string().optional(),
+    })
+    .strict()
+
+  const DownloadAttachmentInput = z
+    .object({
+      chat_id: z.string().min(1),
+      message_id: z.string().min(1),
+      thread_ts: z.string().optional(),
+    })
+    .strict()
+
+  const ListSessionsInput = z.object({}).strict()
+
+  // -------------------------------------------------------------------------
+  // reply — the primary S5 target. Handler at server.ts case 'reply' calls
+  // assertOutboundAllowed(chatId, threadTs) and web.chat.postMessage; both
+  // require chat_id+text. The other assertions below (missing, wrong type,
+  // unknown key) cover the three failure classes the task brief called out.
+  // -------------------------------------------------------------------------
+  describe('ReplyInput', () => {
+    test('accepts minimal valid input (required only)', () => {
+      const result = ReplyInput.safeParse({ chat_id: 'C123', text: 'hello' })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.chat_id).toBe('C123')
+        expect(result.data.text).toBe('hello')
+        expect(result.data.thread_ts).toBeUndefined()
+        expect(result.data.files).toBeUndefined()
+      }
+    })
+
+    test('accepts full input with optional thread_ts and files', () => {
+      const result = ReplyInput.safeParse({
+        chat_id: 'C123',
+        text: 'hello',
+        thread_ts: '1234567890.123456',
+        files: ['/tmp/a.txt', '/tmp/b.txt'],
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.files).toEqual(['/tmp/a.txt', '/tmp/b.txt'])
+      }
+    })
+
+    test('rejects missing chat_id (defense-in-depth for assertOutboundAllowed)', () => {
+      const result = ReplyInput.safeParse({ text: 'hello' })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const issues = result.error.issues
+        expect(issues.some((i) => i.path.join('.') === 'chat_id')).toBe(true)
+      }
+    })
+
+    test('rejects missing text', () => {
+      const result = ReplyInput.safeParse({ chat_id: 'C123' })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.join('.') === 'text')).toBe(true)
+      }
+    })
+
+    test('rejects empty chat_id (min(1))', () => {
+      const result = ReplyInput.safeParse({ chat_id: '', text: 'hello' })
+      expect(result.success).toBe(false)
+    })
+
+    test('rejects wrong-type text (number instead of string)', () => {
+      const result = ReplyInput.safeParse({ chat_id: 'C123', text: 42 })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const textIssue = result.error.issues.find((i) => i.path.join('.') === 'text')
+        expect(textIssue?.code).toBe('invalid_type')
+      }
+    })
+
+    test('rejects unknown field (.strict() contract)', () => {
+      const result = ReplyInput.safeParse({
+        chat_id: 'C123',
+        text: 'hello',
+        evil: 'extra',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        // Zod v4 reports unrecognized_keys at the object root.
+        expect(result.error.issues.some((i) => i.code === 'unrecognized_keys')).toBe(true)
+      }
+    })
+
+    test('rejects non-array files', () => {
+      const result = ReplyInput.safeParse({
+        chat_id: 'C123',
+        text: 'hello',
+        files: '/tmp/a.txt',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('rejects non-string element in files array', () => {
+      const result = ReplyInput.safeParse({
+        chat_id: 'C123',
+        text: 'hello',
+        files: ['/tmp/a.txt', 42],
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('error message never echoes argument values (token-safety)', () => {
+      // A malformed call could carry a token-shaped string as a value.
+      // Zod's default issue messages name paths + expected/received types,
+      // never the actual value. This test locks that property in so a
+      // future Zod upgrade or custom .message() call cannot regress it.
+      const secret = 'xoxb-SECRET-LEAK-CANARY-9f0e1d2c3b4a'
+      const result = ReplyInput.safeParse({ chat_id: 'C123', text: secret, evil: secret })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.message).not.toContain(secret)
+        expect(JSON.stringify(result.error.issues)).not.toContain(secret)
+      }
+    })
+  })
+
+  describe('ReactInput', () => {
+    test('accepts valid input', () => {
+      const result = ReactInput.safeParse({
+        chat_id: 'C123',
+        message_id: '1234567890.123456',
+        emoji: 'thumbsup',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects missing emoji (required field)', () => {
+      const result = ReactInput.safeParse({
+        chat_id: 'C123',
+        message_id: '1234567890.123456',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.join('.') === 'emoji')).toBe(true)
+      }
+    })
+
+    test('rejects unknown field', () => {
+      const result = ReactInput.safeParse({
+        chat_id: 'C123',
+        message_id: '1234567890.123456',
+        emoji: 'thumbsup',
+        bogus: true,
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('EditMessageInput', () => {
+    test('accepts valid input', () => {
+      const result = EditMessageInput.safeParse({
+        chat_id: 'C123',
+        message_id: '1234567890.123456',
+        text: 'updated',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects missing message_id (required field)', () => {
+      const result = EditMessageInput.safeParse({
+        chat_id: 'C123',
+        text: 'updated',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.join('.') === 'message_id')).toBe(true)
+      }
+    })
+  })
+
+  describe('FetchMessagesInput', () => {
+    test('accepts channel-only input', () => {
+      const result = FetchMessagesInput.safeParse({ channel: 'C123' })
+      expect(result.success).toBe(true)
+    })
+
+    test('accepts channel + limit + thread_ts', () => {
+      const result = FetchMessagesInput.safeParse({
+        channel: 'C123',
+        limit: 50,
+        thread_ts: '1234567890.123456',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects missing channel (required field)', () => {
+      const result = FetchMessagesInput.safeParse({ limit: 10 })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.join('.') === 'channel')).toBe(true)
+      }
+    })
+
+    test('rejects non-integer limit', () => {
+      const result = FetchMessagesInput.safeParse({ channel: 'C123', limit: 1.5 })
+      expect(result.success).toBe(false)
+    })
+
+    test('rejects non-positive limit', () => {
+      const result = FetchMessagesInput.safeParse({ channel: 'C123', limit: 0 })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('DownloadAttachmentInput', () => {
+    test('accepts valid input', () => {
+      const result = DownloadAttachmentInput.safeParse({
+        chat_id: 'C123',
+        message_id: '1234567890.123456',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects missing chat_id (required field)', () => {
+      const result = DownloadAttachmentInput.safeParse({
+        message_id: '1234567890.123456',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.join('.') === 'chat_id')).toBe(true)
+      }
+    })
+  })
+
+  describe('ListSessionsInput', () => {
+    test('accepts empty object', () => {
+      const result = ListSessionsInput.safeParse({})
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects any extra field (.strict() on empty object)', () => {
+      const result = ListSessionsInput.safeParse({ foo: 'bar' })
+      expect(result.success).toBe(false)
+    })
   })
 })

--- a/server.ts
+++ b/server.ts
@@ -312,6 +312,66 @@ const mcp = new Server(
 // Tools — definition
 // ---------------------------------------------------------------------------
 
+// Per-tool Zod input schemas. Co-located with the tools list so the
+// JSON Schema (what the MCP client sees) and the runtime validator
+// stay visibly in sync. `.strict()` rejects unknown keys so a malformed
+// or crafted tool call cannot smuggle in extra fields. Each schema
+// mirrors the corresponding `inputSchema` below — required/optional
+// fields must match so a previously-accepted call still works.
+const ReplyInput = z
+  .object({
+    chat_id: z.string().min(1),
+    text: z.string().min(1),
+    thread_ts: z.string().optional(),
+    files: z.array(z.string()).optional(),
+  })
+  .strict()
+
+const ReactInput = z
+  .object({
+    chat_id: z.string().min(1),
+    message_id: z.string().min(1),
+    emoji: z.string().min(1),
+    thread_ts: z.string().optional(),
+  })
+  .strict()
+
+const EditMessageInput = z
+  .object({
+    chat_id: z.string().min(1),
+    message_id: z.string().min(1),
+    text: z.string().min(1),
+    thread_ts: z.string().optional(),
+  })
+  .strict()
+
+const FetchMessagesInput = z
+  .object({
+    channel: z.string().min(1),
+    limit: z.number().int().positive().optional(),
+    thread_ts: z.string().optional(),
+  })
+  .strict()
+
+const DownloadAttachmentInput = z
+  .object({
+    chat_id: z.string().min(1),
+    message_id: z.string().min(1),
+    thread_ts: z.string().optional(),
+  })
+  .strict()
+
+const ListSessionsInput = z.object({}).strict()
+
+export const toolSchemas = {
+  reply: ReplyInput,
+  react: ReactInput,
+  edit_message: EditMessageInput,
+  fetch_messages: FetchMessagesInput,
+  download_attachment: DownloadAttachmentInput,
+  list_sessions: ListSessionsInput,
+} as const
+
 mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
@@ -419,7 +479,37 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name } = request.params
-  const args = (request.params.arguments || {}) as Record<string, any>
+  let args = (request.params.arguments || {}) as Record<string, any>
+
+  // Defense-in-depth: validate tool inputs with per-tool Zod schemas
+  // before dispatch. Without this, a malformed tool call (wrong type,
+  // missing required field, extra field) reaches the tool body and
+  // e.g. `assertOutboundAllowed(undefined, ...)` / Slack API calls
+  // with undefined values. `safeParse` returns a structured error
+  // (isError: true) rather than throwing so the MCP client sees a
+  // proper error result. The error message intentionally surfaces
+  // only Zod's path+type text, never argument values, since a
+  // malformed call could carry a token-shaped string.
+  const schema = toolSchemas[name as keyof typeof toolSchemas]
+  if (schema) {
+    const result = schema.safeParse(args)
+    if (!result.success) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Invalid arguments for tool "${name}": ${result.error.message}`,
+          },
+        ],
+        isError: true,
+      }
+    }
+    args = result.data as Record<string, any>
+  } else {
+    // Tool exists in the switch but not in toolSchemas — reviewer oversight.
+    // Log a warning so it surfaces in operator logs.
+    console.warn(`[mcp] tool "${name}" has no input schema; skipping validation`)
+  }
 
   switch (name) {
     // -----------------------------------------------------------------------

--- a/server.ts
+++ b/server.ts
@@ -363,6 +363,8 @@ const DownloadAttachmentInput = z
 
 const ListSessionsInput = z.object({}).strict()
 
+// NOTE: These schemas are duplicated for isolated testing in `server.test.ts`.
+// If you update a schema here, please update the corresponding copy there.
 export const toolSchemas = {
   reply: ReplyInput,
   react: ReactInput,


### PR DESCRIPTION
Part of the v0.5.1 Batch 1 multi-agent orchestration — server.ts also touched by PR #86 (S1); rebase may be required.

## Validation gap

The `CallToolRequestSchema` handler in `server.ts` destructured the incoming tool arguments as `Record<string, any>` and immediately used them in security-sensitive calls:

- `assertOutboundAllowed(args.chat_id, args.thread_ts)` — passes `undefined` straight through the outbound gate when `chat_id` is missing.
- `web.chat.postMessage({ channel, text, thread_ts })`, `web.reactions.add`, `web.chat.update`, `web.conversations.replies`, `web.conversations.history` — all called with unchecked fields. Wrong-type or missing fields bubble up as Slack API errors at best, silent pass-through at worst.

The outer MCP `CallToolRequestSchema` validates only the envelope (`name`, `arguments`), never the per-tool shape. This PR closes that defense-in-depth gap.

## Fix

Per-tool Zod schemas, co-located with the tools list in `server.ts`. All `.strict()` so a crafted call cannot smuggle in extra fields that might bypass later guards. Validation runs via `safeParse` at switch entry, before any tool body. Failures return a structured `{ content, isError: true }` result — never throw.

Error-message hygiene: Zod's default issue messages name paths + expected types (e.g. `"expected string, received number"`), never the actual value. A token-canary test locks that property in so a future Zod upgrade or a custom `.message()` call cannot regress it.

## Tools validated

| Tool | Required | Optional |
| --- | --- | --- |
| `reply` | `chat_id`, `text` | `thread_ts`, `files[]` |
| `react` | `chat_id`, `message_id`, `emoji` | `thread_ts` |
| `edit_message` | `chat_id`, `message_id`, `text` | `thread_ts` |
| `fetch_messages` | `channel` | `limit`, `thread_ts` |
| `download_attachment` | `chat_id`, `message_id` | `thread_ts` |
| `list_sessions` | — | — |

Each schema mirrors the existing `inputSchema` JSON Schema — required/optional match, so previously-accepted calls still pass. `thread_ts` is added as optional to the three tools whose handlers read `args.thread_ts` (react, edit_message, download_attachment) — the JSON Schema underdocumented it, but the handler has always used it.

## Tests

24 new tests in `server.test.ts` under `MCP tool input schemas (S5)`:

- `ReplyInput`: minimal valid, full valid, missing `chat_id`, missing `text`, empty `chat_id`, wrong-type `text`, unknown field, non-array `files`, non-string file element, error-message hygiene (token canary).
- `ReactInput`: valid, missing `emoji`, unknown field.
- `EditMessageInput`: valid, missing `message_id`.
- `FetchMessagesInput`: channel-only, full, missing `channel`, non-integer `limit`, non-positive `limit`.
- `DownloadAttachmentInput`: valid, missing `chat_id`.
- `ListSessionsInput`: empty object accepted, any extra field rejected.

Schemas are duplicated in the test file deliberately — importing from `server.ts` would trigger its top-level bootstrap (`loadEnv()` → `process.exit(1)` on missing `.env`). A comment in the test block calls out that the copies must stay in sync.

## Verification

- `bun run typecheck` — clean
- `bun test` — **394 pass / 0 fail** (baseline 370, delta +24)
- `grep 'args as any'` in `server.ts` — no matches remain

## Scope

- `server.ts` — tool registration (added `toolSchemas` block before `setRequestHandler(ListToolsRequestSchema)`) + handler entry (added `safeParse` gate at top of `setRequestHandler(CallToolRequestSchema)`).
- `server.test.ts` — new `MCP tool input schemas (S5)` describe block.

No changes to the dispatch shape, permission relay, access store, or any other subsystem.

Closes ccsc-60i

Jeremy made me do it
-claude