### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-04-19
+
+### Added
+- **SessionHandle.update() mutex-serialized state mutation** (#92) — closes the "not yet implemented" stub from v0.5.0. `update(fn)` now uses a per-handle write queue so concurrent tool calls serialize their state transitions. `saveSession` uses `await writeFile` instead of `writeFileSync` and propagates file-write failures via `Error.cause`.
+- **SessionSupervisor wired into server.ts** (#93) — the supervisor from v0.5.0 is now live: `createSessionSupervisor(STATE_DIR)` at boot, `supervisor.activate()` on every inbound message (human and peer-bot), idle reaper on 60s interval via `SLACK_SESSION_IDLE_MS`, `supervisor.shutdown()` on SIGTERM/SIGINT/stdin-EOF. Quarantine tracking persists across deactivate/activate cycles.
+- **Journal event emission at gate/session/pairing paths** (#94) — 10 of the 19 `EventKind` values now fire in production: `system.boot`, `system.shutdown`, `gate.inbound.deliver`, `gate.inbound.drop`, `gate.outbound.allow`, `gate.outbound.deny`, `exfil.block`, `session.activate`, `session.quiesce`, `session.deactivate`. Remaining `pairing.*` and `policy.*` events land when their trigger points exist (pairing.accepted lives in the CLI skill, not the server). Journal path: `~/.claude/channels/slack/audit.log`.
+- **430 tests** — up from 370 in v0.5.0 (+60 covering the security fixes and wiring).
+
+### Fixed
+- **`assertSendable` state-root denylist (S1)** (#86) — `assertSendable` now accepts an explicit `stateRoot` parameter and rejects any path under it (via `isUnderRoot` + realpath resolution). Closes the doc-vs-code gap where CLAUDE.md claimed `.env`/`access.json`/`audit.log`/`sessions/` were blocked, but only `allowlistRoots` + basename denylists were enforced. Operators who misconfigure `SLACK_SENDABLE_ROOTS=~/.claude` no longer leak `access.json`.
+- **Journal broken-flag + schema-parse ordering (S2, S3)** (#89) — `_doWrite` now checks `if (this.broken) throw this.broken` at entry, ensuring in-flight queue entries reject correctly. ZodError during `JournalEvent.parse()` no longer sets `this.broken` (schema errors are retriable); parse now runs before hash computation so a bad event never mutates state.
+- **`loadSession` Zod schema validation (S4)** (#87) — `loadSession` now validates against a strict `SessionSchema` Zod schema. Corrupt/attacker-modified session files (e.g., `ownerId: 123`) throw at load time instead of passing through to the supervisor. Added `owner` alias for `ownerId` during migration.
+- **Per-tool Zod input schemas for MCP handlers (S5)** (#91) — All 9 MCP tools (`reply`, `react`, `edit_message`, `fetch_messages`, `download_attachment`, `upload_file`, `list_channels`, `get_thread_replies`, `list_sessions`) now validate args via `safeParse` at switch entry. Malformed calls return structured error objects with `code: "invalid_params"` instead of runtime exceptions.
+- **Supervisor quarantine state survives deactivate (S6)** (#90) — `SessionSupervisor` now tracks quarantined keys in a `Map<string, Error>`. `deactivate()` on a quarantined handle moves it to the quarantine map (not silent deletion). `activate()` on a quarantined key rejects with the original error until explicit `clearQuarantine(key)`.
+
+### Changed
+- **Known caveats section removed** — the `SessionHandle.update()` stub blocker no longer applies; supervisor is fully wired.
+
 ## [0.5.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# claude-code-slack-channel v0.5.0
+# claude-code-slack-channel v0.5.1
 
 Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channels, just like you'd chat in the terminal. Per-thread session isolation, hash-chained tamper-evident audit journal, policy-gated tools, five-layer prompt-injection defense.
 
@@ -6,7 +6,7 @@ Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channe
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jeremylongshore/claude-code-slack-channel/badge)](https://scorecard.dev/viewer/?uri=github.com/jeremylongshore/claude-code-slack-channel)
 
-**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.0)
+**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.1)
 
 > **Research Preview** — Channels require Claude Code v2.1.80+ and `claude.ai` login.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# claude-code-slack-channel v0.5.0
+# claude-code-slack-channel v0.5.1
 
 Two-way Slack channel for Claude Code — chat from Slack DMs and channels, approve tool calls from your phone.
 
@@ -8,7 +8,7 @@ A `claude/channel` implementation for Slack. Socket Mode (outbound WebSocket, no
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jeremylongshore/claude-code-slack-channel/badge)](https://scorecard.dev/viewer/?uri=github.com/jeremylongshore/claude-code-slack-channel)
 
-**Links:** [GitHub](https://github.com/jeremylongshore/claude-code-slack-channel) · [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.0)
+**Links:** [GitHub](https://github.com/jeremylongshore/claude-code-slack-channel) · [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.1)
 
 ---
 
@@ -65,7 +65,9 @@ Security is defense-in-depth: inbound gate drops ungated messages before MCP, ou
 
 claude-code-slack-channel is a production-oriented MCP server that bridges Slack workspaces to Claude Code sessions. The implementation is split across `server.ts` (~1100 lines of stateful runtime wiring) and `lib.ts` (~915 lines of pure, testable functions), with `policy.ts`, `journal.ts`, and `supervisor.ts` providing the policy engine, audit log, and session state machine. Four runtime dependencies (`@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`) — no frameworks, no middleware, no build step for Bun.
 
-**v0.5.0** lands the big-picture redesign: per-thread session isolation (`sessions/<channel>/<thread>.json`), hash-chained tamper-evident audit journal (`journal.ts`), policy engine with monotonicity invariant + shadow-rule linter (`policy.ts`), thread-scoped outbound gate, thread-scoped pairing key, and the `slack/list_sessions` MCP tool. Supervisor and reaper live in `supervisor.ts` as an instantiated library ready for wiring in v0.5.1. ~370 tests.
+**v0.5.1** wires the supervisor and journal into production: `SessionSupervisor` boots at startup, `activate()` fires on every inbound message, idle reaper runs on 60s interval, and 10 of 19 journal EventKinds now emit (`gate.*`, `session.*`, `exfil.block`, `system.*`). Six security fixes from the pre-release audit: state-root denylist for `assertSendable`, journal broken-flag + parse ordering, Zod schema validation in `loadSession`, per-tool Zod input schemas for MCP handlers, and quarantine tracking in the supervisor. ~430 tests.
+
+**v0.5.0** landed the big-picture redesign: per-thread session isolation (`sessions/<channel>/<thread>.json`), hash-chained tamper-evident audit journal (`journal.ts`), policy engine with monotonicity invariant + shadow-rule linter (`policy.ts`), thread-scoped outbound gate, thread-scoped pairing key, and the `slack/list_sessions` MCP tool.
 
 **v0.4.0** added per-channel cross-bot message delivery via `allowBotIds` (#33 — @CaseyMargell). Multi-agent coordination: channels can opt in to receiving messages from specific peer bots (e.g., ops-monitor and engineering bots in `#incidents`). Default-safe — absent or empty `allowBotIds` preserves the "all bot messages dropped" behavior. Self-echo detection uses a triple-check (`bot_id`, `bot_profile.app_id`, `user`) to cover Slack payload variants.
 
@@ -113,7 +115,7 @@ Every security-relevant event (gate drops, policy decisions, session transitions
 
 | Metric | Value |
 |--------|-------|
-| Test Coverage | ~370 tests, security-critical functions |
+| Test Coverage | ~430 tests, security-critical functions |
 | TypeScript | Strict mode, zero errors |
 | Dependencies | 4 production deps |
 | Lines of Code | ~2000 total (`server.ts` ~1100 + `lib.ts` ~915, plus `policy.ts` / `journal.ts` / `supervisor.ts`) |
@@ -135,9 +137,9 @@ Every security-relevant event (gate drops, policy decisions, session transitions
 - Three runtime options (Bun, Node.js, Docker)
 - Governance: CODEOWNERS, SECURITY.md, PR template, branch protection, Dependabot
 
-**Roadmap (v0.5.1)**
-- Wire supervisor + journal event emission into the server hot path (currently library-only)
-- `SessionHandle.update()` mutex-serialized state mutation
+**Roadmap (v0.6.0)**
+- Remaining journal events: `pairing.accepted`, `pairing.expired`, `policy.*`
+- `evaluate()` policy enforcement in MCP tool-call path
 - Upstream PR to `anthropics/claude-plugins-official`
 
 ### Quick Reference
@@ -145,8 +147,8 @@ Every security-relevant event (gate drops, policy decisions, session transitions
 - **Repo:** [github.com/jeremylongshore/claude-code-slack-channel](https://github.com/jeremylongshore/claude-code-slack-channel)
 - **CI:** Passing (GitHub Actions — typecheck, test, CodeQL, Gemini review, Scorecard)
 - **License:** MIT
-- **Latest Release:** [v0.5.0](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.0)
-- **Test Coverage:** ~370 tests covering security-critical functions
+- **Latest Release:** [v0.5.1](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.1)
+- **Test Coverage:** ~430 tests covering security-critical functions
 - **Docs:** [Anthropic Channels Reference](https://docs.anthropic.com/en/docs/claude-code/channels) · [Plugin Spec](https://docs.anthropic.com/en/docs/claude-code/plugins)
 
 ### Contributors

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-channel-slack",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Slack channel for Claude Code — two-way chat via Socket Mode",
   "type": "module",
   "bin": "./server.ts",


### PR DESCRIPTION
## Summary
- Six security fixes from pre-release audit (S1-S6)
- SessionSupervisor + journal wired into server.ts (B1-B3)
- 430 tests (up from 370)
- CHANGELOG, README, docs/index.md updated for v0.5.1

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` — 430 pass, 0 fail

Jeremy made me do it
-claude