### PR TITLE
feat(journal): wire verifyJournal() as --verify-audit-log CLI subcommand

### DIFF
--- a/000-docs/audit-journal-architecture.md
+++ b/000-docs/audit-journal-architecture.md
@@ -269,17 +269,31 @@ at line 3. Deleting line 3 silently (tail truncation) is **not**
 detected by the chain alone; see §107-115 for why, and Epic 30-B for
 the external-anchor mitigation.
 
-### One-liner
+### CLI (`--verify-audit-log`)
+
+Epic 30-A.15 wires `verifyJournal()` as a `server.ts` subcommand. The
+intercept runs before any state setup — no `.env`, no `STATE_DIR`, no
+Slack client needed. An operator can copy a journal off the host and
+verify it from anywhere the repo is checked out.
 
 ```bash
-bun -e 'const { verifyJournal } = await import("./journal.ts"); const r = await verifyJournal(process.argv[1]); if (r.ok) { console.log(`ok: ${r.eventsVerified} events, chain intact`); process.exit(0); } else { const b = r.break; console.error(`tamper at line=${b.lineNumber} seq=${b.seq} ts=${b.ts}\n  reason: ${b.reason}` + (b.expected ? `\n  expected: ${b.expected}\n  actual:   ${b.actual}` : "")); process.exit(1); }' ~/.claude/channels/slack/audit.log
+bun server.ts --verify-audit-log ~/.claude/channels/slack/audit.log
 ```
+
+Output contract (stable — operators may grep):
+
+- Success: `OK: <N> event(s) verified in <path>` on stdout.
+- Break: multi-line `FAIL:` block on stderr with `line:`, `seq:`, `ts:`,
+  `reason:`, plus `expected:` / `actual:` when applicable and an
+  `events verified before break:` tail for truncation forensics.
 
 Exit codes:
 
 - `0` — chain intact end-to-end.
 - `1` — chain break (hash mismatch, `prevHash` mismatch, `seq` gap,
   schema violation, version skew, or parse error).
+- `2` — unexpected error in the verifier itself (should not happen in
+  production; surfaced for operator visibility over a silent success).
 
 ---
 

--- a/lib.ts
+++ b/lib.ts
@@ -1279,3 +1279,99 @@ export function resolveJournalPath(
 
   return { path: null, source: null }
 }
