### PR TITLE
feat(supervisor): SessionHandle.update() mutex-serialized state mutation (B1)

### DIFF
--- a/server.test.ts
+++ b/server.test.ts
@@ -5659,12 +5659,18 @@ describe('SessionHandle.update (ccsc-9d9)', () => {
     await handle.update((s) => ({ ...s, data: { count: 0 } }))
 
     // Fire three concurrent increments without awaiting individually.
-    const p1 = handle.update((s) => ({ ...s, data: { count: (s.data['count'] as number) + 1 } }))
-    const p2 = handle.update((s) => ({ ...s, data: { count: (s.data['count'] as number) + 1 } }))
-    const p3 = handle.update((s) => ({ ...s, data: { count: (s.data['count'] as number) + 1 } }))
+    // Use a safe increment helper that avoids the `as number` cast and
+    // defaults gracefully if the field is absent (per Gemini review).
+    const increment = (s: Session): Session => {
+      const current = typeof s.data['count'] === 'number' ? s.data['count'] : 0
+      return { ...s, data: { ...s.data, count: current + 1 } }
+    }
+    const p1 = handle.update(increment)
+    const p2 = handle.update(increment)
+    const p3 = handle.update(increment)
     await Promise.all([p1, p2, p3])
 
-    expect((handle.session.data['count'] as number)).toBe(3)
+    expect(handle.session.data['count']).toBe(3)
 
     // Disk must also reflect the final value.
     const path = sessionPath(stateRoot, KEY)

--- a/server.test.ts
+++ b/server.test.ts
@@ -3110,10 +3110,11 @@ describe('createSessionSupervisor.activate', () => {
     await expect(sup.shutdown()).rejects.toThrow(/xa3\.14/)
   })
 
-  test('handle.update is a staged stub that rejects with a bead pointer', async () => {
+  test('handle.update on an active handle resolves (ccsc-9d9 implemented)', async () => {
     const sup = makeSupervisor()
     const handle = await sup.activate(key, 'U_OWNER')
-    await expect(handle.update((s) => s)).rejects.toThrow(/not yet implemented/)
+    // update() is now wired (ccsc-9d9); an identity fn must resolve cleanly.
+    await expect(handle.update((s) => s)).resolves.toBeUndefined()
   })
 })
 
@@ -5584,6 +5585,172 @@ describe('SessionSupervisor quarantine (S6)', () => {
     // Both should complete without throwing.
     await expect(sup.reapIdle()).resolves.toBeUndefined()
     await expect(aggressiveSup.reapIdle()).resolves.toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SessionHandle.update() — mutex-serialised state mutation (ccsc-9d9)
+//
+// Verifies the six acceptance criteria from the bead:
+//   1. Basic update mutates in-memory session and persists to disk.
+//   2. Concurrent updates serialize — increments apply in call order.
+//   3. Concurrent update + deactivate serialize without half-written state.
+//   4. update() after quiesce() rejects with /quiescing/i.
+//   5. update() on a quarantined handle rejects with /quarantined/i.
+//   6. save failure during update() quarantines the handle and chains cause.
+// ---------------------------------------------------------------------------
+
+describe('SessionHandle.update (ccsc-9d9)', () => {
+  const KEY: SessionKey = { channel: 'C_UPD', thread: '1700000000.000001' }
+  const OWNER = 'U_UPD'
+
+  let rawRoot: string
+  let stateRoot: string
+  let channelDir: string
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'sup-update-'))
+    stateRoot = realpathSync.native(rawRoot)
+    channelDir = join(stateRoot, 'sessions', KEY.channel)
+    mkdirSync(channelDir, { recursive: true, mode: 0o700 })
+  })
+
+  afterEach(() => {
+    try {
+      const { chmodSync } = require('fs')
+      chmodSync(channelDir, 0o700)
+    } catch { /* best-effort */ }
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  function makeSupervisor() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createSessionSupervisor } = require('./supervisor.ts') as typeof import('./supervisor.ts')
+    return createSessionSupervisor({
+      stateRoot,
+      log: () => { /* silent */ },
+      clock: () => 1_700_000_000_000,
+    })
+  }
+
+  // 1. Basic update mutates in-memory session and persists to disk.
+  test('update mutates in-memory session and persists to disk', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(KEY, OWNER)
+
+    await handle.update((s) => ({ ...s, data: { turns: 1 } }))
+
+    // In-memory reference reflects the patch.
+    expect(handle.session.data).toEqual({ turns: 1 })
+
+    // On-disk file reflects the same patch.
+    const p = sessionPath(stateRoot, KEY)
+    const fromDisk = await loadSession(stateRoot, p)
+    expect(fromDisk.data).toEqual({ turns: 1 })
+  })
+
+  // 2. Concurrent updates serialize in call order — counter increments
+  //    must total the number of calls with no lost writes.
+  test('concurrent updates serialize in call order', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(KEY, OWNER)
+
+    // Seed a counter.
+    await handle.update((s) => ({ ...s, data: { count: 0 } }))
+
+    // Fire three concurrent increments without awaiting individually.
+    const p1 = handle.update((s) => ({ ...s, data: { count: (s.data['count'] as number) + 1 } }))
+    const p2 = handle.update((s) => ({ ...s, data: { count: (s.data['count'] as number) + 1 } }))
+    const p3 = handle.update((s) => ({ ...s, data: { count: (s.data['count'] as number) + 1 } }))
+    await Promise.all([p1, p2, p3])
+
+    expect((handle.session.data['count'] as number)).toBe(3)
+
+    // Disk must also reflect the final value.
+    const path = sessionPath(stateRoot, KEY)
+    const fromDisk = await loadSession(stateRoot, path)
+    expect(fromDisk.data['count']).toBe(3)
+  })
+
+  // 3. Concurrent update + deactivate serialize — final state must be
+  //    consistent: no half-written file and no lost update.
+  test('concurrent update + deactivate serialize without corrupting state', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(KEY, OWNER)
+
+    // Fire update first (not awaited), then quiesce + deactivate.
+    const updateP = handle.update((s) => ({ ...s, data: { sentinel: 'written' } }))
+    const quiesceP = sup.quiesce(KEY)
+
+    // Both must settle without throwing.
+    await Promise.allSettled([updateP, quiesceP])
+    await sup.deactivate(KEY)
+
+    // Disk must be parseable (not corrupt). The sentinel may or may not
+    // be present depending on race ordering, but the file must be valid.
+    const path = sessionPath(stateRoot, KEY)
+    const fromDisk = await loadSession(stateRoot, path)
+    expect(fromDisk.key).toEqual(KEY)
+  })
+
+  // 4. update() after quiesce() rejects with /quiescing/i.
+  test('update after quiesce rejects with quiescing error', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(KEY, OWNER)
+    await sup.quiesce(KEY)
+
+    await expect(handle.update((s) => s)).rejects.toThrow(/quiescing/i)
+  })
+
+  // 5. update() on a quarantined handle rejects with /quarantined/i.
+  test('update on quarantined handle rejects with quarantined error', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(KEY, OWNER)
+
+    // Force quarantine via the package-private transition (same pattern
+    // as the deactivate quarantine tests in S6).
+    const h = handle as unknown as { markQuarantined(): void }
+    h.markQuarantined()
+
+    await expect(handle.update((s) => s)).rejects.toThrow(/quarantined/i)
+  })
+
+  // 6. save failure during update() quarantines the handle + chains cause.
+  test('save failure during update quarantines the handle and chains cause', async () => {
+    const sup = makeSupervisor()
+    const handle = await sup.activate(KEY, OWNER)
+
+    // Make the channel dir unwritable so saveSession()'s tmp-write fails
+    // with EACCES — same chmod trick used in S6.
+    const { chmodSync } = require('fs')
+    chmodSync(channelDir, 0o000)
+
+    let caught: unknown
+    try {
+      await handle.update((s) => ({ ...s, data: { injected: true } }))
+    } catch (err) {
+      caught = err
+    } finally {
+      chmodSync(channelDir, 0o700)
+    }
+
+    // The promise must have rejected.
+    expect(caught).toBeInstanceOf(Error)
+    const err = caught as Error
+
+    // Error must mention quarantined.
+    expect(err.message).toMatch(/quarantined/i)
+
+    // Error.cause must carry the underlying filesystem error.
+    expect(err.cause).toBeInstanceOf(Error)
+    const cause = err.cause as Error
+    expect(cause.message).toMatch(/EACCES|permission denied|EPERM/i)
+
+    // Handle must now be in quarantined state.
+    expect(handle.state).toBe('quarantined')
+
+    // Subsequent update() must also reject with quarantined.
+    await expect(handle.update((s) => s)).rejects.toThrow(/quarantined/i)
   })
 })
 

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -871,9 +871,13 @@ class ConcreteHandle implements SessionHandle {
       )
     }
     if (enqueueTimeState !== 'active') {
-      // Covers 'quiescing', 'deactivating', and 'activating'.
+      // Covers 'quiescing', 'deactivating', and 'activating'. Include the
+      // actual state so callers can distinguish the cases without inspecting
+      // `handle.state` separately.
       return Promise.reject(
-        new Error(`SessionHandle.update: handle quiescing`),
+        new Error(
+          `SessionHandle.update: handle is not active (state: ${enqueueTimeState})`,
+        ),
       )
     }
 
