### PR TITLE
docs(release): v0.6.0 release plan — theme, cut line, order of operations

### DIFF
--- a/000-docs/v0.6.0-release-plan.md
+++ b/000-docs/v0.6.0-release-plan.md
@@ -1,0 +1,192 @@
+# v0.6.0 Release Plan
+
+Written before any v0.6.0-labeled code lands. Mirrors the design-in-public
+pattern used for every other frozen doc in `000-docs/`: the release's shape
+is fixed here, then PRs land against it. A PR that contradicts this plan is
+a revert, not a merge — until this doc is amended.
+
+**Status**: FROZEN on 2026-04-19. Amended only by a PR that edits this file
+first and is merged before the contradicting code.
+
+---
+
+## Theme
+
+**Enforcement.** v0.5.x built the primitives (gate, supervisor, hash-chained
+journal, policy schema). v0.6.0 turns the policy schema into a decision
+procedure that actually *blocks* tool calls, with human-approver flows,
+`user_id`-bound dedup, and policy-decision traces emitted to the journal
+that v0.5.1 shipped.
+
+One sentence: *"The policy engine stops being schema-only and starts
+refusing tool calls."*
+
+---
+
+## Cut line
+
+| Status | Epic | What ships |
+|--------|------|------------|
+| **IN** | Epic 29-B (`ccsc-me6`) | `evaluate()` wired into the permission-relay handler; `auto_approve` / `deny` / `require` branches; multi-approver state machine keyed on verified Slack `user_id`; UTC clock injection; startup warnings; `policy.decision` trace events. |
+| **IN** | Journal extension (`ccsc-4an`) | Wire `pairing.accepted` + `pairing.expired` EventKinds — the two of the 19 declared kinds that v0.5.1 deferred. Closes the observability gap without adding new doctrine. |
+| **OUT — defer** | Epic 30-B (Slack receipts projection, `ccsc-dhh.*`) | Requires 29-B landed first (policy decisions are the content of the projection). Fold into v0.6.1 once 29-B is live and stable. |
+| **OUT — defer to v0.7** | Epic 31-A/B (peer bot manifest protocol, `ccsc-s53` + `ccsc-0qk` trees) | Held conditional on a cryptographic identity primitive (Slack signed-message, A2A identity framework, or bot mTLS). None exist. See [Deferral rationale](#why-epic-31-ab-defers) below. |
+| **OUT — follow-up** | `ccsc-otd` (JournalWriter reverse-chunk read) | Performance-only. Per-developer installs are fine. v0.7 at earliest. |
+| **OUT — follow-up** | `ccsc-4vi` (code-scanning alert triage) | Chore. File-and-forget; can happen any release. |
+
+---
+
+## Why Epic 31-A/B defers
+
+The epic ships the `slack/read_peer_manifests` MCP tool and the publish
+side of a bot-to-bot capability advertisement protocol. The invariant from
+Miller 2006 — *"advertisements are not grants"* — is sound in the spec
+([`bot-manifest-protocol.md`](./bot-manifest-protocol.md)): manifest data
+never reaches `evaluate()`, `policy.ts` has no import from the manifest
+module, role truth lives only in `access.json`.
+
+But invariant-on-paper is not the risk. The risk is that *reading a
+manifest creates a new information channel that becomes a trust assumption
+in operator practice*. A peer bot advertises "I'm an approver." Without
+cryptographic message integrity, any actor with the peer's bot token can
+forge that advertisement. Operators — not the code, but the humans reading
+thread traffic — start believing the advertisement. The threat model's
+T9 (identity forgery) becomes load-bearing.
+
+Shipping the consumer side before one of these lands is reckless:
+
+1. Slack signed-message primitive (workspace-signed metadata).
+2. A2A identity framework (cross-agent trust signal).
+3. Bot mTLS (workspace-level cryptographic identity binding).
+
+None currently exist. The 33 open beads in the `s53` + `0qk` trees stay
+labeled `release:v0.6.0` as an aspirational tag; **this plan overrides**
+and pushes the entire subtree to v0.7.0 minimum. A separate doc amendment
+will re-open the question when an identity primitive arrives.
+
+---
+
+## Order of operations
+
+Ordered so each step produces an independently-reviewable PR and the
+branch stays small. Every bead gets a descendant of its sub-epic's first
+bead; no mega-commits.
+
+### Phase 1 — Wire the evaluator (4 beads, `ccsc-me6.13` sub-epic)
+
+1. **`ccsc-me6.1`** — Consult `evaluate()` at the permission-relay entry
+   in `server.ts`. Grep anchor: `pendingPermissions` or the Block Kit
+   payload constructor. Emits nothing yet; just threads the decision.
+2. **`ccsc-me6.2`** — `auto_approve` branch: bypass Block Kit, emit
+   decision trace.
+3. **`ccsc-me6.3`** — `deny` branch: post `reason` to thread, no prompt,
+   no exec.
+4. **`ccsc-me6.11`** — Emit `policy.decision` events to the journal
+   (consumes the Epic 30-A writer that v0.5.1 shipped).
+
+**PR target**: 1 PR covering 29-B.1 through 29-B.3 + 29-B.11. Decision
+wiring + trace events are one coherent unit. Estimated 200–400 lines
+of code + tests.
+
+### Phase 2 — Multi-approver state machine (4 beads, `ccsc-me6.14` sub-epic)
+
+5. **`ccsc-me6.4`** — `require` branch: pending-approvers map keyed on
+   `(thread_ts, requestId)`. Uses the `thread_ts` predicate that PR #96
+   added to `MatchSpec`.
+6. **`ccsc-me6.5`** — Approver dedup on verified Slack `user_id`, **not**
+   display name. (Issue #97 is the binding constraint — cite it in the
+   PR description.)
+7. **`ccsc-me6.6`** — UTC clock injection for `auto_approve.window` TTL
+   comparisons.
+8. **`ccsc-me6.7`** — Startup warning: log rules with empty `match` +
+   `auto_approve` as a footgun operators should narrow.
+
+**PR target**: 1 PR. The four beads are orthogonal to Phase 1 but mutually
+entangled (the require branch in Phase 1 stubs what Phase 2 implements).
+Estimated 300–500 lines.
+
+### Phase 3 — Integration tests (3 beads, `ccsc-me6.15` sub-epic)
+
+9. **`ccsc-me6.8`** — `auto_approve` for `read_file /safe` does NOT prompt.
+10. **`ccsc-me6.9`** — `require:2` needs two distinct `user_id`s.
+11. **`ccsc-me6.10`** — `deny` surfaces reason in thread, no exec.
+
+**PR target**: 1 PR. Locks the behavior in once Phases 1+2 are live.
+
+### Phase 4 — Journal pairing extension + changelog (2 beads)
+
+12. **`ccsc-4an`** — Wire `pairing.accepted` + `pairing.expired` events.
+    IPC for the first; `pruneExpired()` refactor for the second.
+13. **`ccsc-me6.12`** — CHANGELOG `[Unreleased]` entries for 29-B.
+14. **`ccsc-me6.16`** — The epic-root "v0.6.0 changelog entry" bead —
+    close at release time after stamping the version number.
+
+**PR target**: 2 PRs (pairing events; docs). Docs PR is the release gate.
+
+---
+
+## Risks & open questions
+
+### R1 — `pending-approvers` persistence across restarts
+v0.5.1's supervisor persists `sessions/<channel>/<thread>.json` but the
+policy's pending-approvers map is currently in-process. A restart mid-
+approval abandons the pending request silently. **Open question**: does
+the pending-approvers map piggyback on the session JSON, or does it live
+in its own file?
+
+**Decision owner**: whoever claims `ccsc-me6.4`. Bead description should
+be amended with the answer before implementation, not after.
+
+### R2 — `policy.decision` event volume
+Every tool call produces a policy decision; this could 10× journal
+write volume on a busy channel. `ccsc-otd` (reverse-chunk read) becomes
+load-bearing faster than we expected. **Mitigation**: revisit `ccsc-otd`
+priority if Phase 1 profiling shows `JournalWriter.open()` dominating
+cold-start on logs > 10 MB.
+
+### R3 — Startup warnings vs. hard fails
+Epic 29-A shipped `detectShadowing()` as warn-not-block. 29-B's startup
+warning (`me6.7`) follows the same posture. **Open question**: at what
+point does "warn" become "refuse to boot"? Proposal: never. Operators
+who intentionally author broad auto_approve rules (e.g., during a
+bootstrap) shouldn't be blocked. Document the intentional drift in the
+PR that wires the warning.
+
+---
+
+## Non-goals
+
+Explicit exclusions so reviewers can reject scope expansion cleanly:
+
+1. **Approver-role verification via manifest.** Requires Epic 31-A, which
+   is deferred. Multi-approver in 29-B binds on Slack `user_id` alone;
+   the *role* of that user_id is looked up in `access.json`.
+2. **Policy hot-reload during a running approval.** Monotonicity check
+   (`checkMonotonicity()`, 29-A) is the hot-reload invariant. 29-B does
+   not add a reload trigger — operators restart the server.
+3. **Approval revocation UI.** A granted approval runs to its `ttlMs`
+   ceiling and expires. No "revoke" affordance. File if needed post-v0.6.
+4. **Rate limits on Block Kit posts.** Out of scope; Slack will rate-limit
+   us if we misbehave, and that's observable.
+
+---
+
+## Exit criteria
+
+v0.6.0 ships when:
+
+1. All beads listed under [Order of operations](#order-of-operations) are
+   closed with evidence.
+2. `bun test` passes (target: ~500 tests from the current 443 baseline).
+3. `bun run typecheck` clean.
+4. CHANGELOG `[Unreleased]` promoted to `[v0.6.0]` with the release date.
+5. README updated if (and only if) a user-visible behavior changed —
+   likely a section on operator-authored policy rules.
+6. No `release:v0.5.x` labeled open beads remain (hygiene).
+
+---
+
+## Amendment log
+
+- **2026-04-19** — Initial plan written after v0.5.1 shipped. Defers
+  31-A/B to v0.7.0. First bead to claim: `ccsc-me6.1`. — `ccsc-8rj`.


### PR DESCRIPTION
## Summary

Frozen v0.6.0 release plan at [`000-docs/v0.6.0-release-plan.md`](./000-docs/v0.6.0-release-plan.md). Written after research across three subagents mapping Epic 29-B (17 beads), v0.6.0 journal follow-ups (ccsc-4an), and Epic 31-A/B (33 beads, currently labeled v0.6.0).

## Key scope decisions

| Decision | Epic | Rationale |
|----------|------|-----------|
| **IN** | Epic 29-B (`ccsc-me6` tree) | Pure wiring: `evaluate()` already exists (Epic 29-A shipped, `ccsc-v1b` closed). 29-B is the enforcement epic this release is built around. |
| **IN** | `ccsc-4an` (pairing journal events) | Closes the 2-of-19 EventKind gap v0.5.1 deferred. |
| **OUT → v0.6.1** | Epic 30-B Slack receipts (`ccsc-dhh.*`) | Depends on 29-B landing first. |
| **OUT → v0.7.0 minimum** | Epic 31-A/B (`ccsc-s53` + `ccsc-0qk`, 33 beads) | Held on a cryptographic identity primitive that doesn't exist (Slack signed-message, A2A, or bot mTLS). Invariant-on-paper is sound; operator-trust-assumption risk is real. |

## Why 31-A/B defers (the hard call)

The [Miller 2006 invariant](./000-docs/bot-manifest-protocol.md) — *"advertisements are not grants"* — is technically enforced: manifest data never reaches `evaluate()`, `policy.ts` has no import from the manifest module. But *reading* a manifest creates a new information channel. Without message-integrity signing, a compromised peer bot can forge capability advertisements, and operators — humans, not code — start trusting them. T9 (identity forgery) becomes load-bearing. Shipping the consumer before the identity primitive exists is reckless. Detailed rationale in the plan doc.

This PR does NOT relabel those 33 beads — that's a follow-up housekeeping commit on main after merge, so the PR stays a pure doc-add.

## Order of operations

Four phases producing ~5 independently-reviewable PRs. First bead to claim: `ccsc-me6.1` (wire `evaluate()` at permission-relay entry). Full phase breakdown in the doc.

## Test plan

- [x] Pure doc add — no code, no tests.
- [x] `bun run typecheck` — unaffected (n/a).
- [x] Research grounded in three parallel subagent passes (Epic 29-B readiness, 30-B scope, 31-A/B deferral).
- [x] Cross-referenced `ccsc-v1b` closed, `ccsc-xa3` closed (both are 29-B prerequisites).

## After merge

Two housekeeping commits on main:
1. Relabel 33 beads (`ccsc-s53.*`, `ccsc-0qk.*`) `release:v0.6.0` → `release:v0.7.0` executing the plan's deferral.
2. Claim `ccsc-me6.1` and start Phase 1 of the plan.

Closes ccsc-8rj.

Jeremy made me do it
-claude