+
+// ---------------------------------------------------------------------------
+// --verify-audit-log CLI subcommand (ccsc-t7j, Epic 30-A.15)
+// ---------------------------------------------------------------------------
+
+/** Parse `--verify-audit-log` from argv. Returns the configured path, or
+ *  null when the flag is absent or malformed. Mirrors the accept/reject
+ *  rules of `resolveJournalPath`: flag-shaped values (leading `-`) and
+ *  empty values fall through rather than being silently treated as a
+ *  path. Pure — does not touch the filesystem.
+ *
+ *  Forms accepted:
+ *    - `--verify-audit-log PATH`    (space-separated)
+ *    - `--verify-audit-log=PATH`    (equals form)
+ *
+ *  When present and valid, server.ts takes the verify-and-exit path
+ *  before any state setup (no state dir, no tokens, no Slack client).
+ *  That's intentional: verifying a journal file is a pure offline read.
+ */
+export function parseVerifyArg(argv: ReadonlyArray<string>): string | null {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg === '--verify-audit-log') {
+      const next = argv[i + 1]
+      if (
+        typeof next === 'string' &&
+        next.length > 0 &&
+        !next.startsWith('-')
+      ) {
+        return next
+      }
+      continue
+    }
+    if (arg.startsWith('--verify-audit-log=')) {
+      const val = arg.slice('--verify-audit-log='.length)
+      if (val.length > 0) {
+        return val
+      }
+      continue
+    }
+  }
+  return null
+}
+
+/** Shape mirror of `VerifyResult` from journal.ts, repeated here so
+ *  lib.ts stays framework-free (no journal.ts import — avoids a cycle
+ *  and keeps lib.ts pure). Discriminated on `ok`. */
+export type VerifyResultShape =
+  | { ok: true; eventsVerified: number }
+  | {
+      ok: false
+      eventsVerified: number
+      break: {
+        lineNumber: number
+        seq: number | null
+        ts: string | null
+        reason: string
+        expected?: string
+        actual?: string
+      }
+    }
+
+/** Format a `VerifyResult` for CLI output. Returns the text to print
+ *  and the process exit code (0 on ok, 1 on break). Pure. The formatter
+ *  is intentionally verbose on failure — the operator needs line number,
+ *  seq, and the hash mismatch to locate the tamper point in the file.
+ *
+ *  Output contract (stable — operators may grep):
+ *    Success: `OK: <N> event(s) verified in <path>`
+ *    Break:   multi-line, first line starts with `FAIL:` then a reason
+ *             block with `  line:`, `  seq:`, `  ts:`, `  reason:`,
+ *             `  expected:` / `  actual:` when present.
+ */
+export function formatVerifyResult(
+  result: VerifyResultShape,
+  path: string,
+): { text: string; exitCode: 0 | 1 } {
+  if (result.ok) {
+    return {
+      text: `OK: ${result.eventsVerified} event(s) verified in ${path}`,
+      exitCode: 0,
+    }
+  }
+  const b = result.break
+  const lines = [
+    `FAIL: audit journal broken at ${path}`,
+    `  line:     ${b.lineNumber}`,
+    `  seq:      ${b.seq === null ? '(unparsed)' : String(b.seq)}`,
+    `  ts:       ${b.ts ?? '(unparsed)'}`,
+    `  reason:   ${b.reason}`,
+  ]
+  if (b.expected !== undefined) lines.push(`  expected: ${b.expected}`)
+  if (b.actual !== undefined) lines.push(`  actual:   ${b.actual}`)
+  lines.push(`  events verified before break: ${result.eventsVerified}`)
+  return { text: lines.join('\n'), exitCode: 1 }
+}

--- a/server.test.ts
+++ b/server.test.ts
@@ -5107,6 +5107,139 @@ describe('resolveJournalPath', () => {
 })
 
 // ---------------------------------------------------------------------------