@@ -897,7 +901,7 @@ class ConcreteHandle implements SessionHandle {
         return
       }
       if (this._state !== 'active') {
-        reject(new Error(`SessionHandle.update: handle quiescing`))
+        reject(new Error(`SessionHandle.update: handle is not active (state: ${this._state})`))
         return
       }
 

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -418,8 +418,23 @@ export function createSessionSupervisor(
     }
 
     const handle = new ConcreteHandle(key, session, path)
+    // Wire the quarantine callback so update()'s failure arm can record
+    // the error in the supervisor's quarantined map AND remove the handle
+    // from live. Without this the supervisor's two maps would be out of
+    // sync: live still carrying a quarantined handle that activate()
+    // would return instead of rejecting.
+    const id = keyId(key)
+    handle.onQuarantine = (err: Error) => {
+      quarantined.set(id, err)
+      live.delete(id)
+      log('session.update_error', {
+        channel: key.channel,
+        thread: key.thread,
+        error: errorMessage(err),
+      })
+    }
     handle.markActive()
-    live.set(keyId(key), handle)
+    live.set(id, handle)
 
     log('session.activate', {
       channel: key.channel,
@@ -674,6 +689,14 @@ class ConcreteHandle implements SessionHandle {
    *  `sessionPath()` (which would re-mkdir the parent). */
   readonly path: string
 
+  /** Mutex tail for serialised `update()` calls. Each call chains its
+   *  work onto this promise so concurrent updates run in strict call
+   *  order without interleaving. Initialized to a resolved promise so
+   *  the first update starts immediately. The chain carries
+   *  `Promise<void>` throughout; individual links catch their own errors
+   *  to prevent a rejected link from collapsing the whole chain. */
+  private writeQueue: Promise<void> = Promise.resolve()
+
   /** In-flight drain promise allocated by `beginQuiesce()`. Null when
    *  the handle is Active (nothing to drain). Callers of quiesce share
    *  this promise so concurrent quiesce() requests do not allocate
@@ -684,6 +707,15 @@ class ConcreteHandle implements SessionHandle {
    *  last in-flight entry drains, or directly by `beginQuiesce()` when
    *  the map is already empty at quiesce time. */
   private resolveQuiesce: (() => void) | null = null
+
+  /** Callback invoked when `update()` transitions the handle to
+   *  `quarantined`. The supervisor injects this so its `quarantined` map
+   *  stays consistent: a quarantine triggered inside the write queue
+   *  must be recorded in the same map that `activate()` checks, or a
+   *  subsequent activate() would silently reload a potentially-corrupt
+   *  file instead of rejecting. Set once by the supervisor after
+   *  construction; never null after `markActive()`. */
+  onQuarantine: ((err: Error) => void) | null = null
 
   constructor(key: SessionKey, session: Session, path: string) {
     this.key = key
@@ -815,15 +847,88 @@ class ConcreteHandle implements SessionHandle {
     }
   }
 
-  update(_fn: (prev: Session) => Session): Promise<void> {
-    // Staged for a later bead. update() is documented in the interface
-    // so later code can rely on the shape, but the mutex + atomic-write
-    // plumbing lands with the first real consumer (29-B or a follow-up
-    // 32-B bead). The interface's "rejects when state !== 'active'"
-    // clause lands with the real impl — for now we reject uniformly.
-    return Promise.reject(
-      new Error('SessionHandle.update: not yet implemented (later 32-B bead)'),
-    )
+  /** Serialise a state mutation through the per-session write mutex,
+   *  persist it atomically, and refresh `this.session` on success.
+   *
+   *  The write queue is a promise chain: each call appends a new link
+   *  and returns a promise that resolves only after the previous link
+   *  settles. Links catch their own errors so a failed update does not
+   *  prevent subsequent calls from running — the handle quarantines
+   *  itself and further calls will immediately reject at the state check.
+   *
+   *  Implementation mirrors the `deactivate()` save path: both use
+   *  `saveSession()` (tmp + chmod + rename from lib.ts) and both
+   *  transition to `quarantined` on save failure. */
+  update(fn: (prev: Session) => Session): Promise<void> {
+    // Capture state at enqueue time for the early-exit checks below.
+    // We re-check after acquiring the mutex because state can change
+    // while waiting in the queue (a concurrent quiesce, for example).
+    const enqueueTimeState = this._state
+
+    if (enqueueTimeState === 'quarantined') {
+      return Promise.reject(
+        new Error(`SessionHandle.update: handle is quarantined`),
+      )
+    }
+    if (enqueueTimeState !== 'active') {
+      // Covers 'quiescing', 'deactivating', and 'activating'.
+      return Promise.reject(
+        new Error(`SessionHandle.update: handle quiescing`),
+      )
+    }
+
+    // Expose a stable Promise<void> to the caller that resolves/rejects
+    // based solely on this link's outcome.
+    let resolve!: () => void
+    let reject!: (err: unknown) => void
+    const callerPromise = new Promise<void>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+
+    // Chain the work unit onto the write queue. The link must catch all
+    // errors to avoid collapsing the chain — the original rejection is
+    // forwarded to the caller via `callerPromise`.
+    this.writeQueue = this.writeQueue.then(async () => {
+      // Re-check state now that we hold the mutex. A concurrent quiesce
+      // or a previous update's quarantine may have changed things.
+      if (this._state === 'quarantined') {
+        reject(new Error(`SessionHandle.update: handle is quarantined`))
+        return
+      }
+      if (this._state !== 'active') {
+        reject(new Error(`SessionHandle.update: handle quiescing`))
+        return
+      }
+
+      const prev = this.session
+      const next = fn(prev)
+
+      try {
+        await saveSession(this.path, next)
+        this.session = next
+        resolve()
+      } catch (err) {
+        // Save failure: quarantine the handle so future update() and
+        // activate() calls fail fast. In-memory session reverts to
+        // `prev` (it was never reassigned). This mirrors the deactivate()
+        // failure arm exactly (session-state-machine.md §132-137).
+        this._state = 'quarantined'
+        const errObj = err instanceof Error ? err : new Error(String(err))
+        // Notify the supervisor so its quarantined map and live map stay
+        // in sync. Without this, a subsequent activate() would return the
+        // cached live handle (which is now quarantined) instead of
+        // rejecting — violating the sticky-quarantine invariant.
+        this.onQuarantine?.(errObj)
+        reject(
+          new Error(`SessionHandle.update: save failed; handle quarantined`, {
+            cause: errObj,
+          }),
+        )
+      }
+    })
+
+    return callerPromise
   }
 }
 


### PR DESCRIPTION
Batch 3 PR A of 3 — unblocks the supervisor wiring (B2) and journal event emission (B3).

## Contract

`SessionHandle.update(fn: (prev: Session) => Session): Promise<void>` serialises state mutations through a per-handle promise-chain mutex (`writeQueue`). Each call appends a new link to the chain; links run sequentially in call order, preventing interleaving on concurrent callers.

**Mutex discipline.** The write queue tail is a `Promise<void>` field on `ConcreteHandle`. Each `update()` call chains `.then(async () => { … })` onto it and exposes a separate `callerPromise` that resolves/rejects based solely on that link's outcome. Links catch their own errors so a failed write does not collapse the chain for subsequent callers.

**Quiesce/quarantine rejection.** State is checked at enqueue time (early exit) and again inside the mutex link (re-check after queue wait). Quiescing/deactivating/activating handles reject with `"handle quiescing"`; quarantined handles reject with `"handle is quarantined"`.

**Atomic save.** Reuses `saveSession()` from `lib.ts` (tmp + chmod + rename pattern). No new I/O paths introduced.

**Save failure → quarantine.** On `saveSession()` throw: `_state` transitions to `quarantined`, `Error.cause` chains the original filesystem error, and `onQuarantine()` (injected by the supervisor at activate-time) updates the supervisor's `quarantined` map and removes the entry from `live`. This keeps the two maps consistent so a subsequent `activate()` rejects rather than returning a cached-but-corrupt handle.

## Design doc reference

See `000-docs/session-state-machine.md` §132–137 (quarantined transition), §210 invariant 1 (serialised writes per key), and §221–267 (supervisor contract).

No doc changes were required — the implementation follows the spec as written.

## New tests (413 → 419, +6)

Added `describe('SessionHandle.update (ccsc-9d9)')`:

1. **Basic update mutates + persists** — identity of in-memory `session` and on-disk JSON after a single update.
2. **Concurrent updates serialize** — three concurrent counter increments; final value must be 3, no lost writes.
3. **Concurrent update + deactivate** — fire update then quiesce/deactivate without awaiting; file must remain valid (parseable) regardless of race ordering.
4. **Update after quiesce rejects** — `/quiescing/i`.
5. **Update on quarantined handle rejects** — force quarantine via package-private `markQuarantined()`, then assert `/quarantined/i`.
6. **Save failure quarantines + chains cause** — chmod directory to `0o000` (same trick as S6), assert `handle.state === 'quarantined'`, `err.cause` matches `/EACCES|permission denied|EPERM/i`, and subsequent update also rejects with `/quarantined/i`.

Also updated the stale activate-suite test `'handle.update is a staged stub…'` → `'handle.update on an active handle resolves (ccsc-9d9 implemented)'` to reflect the real implementation.

`Closes ccsc-9d9`.

Jeremy made me do it
-claude