### PR TITLE
feat(integration): wire journal event emission into gate/session/pairing paths (B2)

### DIFF
--- a/server.test.ts
+++ b/server.test.ts
@@ -6264,3 +6264,306 @@ describe('Supervisor wiring (ccsc-jqs)', () => {
     expect(elapsed).toBeGreaterThanOrEqual(40) // at least ~50ms of work done
   })
 })
+
+// ---------------------------------------------------------------------------
+// Journal event wiring (ccsc-3fo)
+//
+// These tests exercise the integration points added in the B2 bead:
+//   1. gate.inbound.deliver emitted on allowed inbound messages.
+//   2. gate.inbound.drop emitted when gate returns 'drop'.
+//   3. gate.outbound.deny emitted when assertOutboundAllowed throws.
+//   4. exfil.block emitted when assertSendable throws.
+//   5. session.* events emitted in order by the supervisor (activate →
+//      quiesce → deactivate).
+//   6. A broken journal writer does not crash the message-delivery hot path.
+//
+// Importing server.ts directly would trigger its side-effectful bootstrap.
+// The journal-write glue is therefore inlined here, exactly as activateAndTouch
+// is inlined in the 'Supervisor wiring' suite above. Keep both in sync with
+// server.ts.
+// ---------------------------------------------------------------------------
+
+/** Inlined from server.ts journalWrite — fire-and-forget wrapper that
+ *  swallows write errors so a broken journal never interrupts the hot path. */
+async function journalWriteInline(
+  journal: import('./journal.ts').JournalWriter,
+  input: Parameters<import('./journal.ts').JournalWriter['writeEvent']>[0],
+  onError?: (err: unknown) => void,
+): Promise<void> {
+  try {
+    await journal.writeEvent(input)
+  } catch (err) {
+    onError?.(err)
+  }
+}
+
+describe('Journal event wiring (ccsc-3fo)', () => {
+  let rawRoot: string
+  let logPath: string
+
+  beforeEach(() => {
+    rawRoot = mkdtempSync(join(tmpdir(), 'journal-wiring-'))
+    logPath = join(realpathSync.native(rawRoot), 'audit.log')
+  })
+
+  afterEach(() => {
+    rmSync(rawRoot, { recursive: true, force: true })
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 1 — Deliver emits gate.inbound.deliver
+  // -------------------------------------------------------------------------
+  test('gate.inbound.deliver is emitted on an allowed inbound message', async () => {
+    const { JournalWriter, verifyJournal } = await import('./journal.ts')
+    const anchor = 'b'.repeat(64)
+    const w = await JournalWriter.open({ path: logPath, initialPrevHash: anchor })
+
+    // Inline the deliver-path journal write from server.ts handleMessage:
+    //   case 'deliver': { journalWrite({ kind: 'gate.inbound.deliver', ... }) }
+    await journalWriteInline(w, {
+      kind: 'gate.inbound.deliver',
+      outcome: 'allow',
+      actor: 'session_owner',
+      sessionKey: { channel: 'C001', thread: '1700000000.000001' },
+      input: { channel: 'C001', user: 'U_ALICE', thread_ts: '1700000000.000001' },
+    })
+
+    await w.close()
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.eventsVerified).toBe(1)
+
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n')
+    expect(lines).toHaveLength(1)
+    const ev = JSON.parse(lines[0]!)
+    expect(ev.kind).toBe('gate.inbound.deliver')
+    expect(ev.outcome).toBe('allow')
+    expect(ev.actor).toBe('session_owner')
+    expect(ev.sessionKey).toEqual({ channel: 'C001', thread: '1700000000.000001' })
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 2 — Drop emits gate.inbound.drop
+  // -------------------------------------------------------------------------
+  test('gate.inbound.drop is emitted when gate returns drop', async () => {
+    const { JournalWriter, verifyJournal } = await import('./journal.ts')
+    const anchor = 'c'.repeat(64)
+    const w = await JournalWriter.open({ path: logPath, initialPrevHash: anchor })
+
+    // Inline the drop-path journal write from server.ts handleMessage:
+    //   case 'drop': { journalWrite({ kind: 'gate.inbound.drop', ... }); return }
+    await journalWriteInline(w, {
+      kind: 'gate.inbound.drop',
+      outcome: 'drop',
+      actor: 'session_owner',
+      input: { channel: 'C001', user: 'U_BOB' },
+    })
+
+    await w.close()
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n')
+    expect(lines).toHaveLength(1)
+    const ev = JSON.parse(lines[0]!)
+    expect(ev.kind).toBe('gate.inbound.drop')
+    expect(ev.outcome).toBe('drop')
+    // The drop payload must not contain the message body — only identifiers.
+    expect(ev.input).not.toHaveProperty('text')
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 3 — Outbound deny emits gate.outbound.deny
+  // -------------------------------------------------------------------------
+  test('gate.outbound.deny is emitted when assertOutboundAllowed throws', async () => {
+    const { JournalWriter, verifyJournal } = await import('./journal.ts')
+    const anchor = 'd'.repeat(64)
+    const w = await JournalWriter.open({ path: logPath, initialPrevHash: anchor })
+
+    // Inline the tool-handler try/catch from server.ts (e.g. reply case):
+    //   try { assertOutboundAllowed(chatId, threadTs) } catch (err) {
+    //     journalWrite({ kind: 'gate.outbound.deny', ... }); throw err }
+    const deliveredSet = new Set<string>()
+    const access = makeAccess()
+    let thrown: Error | null = null
+    let writeError: unknown = null
+    try {
+      assertOutboundAllowed('C999', undefined, access, deliveredSet)
+    } catch (outboundErr) {
+      thrown = outboundErr instanceof Error ? outboundErr : new Error(String(outboundErr))
+      await journalWriteInline(
+        w,
+        {
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'reply',
+          input: { channel: 'C999' },
+          reason: 'outbound gate blocked: channel not delivered',
+        },
+        (err) => { writeError = err },
+      )
+    }
+
+    await w.close()
+
+    expect(thrown).not.toBeNull()
+    expect(writeError).toBeNull()
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n')
+    expect(lines).toHaveLength(1)
+    const ev = JSON.parse(lines[0]!)
+    expect(ev.kind).toBe('gate.outbound.deny')
+    expect(ev.outcome).toBe('deny')
+    expect(ev.toolName).toBe('reply')
+    // reason must be present as a string
+    expect(typeof ev.reason).toBe('string')
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 4 — Exfil block emits exfil.block (non-leaky reason)
+  // -------------------------------------------------------------------------
+  test('exfil.block is emitted when assertSendable blocks a state-dir file', async () => {
+    const { JournalWriter, verifyJournal } = await import('./journal.ts')
+    const anchor = 'e'.repeat(64)
+    const w = await JournalWriter.open({ path: logPath, initialPrevHash: anchor })
+
+    // Inline the file-upload try/catch from server.ts reply handler:
+    //   try { assertSendable(filePath) } catch (exfilErr) {
+    //     journalWrite({ kind: 'exfil.block', ..., reason: exfilErr.message })
+    //     throw exfilErr }
+    const stateDir = rawRoot
+    const blockedFile = join(stateDir, '.env')
+    writeFileSync(blockedFile, 'SLACK_BOT_TOKEN=xoxb-fake')
+    const inboxDir = join(stateDir, 'inbox')
+    mkdirSync(inboxDir, { recursive: true })
+
+    let thrown: Error | null = null
+    try {
+      assertSendable(blockedFile, inboxDir, [], stateDir)
+    } catch (exfilErr) {
+      thrown = exfilErr instanceof Error ? exfilErr : new Error(String(exfilErr))
+      // IMPORTANT: do NOT include the file path — only a short reason string.
+      await journalWriteInline(w, {
+        kind: 'exfil.block',
+        outcome: 'deny',
+        toolName: 'reply',
+        reason: thrown.message,
+      })
+    }
+
+    await w.close()
+
+    expect(thrown).not.toBeNull()
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n')
+    expect(lines).toHaveLength(1)
+    const ev = JSON.parse(lines[0]!)
+    expect(ev.kind).toBe('exfil.block')
+    expect(ev.outcome).toBe('deny')
+    // The reason must NOT contain the full file path (leakage risk per brief)
+    expect(ev.reason ?? '').not.toContain(stateDir)
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 5 — Session lifecycle emits session.activate → quiesce → deactivate
+  //           in order, with a valid hash chain
+  // -------------------------------------------------------------------------
+  test('supervisor emits session.activate, session.quiesce, session.deactivate in order', async () => {
+    const { JournalWriter, verifyJournal } = await import('./journal.ts')
+    const anchor = 'f'.repeat(64)
+    const w = await JournalWriter.open({ path: logPath, initialPrevHash: anchor })
+
+    const sup = createSessionSupervisor({
+      stateRoot: rawRoot,
+      journal: w,
+      idleMs: 1, // make everything eligible for reaping immediately
+      clock: () => Date.now() - 1000, // back-date so lastActiveAt < threshold
+    })
+
+    const key: SessionKey = { channel: 'C_LIFECYCLE', thread: '1700000001.000001' }
+
+    // 1. activate
+    await activateAndTouch(sup, key, 'U_LIFECYCLE')
+
+    // 2. quiesce (needed before deactivate)
+    await sup.quiesce(key)
+
+    // 3. deactivate
+    await sup.deactivate(key)
+
+    await w.close()
+
+    const result = await verifyJournal(logPath)
+    expect(result.ok).toBe(true)
+
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n')
+    const events = lines.map((l) => JSON.parse(l))
+
+    const kinds = events.map((e: { kind: string }) => e.kind)
+    expect(kinds).toContain('session.activate')
+    expect(kinds).toContain('session.quiesce')
+    expect(kinds).toContain('session.deactivate')
+
+    // Order: activate < quiesce < deactivate
+    const idxActivate = kinds.indexOf('session.activate')
+    const idxQuiesce = kinds.indexOf('session.quiesce')
+    const idxDeactivate = kinds.indexOf('session.deactivate')
+    expect(idxActivate).toBeLessThan(idxQuiesce)
+    expect(idxQuiesce).toBeLessThan(idxDeactivate)
+
+    // seq must be strictly increasing
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].seq).toBe(events[i - 1].seq + 1)
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 6 — Broken journal writer does not crash the hot path
+  // -------------------------------------------------------------------------
+  test('a broken journal writer does not prevent inbound message delivery or supervisor activation', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    const anchor = '9'.repeat(64)
+    const w = await JournalWriter.open({ path: logPath, initialPrevHash: anchor })
+    // Close immediately to put the writer into the "closed" broken state.
+    // writeEvent() on a closed writer rejects (not throws synchronously).
+    await w.close()
+
+    const errors: unknown[] = []
+    const onError = (err: unknown) => errors.push(err)
+
+    // Simulate the deliver path writing an event to a broken journal.
+    // journalWriteInline must not throw even though the writer is closed.
+    await expect(
+      journalWriteInline(
+        w,
+        {
+          kind: 'gate.inbound.deliver',
+          outcome: 'allow',
+          actor: 'session_owner',
+          input: { channel: 'C001', user: 'U_ALICE' },
+        },
+        onError,
+      ),
+    ).resolves.toBeUndefined()
+
+    // The error must have been forwarded to the onError callback,
+    // not swallowed silently (the handler can log it).
+    expect(errors.length).toBeGreaterThan(0)
+
+    // The supervisor with the same broken writer must still activate successfully.
+    const sup = createSessionSupervisor({ stateRoot: rawRoot, journal: w })
+    const key: SessionKey = { channel: 'C_BROKEN', thread: '1700000002.000002' }
+    // activate must succeed — the supervisor's journalWrite swallows errors.
+    await expect(activateAndTouch(sup, key, 'U_BROKEN')).resolves.toBeUndefined()
+
+    // Session file must have been created on disk.
+    const { sessionPath: sPath } = await import('./lib.ts')
+    expect(existsSync(sPath(rawRoot, key))).toBe(true)
+  })
+})

--- a/server.ts
+++ b/server.ts
@@ -251,6 +251,24 @@ function assertOutboundAllowed(
 }
 
 // ---------------------------------------------------------------------------
+// Audit journal — fire-and-forget helper
+// ---------------------------------------------------------------------------
+
+/** Fire-and-forget journal write. Must never throw — a broken audit log
+ *  MUST NOT interrupt message delivery or tool execution. Errors are
+ *  forwarded to stderr so operators can detect a broken journal without
+ *  losing the hot path. Per audit-journal-architecture.md invariant. */
+function journalWrite(input: Parameters<import('./journal.ts').JournalWriter['writeEvent']>[0]): void {
+  if (journal === null) return
+  journal.writeEvent(input).catch((err: unknown) => {
+    console.error('[slack] journal.writeEvent failed', {
+      kind: input.kind,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Gate function (wires up getAccess/saveAccess/botUserId for production use)
 // ---------------------------------------------------------------------------
 
@@ -543,7 +561,26 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       const threadTs: string | undefined = args.thread_ts
       const files: string[] | undefined = args.files
 
-      assertOutboundAllowed(chatId, threadTs)
+      try {
+        assertOutboundAllowed(chatId, threadTs)
+      } catch (outboundErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'reply',
+          sessionKey: threadTs !== undefined ? { channel: chatId, thread: threadTs } : undefined,
+          input: { channel: chatId, thread_ts: threadTs },
+          reason: outboundErr instanceof Error ? outboundErr.message : String(outboundErr),
+        })
+        throw outboundErr
+      }
+      journalWrite({
+        kind: 'gate.outbound.allow',
+        outcome: 'allow',
+        toolName: 'reply',
+        sessionKey: threadTs !== undefined ? { channel: chatId, thread: threadTs } : undefined,
+        input: { channel: chatId, thread_ts: threadTs },
+      })
 
       const access = getAccess()
       const limit = access.textChunkLimit || DEFAULT_CHUNK_LIMIT
@@ -565,7 +602,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Upload files if provided
       if (files && files.length > 0) {
         for (const filePath of files) {
-          assertSendable(filePath)
+          try {
+            assertSendable(filePath)
+          } catch (exfilErr) {
+            journalWrite({
+              kind: 'exfil.block',
+              outcome: 'deny',
+              toolName: 'reply',
+              reason: exfilErr instanceof Error ? exfilErr.message : String(exfilErr),
+            })
+            throw exfilErr
+          }
           const resolved = resolve(filePath)
           const uploadArgs: Record<string, any> = {
             channel_id: chatId,
@@ -595,7 +642,26 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Callers that know the parent thread pass `thread_ts`; when
       // omitted, fall back to channel-level opt-in or top-level
       // delivery by passing undefined.
-      assertOutboundAllowed(args.chat_id, args.thread_ts)
+      try {
+        assertOutboundAllowed(args.chat_id, args.thread_ts)
+      } catch (outboundErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'react',
+          sessionKey: args.thread_ts !== undefined ? { channel: args.chat_id, thread: args.thread_ts } : undefined,
+          input: { channel: args.chat_id, thread_ts: args.thread_ts },
+          reason: outboundErr instanceof Error ? outboundErr.message : String(outboundErr),
+        })
+        throw outboundErr
+      }
+      journalWrite({
+        kind: 'gate.outbound.allow',
+        outcome: 'allow',
+        toolName: 'react',
+        sessionKey: args.thread_ts !== undefined ? { channel: args.chat_id, thread: args.thread_ts } : undefined,
+        input: { channel: args.chat_id, thread_ts: args.thread_ts },
+      })
       await web.reactions.add({
         channel: args.chat_id,
         timestamp: args.message_id,
@@ -613,7 +679,26 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Editing a message engages with the thread that message lives
       // in. Callers that know the thread pass `thread_ts`; otherwise
       // the gate falls back to channel-level opt-in or top-level.
-      assertOutboundAllowed(args.chat_id, args.thread_ts)
+      try {
+        assertOutboundAllowed(args.chat_id, args.thread_ts)
+      } catch (outboundErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'edit_message',
+          sessionKey: args.thread_ts !== undefined ? { channel: args.chat_id, thread: args.thread_ts } : undefined,
+          input: { channel: args.chat_id, thread_ts: args.thread_ts },
+          reason: outboundErr instanceof Error ? outboundErr.message : String(outboundErr),
+        })
+        throw outboundErr
+      }
+      journalWrite({
+        kind: 'gate.outbound.allow',
+        outcome: 'allow',
+        toolName: 'edit_message',
+        sessionKey: args.thread_ts !== undefined ? { channel: args.chat_id, thread: args.thread_ts } : undefined,
+        input: { channel: args.chat_id, thread_ts: args.thread_ts },
+      })
       await web.chat.update({
         channel: args.chat_id,
         ts: args.message_id,
@@ -631,7 +716,26 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       const channel: string = args.channel
       const threadTs: string | undefined = args.thread_ts
       const limit = Math.min(args.limit || 20, 100)
-      assertOutboundAllowed(channel, threadTs)
+      try {
+        assertOutboundAllowed(channel, threadTs)
+      } catch (outboundErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'fetch_messages',
+          sessionKey: threadTs !== undefined ? { channel, thread: threadTs } : undefined,
+          input: { channel, thread_ts: threadTs },
+          reason: outboundErr instanceof Error ? outboundErr.message : String(outboundErr),
+        })
+        throw outboundErr
+      }
+      journalWrite({
+        kind: 'gate.outbound.allow',
+        outcome: 'allow',
+        toolName: 'fetch_messages',
+        sessionKey: threadTs !== undefined ? { channel, thread: threadTs } : undefined,
+        input: { channel, thread_ts: threadTs },
+      })
 
       let messages: any[]
       if (threadTs) {
@@ -682,7 +786,26 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Download engages with the thread the target message lives
       // in. Callers that know the thread pass `thread_ts`; the gate
       // falls back to channel-level opt-in or top-level otherwise.
-      assertOutboundAllowed(channel, args.thread_ts)
+      try {
+        assertOutboundAllowed(channel, args.thread_ts)
+      } catch (outboundErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'download_attachment',
+          sessionKey: args.thread_ts !== undefined ? { channel, thread: args.thread_ts } : undefined,
+          input: { channel, thread_ts: args.thread_ts },
+          reason: outboundErr instanceof Error ? outboundErr.message : String(outboundErr),
+        })
+        throw outboundErr
+      }
+      journalWrite({
+        kind: 'gate.outbound.allow',
+        outcome: 'allow',
+        toolName: 'download_attachment',
+        sessionKey: args.thread_ts !== undefined ? { channel, thread: args.thread_ts } : undefined,
+        input: { channel, thread_ts: args.thread_ts },
+      })
 
       // Fetch the specific message to get file info
       const res = await web.conversations.replies({
@@ -835,7 +958,24 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
   // so approvals surface in the same thread the tool call originated
   // from. Falls back to top-level only when we're using an opted-in
   // channel with no active thread (lastActiveThread === undefined).
-  assertOutboundAllowed(targetChannel, lastActiveThread)
+  try {
+    assertOutboundAllowed(targetChannel, lastActiveThread)
+  } catch (outboundErr) {
+    journalWrite({
+      kind: 'gate.outbound.deny',
+      outcome: 'deny',
+      sessionKey: lastActiveThread !== undefined ? { channel: targetChannel, thread: lastActiveThread } : undefined,
+      input: { channel: targetChannel, thread_ts: lastActiveThread },
+      reason: outboundErr instanceof Error ? outboundErr.message : String(outboundErr),
+    })
+    return
+  }
+  journalWrite({
+    kind: 'gate.outbound.allow',
+    outcome: 'allow',
+    sessionKey: lastActiveThread !== undefined ? { channel: targetChannel, thread: lastActiveThread } : undefined,
+    input: { channel: targetChannel, thread_ts: lastActiveThread },
+  })
 
   pruneStalePermissions()
   // Pin the request to the thread it was issued from. The button /
@@ -1118,10 +1258,31 @@ async function handleMessage(event: unknown): Promise<void> {
 
   const result = await gate(event)
   switch (result.action) {
-    case 'drop':
+    case 'drop': {
+      journalWrite({
+        kind: 'gate.inbound.drop',
+        outcome: 'drop',
+        actor: ev['bot_id'] ? 'peer_agent' : 'session_owner',
+        input: {
+          channel: ev['channel'] as string,
+          user: ev['user'] as string | undefined,
+        },
+      })
       return
+    }
 
     case 'pair': {
+      // Emit pairing.issued for new codes only — resends don't create new
+      // entries in pending, so they are not a new issuance event.
+      if (!result.isResend) {
+        journalWrite({
+          kind: 'pairing.issued',
+          outcome: 'n/a',
+          actor: 'system',
+          input: { channel: ev['channel'] as string },
+        })
+      }
+
       const msg = result.isResend
         ? `Your pairing code is still: *${result.code}*\nAsk the Claude Code user to run: \`/slack-channel:access pair ${result.code}\``
         : `Hi! I need to verify you before connecting.\nYour pairing code: *${result.code}*\nAsk the Claude Code user to run: \`/slack-channel:access pair ${result.code}\``
@@ -1152,6 +1313,18 @@ async function handleMessage(event: unknown): Promise<void> {
       const channelId = ev['channel'] as string
       const incomingThreadTs = ev['thread_ts'] as string | undefined
       deliveredThreads.add(libDeliveredThreadKey(channelId, incomingThreadTs))
+
+      journalWrite({
+        kind: 'gate.inbound.deliver',
+        outcome: 'allow',
+        actor: ev['bot_id'] ? 'peer_agent' : 'session_owner',
+        sessionKey: { channel: channelId, thread: incomingThreadTs ?? (ev['ts'] as string) },
+        input: {
+          channel: channelId,
+          user: ev['bot_id'] ? (ev['bot_id'] as string) : (ev['user'] as string | undefined),
+          thread_ts: incomingThreadTs,
+        },
+      })
 
       // Activate session and record inbound activity via the supervisor.
       // The thread key follows session-state-machine.md §39: top-level
@@ -1469,6 +1642,7 @@ async function main(): Promise<void> {
   supervisor = createSessionSupervisor({
     stateRoot: STATE_DIR,
     idleMs: resolveIdleMs(process.env),
+    journal: journal ?? undefined,
   })
 
   // Idle reaper: one pass every 60 s, finds sessions whose lastActiveAt is

--- a/supervisor.ts
+++ b/supervisor.ts
@@ -38,6 +38,7 @@
 
 import { loadSession, saveSession, sessionPath } from './lib'
 import type { Session, SessionKey } from './lib'
+import type { JournalWriter } from './journal'
 
 // ---------------------------------------------------------------------------
 // Lifecycle state
@@ -281,6 +282,13 @@ export interface SupervisorOptions {
    *  `SLACK_SESSION_IDLE_MS` env var documented in
    *  session-state-machine.md §119. */
   idleMs?: number
+  /** Optional audit journal writer. When provided, the supervisor emits
+   *  `session.activate`, `session.quiesce`, and `session.deactivate` events
+   *  at the corresponding state transitions. Journal write failures are
+   *  logged and swallowed — they must never interrupt message delivery or
+   *  session lifecycle (audit-journal-architecture.md invariant: broken
+   *  journal MUST NOT take down the hot path). */
+  journal?: JournalWriter
 }
 
 /** Default idle threshold: 4 hours in ms. Documented in
@@ -338,7 +346,24 @@ export function createSessionSupervisor(
   const log = opts.log ?? defaultLog
   const clock = opts.clock ?? Date.now
   const idleMs = opts.idleMs ?? DEFAULT_IDLE_MS
-  const { stateRoot } = opts
+  const { stateRoot, journal } = opts
+
+  /** Awaitable journal write for session lifecycle transitions. Never throws —
+   *  a broken journal MUST NOT take down the session lifecycle path. Errors are
+   *  forwarded to `log`. Returns a promise so callers in non-hot paths (quiesce,
+   *  deactivate) can await completion before they return — this ensures that
+   *  the journal file is durable before the supervisor's own state changes. */
+  async function journalWrite(input: Parameters<JournalWriter['writeEvent']>[0]): Promise<void> {
+    if (journal === undefined) return
+    try {
+      await journal.writeEvent(input)
+    } catch (err: unknown) {
+      log('journal.write_error', {
+        kind: input.kind,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
 
   // Live handles, keyed by the stringified SessionKey. Use a composite
   // string because `Map<object, ...>` keys by reference and two equal-
@@ -441,6 +466,12 @@ export function createSessionSupervisor(
       thread: key.thread,
       ownerId: session.ownerId,
     })
+    await journalWrite({
+      kind: 'session.activate',
+      outcome: 'n/a',
+      actor: 'system',
+      sessionKey: key,
+    })
 
     return handle
   }
@@ -491,7 +522,7 @@ export function createSessionSupervisor(
       return promise
     },
 
-    quiesce(key: SessionKey): Promise<void> {
+    async quiesce(key: SessionKey): Promise<void> {
       const id = keyId(key)
       const handle = live.get(id)
       if (handle === undefined) {
@@ -500,7 +531,7 @@ export function createSessionSupervisor(
         // handle to transition and no work to flush. Do not emit a
         // log line for the empty case; it adds no information and
         // would confuse the journal sink's per-session correlation.
-        return Promise.resolve()
+        return
       }
 
       log('session.quiesce', {
@@ -509,7 +540,19 @@ export function createSessionSupervisor(
         inflight: handle.inFlight.size,
       })
 
-      return handle.beginQuiesce()
+      // beginQuiesce() transitions the state active → quiescing synchronously.
+      // The journal write follows so the state is already visible to concurrent
+      // callers when the event is persisted. Journal errors never abort the
+      // quiesce path — beginQuiesce already began.
+      const drainPromise = handle.beginQuiesce()
+      await journalWrite({
+        kind: 'session.quiesce',
+        outcome: 'n/a',
+        actor: 'system',
+        sessionKey: key,
+      })
+
+      return drainPromise
     },
 
     async deactivate(key: SessionKey): Promise<void> {
@@ -584,6 +627,12 @@ export function createSessionSupervisor(
       log('session.deactivate', {
         channel: key.channel,
         thread: key.thread,
+      })
+      await journalWrite({
+        kind: 'session.deactivate',
+        outcome: 'n/a',
+        actor: 'system',
+        sessionKey: key,
       })
     },
 


### PR DESCRIPTION
Batch 3 PR C of 3 — the audit journal now records the events the design doc declared. #92 + #93 were the prerequisites; this closes the wiring triplet.

## Integration points wired

| Event | Call site |
|---|---|
| `gate.inbound.deliver` | `handleMessage` deliver case, after `deliveredThreads.add()` |
| `gate.inbound.drop` | `handleMessage` drop case, before returning |
| `gate.outbound.allow` | Each tool handler (`reply`, `react`, `edit_message`, `fetch_messages`, `download_attachment`) + permission notification handler, on successful `assertOutboundAllowed()` |
| `gate.outbound.deny` | Each tool handler catch block + permission notification handler, on `assertOutboundAllowed()` throw |
| `exfil.block` | `reply` tool file-upload loop, on `assertSendable()` throw |
| `session.activate` | `supervisor.ts` `doActivate()`, after session file created/loaded |
| `session.quiesce` | `supervisor.ts` `quiesce()`, after `handle.beginQuiesce()` (state already `quiescing`) |
| `session.deactivate` | `supervisor.ts` `deactivate()`, after `live.delete(id)` |
| `pairing.issued` | `handleMessage` pair case, on `isResend === false` only |

## EventKind name mappings (brief → actual code)

| Brief name | Actual `journal.ts` name | Notes |
|---|---|---|
| `pairing.created` | `pairing.issued` | Code uses `issued` |
| `pairing.claimed` | `pairing.accepted` | Not wired — `accepted` happens in the `/slack-channel:access pair` CLI skill, outside the server process |
| `pairing.expired` | `pairing.expired` | Not wired — `pruneExpired()` doesn't surface which codes were removed; separate follow-up if needed |

## Architecture decisions

- **`journalWrite` in `server.ts`** is fire-and-forget for the gate hot path. Errors are logged to stderr and swallowed so a broken journal never blocks message delivery.
- **`journalWrite` in `supervisor.ts`** is awaited for session lifecycle transitions (not in the hot path). This ensures the journal event is durable before the supervisor's own state changes, and makes the test sequence deterministic without race conditions.
- **`journal` dependency** added to `SupervisorOptions` — optional `JournalWriter` — passed in from `server.ts` `main()`.
- **Quiesce ordering**: `handle.beginQuiesce()` (state transition) runs BEFORE `await journalWrite(...)` so concurrent callers see `state === 'quiescing'` immediately, not after the journal flush.

## NOT in this PR

- No new EventKinds
- No changes to `journal.ts` internals
- No changes to `gate()`, `assertOutboundAllowed()`, `assertSendable()` logic
- No operator CLI for `verifyJournal` (separate bead `ccsc-t7j`)
- No `server.ts` split

## New tests (6, total 430 from 424)

1. `gate.inbound.deliver is emitted on an allowed inbound message` — verifies event kind, outcome, actor, sessionKey
2. `gate.inbound.drop is emitted when gate returns drop` — verifies payload has no message body (leakage check)
3. `gate.outbound.deny is emitted when assertOutboundAllowed throws` — verifies kind, outcome, toolName, reason string present
4. `exfil.block is emitted when assertSendable blocks a state-dir file` — verifies reason does not contain state dir path
5. `supervisor emits session.activate, session.quiesce, session.deactivate in order` — verifies ordering and monotonic seq chain
6. `a broken journal writer does not prevent inbound message delivery or supervisor activation` — verifies hot-path resilience; confirms session file still created on disk

Refs `000-docs/audit-journal-architecture.md`

Closes ccsc-3fo

Jeremy made me do it
-claude