+// parseVerifyArg — ccsc-t7j, Epic 30-A.15
+// ---------------------------------------------------------------------------
+
+describe('parseVerifyArg', () => {
+  const loadLib = async () => await import('./lib.ts')
+
+  test('returns null when the flag is absent', async () => {
+    const { parseVerifyArg } = await loadLib()
+    expect(parseVerifyArg([])).toBeNull()
+    expect(parseVerifyArg(['--audit-log-file', '/x'])).toBeNull()
+  })
+
+  test('picks up --verify-audit-log space-separated form', async () => {
+    const { parseVerifyArg } = await loadLib()
+    expect(parseVerifyArg(['--verify-audit-log', '/tmp/audit.log'])).toBe(
+      '/tmp/audit.log',
+    )
+  })
+
+  test('picks up --verify-audit-log=PATH equals form', async () => {
+    const { parseVerifyArg } = await loadLib()
+    expect(parseVerifyArg(['--verify-audit-log=/tmp/audit.log'])).toBe(
+      '/tmp/audit.log',
+    )
+  })
+
+  test('flag-shaped successor falls through (shell-mistake protection)', async () => {
+    // `--verify-audit-log --debug` is an operator mistake. Do not treat
+    // `--debug` as the path to verify. Mirrors resolveJournalPath rules
+    // so the two flags behave consistently.
+    const { parseVerifyArg } = await loadLib()
+    expect(parseVerifyArg(['--verify-audit-log', '--debug'])).toBeNull()
+    expect(parseVerifyArg(['--verify-audit-log', '-'])).toBeNull()
+  })
+
+  test('empty value (bare flag or trailing =) returns null', async () => {
+    const { parseVerifyArg } = await loadLib()
+    expect(parseVerifyArg(['--verify-audit-log'])).toBeNull()
+    expect(parseVerifyArg(['--verify-audit-log='])).toBeNull()
+  })
+
+  test('equals form preserves leading-hyphen literals', async () => {
+    const { parseVerifyArg } = await loadLib()
+    expect(parseVerifyArg(['--verify-audit-log=-weird.log'])).toBe(
+      '-weird.log',
+    )
+  })
+
+  test('flag works mid-argv with unrelated args around it', async () => {
+    const { parseVerifyArg } = await loadLib()
+    expect(
+      parseVerifyArg([
+        '--some-other',
+        'x',
+        '--verify-audit-log',
+        '/tmp/a.log',
+        '--trailing',
+      ]),
+    ).toBe('/tmp/a.log')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatVerifyResult — ccsc-t7j, Epic 30-A.15
+// ---------------------------------------------------------------------------
+
+describe('formatVerifyResult', () => {
+  const loadLib = async () => await import('./lib.ts')
+
+  test('success case prints count + path, exit 0', async () => {
+    const { formatVerifyResult } = await loadLib()
+    const out = formatVerifyResult(
+      { ok: true, eventsVerified: 42 },
+      '/tmp/audit.log',
+    )
+    expect(out.exitCode).toBe(0)
+    expect(out.text).toBe('OK: 42 event(s) verified in /tmp/audit.log')
+  })
+
+  test('break case prints FAIL with line/seq/ts/reason, exit 1', async () => {
+    const { formatVerifyResult } = await loadLib()
+    const out = formatVerifyResult(
+      {
+        ok: false,
+        eventsVerified: 7,
+        break: {
+          lineNumber: 8,
+          seq: 8,
+          ts: '2026-04-19T12:34:56.789Z',
+          reason: 'hash mismatch',
+          expected: 'a'.repeat(64),
+          actual: 'b'.repeat(64),
+        },
+      },
+      '/tmp/audit.log',
+    )
+    expect(out.exitCode).toBe(1)
+    expect(out.text).toContain('FAIL: audit journal broken at /tmp/audit.log')
+    expect(out.text).toContain('line:     8')
+    expect(out.text).toContain('seq:      8')
+    expect(out.text).toContain('ts:       2026-04-19T12:34:56.789Z')
+    expect(out.text).toContain('reason:   hash mismatch')
+    expect(out.text).toContain(`expected: ${'a'.repeat(64)}`)
+    expect(out.text).toContain(`actual:   ${'b'.repeat(64)}`)
+    expect(out.text).toContain('events verified before break: 7')
+  })
+
+  test('break case with unparsed seq/ts renders placeholders', async () => {
+    // Parse-error on line 1: no schema-valid event to pull seq/ts from.
+    const { formatVerifyResult } = await loadLib()
+    const out = formatVerifyResult(
+      {
+        ok: false,
+        eventsVerified: 0,
+        break: {
+          lineNumber: 1,
+          seq: null,
+          ts: null,
+          reason: 'parse error: Unexpected token',
+        },
+      },
+      '/tmp/audit.log',
+    )
+    expect(out.exitCode).toBe(1)
+    expect(out.text).toContain('seq:      (unparsed)')
+    expect(out.text).toContain('ts:       (unparsed)')
+    // Optional expected/actual omitted when absent.
+    expect(out.text).not.toContain('expected:')
+    expect(out.text).not.toContain('actual:')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // verifyJournal — ccsc-5pi.10 + happy-path E2E from ccsc-5pi.8
 // ---------------------------------------------------------------------------
 

--- a/server.ts
+++ b/server.ts
@@ -46,12 +46,52 @@ import {
   gate as libGate,
   isDuplicateEvent,
   resolveJournalPath,
+  parseVerifyArg,
+  formatVerifyResult,
   EVENT_DEDUP_TTL_MS,
   PERMISSION_REPLY_RE,
   type Access,
   type GateResult,
 } from './lib.ts'
-import { JournalWriter, createBootAnchor } from './journal.ts'
+import { JournalWriter, createBootAnchor, verifyJournal } from './journal.ts'
+
+// ---------------------------------------------------------------------------
+// --verify-audit-log subcommand (ccsc-t7j, Epic 30-A.15)
+//
+// Intercept before any state setup runs. Verifying a journal file is a
+// pure offline read: no state dir, no tokens, no Slack client required.
+// Running this path through the normal bootstrap would fail on machines
+// that don't have `.env` or INBOX_DIR configured, which is exactly where
+// an operator is most likely to verify a copied-off journal file.
+//
+// Runs at module load via top-level await, not inside main(), because
+// the module-level code below (SENDABLE_ROOTS validation, mkdirSync for
+// STATE_DIR/INBOX_DIR, loadEnv) executes before main() is called and
+// would abort a pure verify invocation. The await also keeps the
+// process alive until verifyJournal resolves, so process.exit fires
+// before the synchronous bootstrap side-effects run.
+// ---------------------------------------------------------------------------
+const _verifyPath = parseVerifyArg(process.argv.slice(2))
+if (_verifyPath !== null) {
+  const absPath = resolve(_verifyPath)
+  try {
+    const result = await verifyJournal(absPath)
+    const { text, exitCode } = formatVerifyResult(result, absPath)
+    if (exitCode === 0) {
+      console.log(text)
+    } else {
+      console.error(text)
+    }
+    process.exit(exitCode)
+  } catch (err) {
+    console.error(
+      `[slack] verify-audit-log: unexpected error: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    )
+    process.exit(2)
+  }
+}
 import {
   createSessionSupervisor,
   resolveIdleMs,


### PR DESCRIPTION
## Summary

Closes the design-doc-vs-code gap from [`000-docs/audit-journal-architecture.md`](./000-docs/audit-journal-architecture.md#237-283): the doc specified a verify command behavior but never wired the CLI surface. `verifyJournal()` shipped in Epic 30-A — this just exposes it.

```bash
bun server.ts --verify-audit-log ~/.claude/channels/slack/audit.log
# OK: <N> event(s) verified in <path>   (exit 0)
# FAIL: audit journal broken at <path>  (exit 1, with line/seq/ts/reason/expected/actual)
```

## Why this is retroactive v0.5.1 cleanup, not v0.6.0 pull-forward

The verify function itself shipped in v0.5.0 with the journal. The design doc has shipped with a specced-out CLI since then. Wiring the flag is a pure-delta completion of what v0.5.0 promised — zero new scope. The bead (ccsc-t7j) was unlabeled for exactly this reason.

## Design choices

**Intercept at module load, not inside main().** The intercept runs at module load via top-level await, before any state setup (`SENDABLE_ROOTS` validation, `STATE_DIR` `mkdirSync`, `loadEnv`). That lets an operator copy a journal off the production host and verify it from a checkout with no `.env` and no tokens — exactly where verification matters most.

**Pure helpers in `lib.ts`.** `parseVerifyArg` mirrors the accept/reject rules of the existing `resolveJournalPath` (flag-shaped successors rejected, empty values fall through, equals form preserves literals). `formatVerifyResult` has a stable text contract (operators may grep `^OK:` / `^FAIL:`). No `journal.ts` import in `lib.ts` — avoids a cycle and keeps `lib.ts` pure.

**Exit codes**: 0 intact, 1 break, 2 unexpected verifier error (the third is for operator-visible internal failure — preferable to a silent success path).

## Files touched

| File | Change |
|------|--------|
| `lib.ts` | `parseVerifyArg`, `formatVerifyResult`, `VerifyResultShape` type |
| `server.ts` | Module-level top-level await intercept, before any state setup |
| `server.test.ts` | 10 new tests (parseVerifyArg: 7, formatVerifyResult: 3) |
| `000-docs/audit-journal-architecture.md` | Replace inline `bun -e` one-liner with real CLI flag as primary form |

## Test plan

- [x] `bun run typecheck` — zero errors
- [x] `bun test` — 433 → 443 passing (10 new)
- [x] E2E smoke test — nonexistent path: FAIL exit 1 (read error)
- [x] E2E smoke test — valid log: `OK: 2 event(s) verified` exit 0
- [x] E2E smoke test — tampered line: FAIL exit 1 with line/seq/ts/expected/actual
- [x] Verified the intercept runs before `SENDABLE_ROOTS` validation (no `.env` required)

Closes ccsc-t7j.

Jeremy made me do it
-claude