### PR TITLE
feat(policy): add optional thread_ts predicate to MatchSpec

### DIFF
--- a/000-docs/policy-evaluation-flow.md
+++ b/000-docs/policy-evaluation-flow.md
@@ -72,6 +72,7 @@ const MatchSpec = z.object({
   tool:       z.string().optional(),        // exact tool name
   pathPrefix: z.string().optional(),        // canonicalized via realpath before compare
   channel:    z.string().optional(),        // Slack channel ID
+  thread_ts:  z.string().optional(),        // Slack thread timestamp — schema-only in v0.5.x; Epic 29-B wires into evaluate()
   actor:      z.enum(['session_owner', 'claude_process']).optional(),
   argEquals:  z.record(z.string(), z.unknown()).optional(),
 }).refine(hasAtLeastOneField, 'match must constrain at least one field')
@@ -79,6 +80,10 @@ const MatchSpec = z.object({
 
 Three effects, first-applicable combining (see below). `priority` tie-breaks
 within effect when two rules would otherwise be equivalent.
+
+The `thread_ts` predicate is present in the v1 schema so operators can author
+thread-scoped rules against a stable shape; enforcement is deferred to Epic
+29-B alongside `evaluate()` wiring.
 
 **Why no `allow_any_of`, `allow_if_*` forms?** Every extra combinator is
 another place for a shadow. The three-effect schema is deliberately narrow;

--- a/policy.ts
+++ b/policy.ts
@@ -33,6 +33,12 @@ import { resolve, sep } from 'path'
  *  - `pathPrefix` — canonicalized via realpath by evaluate() (29-A.4);
  *                   the value stored here is the pre-resolve literal.
  *  - `channel`    — Slack channel ID, e.g. "C0123456789".
+ *  - `thread_ts`  — Slack thread timestamp, e.g. "1712345678.001100".
+ *                   Scopes a rule to a single thread within a channel.
+ *                   Schema-only in v0.5.x: reserved for Epic 29-B's
+ *                   evaluate() wiring so operators can ship thread-
+ *                   scoped rules against a stable v1 schema without a
+ *                   migration edit once enforcement lands.
  *  - `actor`      — who is calling the tool. Approvers arrive on a
  *                   later turn so they are not a valid `actor` here.
  *  - `argEquals`  — subset equality on validated MCP input args. Keys
@@ -44,6 +50,7 @@ export const MatchSpec = z
     tool: z.string().min(1).optional(),
     pathPrefix: z.string().min(1).optional(),
     channel: z.string().regex(/^[CD][A-Z0-9]+$/).optional(),
+    thread_ts: z.string().regex(/^\d+\.\d+$/).optional(),
     actor: z.enum(['session_owner', 'claude_process']).optional(),
     argEquals: z.record(z.string(), z.unknown()).optional(),
   })
@@ -52,6 +59,7 @@ export const MatchSpec = z
       m.tool !== undefined ||
       m.pathPrefix !== undefined ||
       m.channel !== undefined ||
+      m.thread_ts !== undefined ||
       m.actor !== undefined ||
       (m.argEquals !== undefined && Object.keys(m.argEquals).length > 0),
     { message: 'match must constrain at least one field' },

--- a/server.test.ts
+++ b/server.test.ts
@@ -2309,6 +2309,40 @@ describe('PolicyRule schema (29-A.1)', () => {
     ).toThrow()
   })
 
+  // ── thread_ts predicate (schema-only until Epic 29-B wires evaluate()) ─
+
+  test('MatchSpec accepts a valid Slack thread_ts', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'auto_approve',
+        match: { thread_ts: '1712345678.001100' },
+      }),
+    ).not.toThrow()
+  })
+
+  test('MatchSpec accepts thread_ts alone as the only constraint (satisfies at-least-one-field)', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    const parsed = PolicyRule.parse({
+      id: 'r1',
+      effect: 'auto_approve',
+      match: { thread_ts: '1712345678.001100' },
+    }) as { match: { thread_ts?: string } }
+    expect(parsed.match.thread_ts).toBe('1712345678.001100')
+  })
+
+  test('MatchSpec rejects malformed thread_ts (missing fractional component)', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'auto_approve',
+        match: { thread_ts: '1712345678' },
+      }),
+    ).toThrow()
+  })
+
   // ── Discriminated union variance ──────────────────────────────────────
 
   test('DenyRule requires a non-empty reason', async () => {


### PR DESCRIPTION
## Summary

- Add optional `thread_ts: z.string().regex(/^\d+\.\d+$/).optional()` to `MatchSpec` Zod schema in `policy.ts`.
- Include it in the at-least-one-field refinement.
- Three new tests in `server.test.ts`: valid thread_ts, thread_ts-alone satisfies the refinement, malformed thread_ts rejected.
- One-line schema note in `000-docs/policy-evaluation-flow.md` documenting that enforcement is deferred to Epic 29-B.

## Why now

Epic 29-B (`evaluate()` wiring) is deferred to v0.6.0. If 29-B lands without `thread_ts` in the schema, every deployed `access.json` with a thread-scoped rule will need a migration edit the moment enforcement arrives. Adding the optional field now — before any operator writes `access.json` against the v1 schema — is ~5 lines of code and zero behavior change.

This is scope-preservation, not scope-expansion. No runtime changes: `evaluate()`, `matchApplies()`, `matchSubsetOrEqual()`, and the shadow/monotonicity checks all ignore `thread_ts` by design. 29-B is the pure wiring PR that reads it.

## Test plan

- [x] `bun run typecheck` — zero errors.
- [x] `bun test` — 430 → 433 passing (3 new tests).
- [x] Schema change does not touch `evaluate()` or any runtime path.

Closes ccsc-0h6.

Jeremy made me do it
-claude