### PR TITLE
feat(policy): Epic 29-B Phase 1 — wire evaluate() into permission-relay

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -219,7 +219,26 @@ The evaluator is a **veto layer**, not the sole gate. Even an allowed decision s
 
 ### Where policies live
 
-Currently: policies are consumed as a `PolicyRule[]` by `evaluate()` — the loader and on-disk format land with the server integration in **Epic 29-B**. This section will be updated when the file format is frozen; until then, treat the schema above as the stable contract.
+Policies live under the top-level `policy` key in `access.json` (same file as `dmPolicy`, `allowFrom`, `channels`). The server parses and validates them **once at boot** via `parsePolicyRules()`; `detectShadowing()` runs and emits warnings to stderr. A malformed rule or a duplicate id is **fatal at boot** — the server exits with a descriptive error message. Silent degradation to "no policy" is not offered: policy enforcement is safety-critical, so a parse failure demands operator action rather than opening a hole.
+
+```json
+{
+  "dmPolicy": "allowlist",
+  "allowFrom": ["U012AB3CD4E"],
+  "channels": { "C0123456789": { "replyAllowedFrom": [] } },
+  "pending": {},
+  "policy": [
+    { "id": "safe-reads", "effect": "auto_approve", "match": { "tool": "read_file", "pathPrefix": "/workspace/docs" } },
+    { "id": "no-shell",   "effect": "deny",         "match": { "tool": "run_shell" }, "reason": "Shell execution is not permitted from this channel." }
+  ]
+}
+```
+
+A missing or empty `policy` field means "no authored rules" and is **not** an error — the evaluator applies defaults (allow most tools, deny tools in `requireAuthoredPolicy` like `upload_file`). This is the first-install path.
+
+**Hot reload is intentionally not supported** (see `000-docs/v0.6.0-release-plan.md` §R3). Operators restart the server to apply new rules. The `checkMonotonicity()` invariant is reserved for a future hot-reload path; landing one now would require a signal handler and a drain-in-flight-approvals protocol that v0.6.0 deliberately defers.
+
+Epic 29-B wired the loader and the `evaluate()` call into the permission-relay handler. The wiring lives in `server.ts` at the `PermissionRequestSchema` handler — see the `decidePermissionRoute()` helper in `lib.ts` for the pure decision-routing logic.
 
 ## File attachments — sendable roots
 

--- a/lib.ts
+++ b/lib.ts
@@ -56,6 +56,16 @@ export interface Access {
   ackReaction?: string
   textChunkLimit?: number
   chunkMode?: 'length' | 'newline'
+  /** Optional array of declarative policy rules, consumed by the
+   *  policy evaluator (see `policy.ts` and
+   *  `000-docs/policy-evaluation-flow.md`). Typed as `unknown[]` here
+   *  so lib.ts stays decoupled from policy.ts — server.ts calls
+   *  `parsePolicyRules()` to produce a validated `PolicyRule[]` at
+   *  boot. A missing or empty field means "no authored rules"; the
+   *  evaluator applies its defaults (allow for most tools, deny for
+   *  tools listed in `requireAuthoredPolicy`). Shape is documented in
+   *  ACCESS.md §Policy rules. */
+  policy?: unknown[]
 }
 
 export type GateAction = 'deliver' | 'drop' | 'pair'
@@ -1278,6 +1288,67 @@ export function resolveJournalPath(
   }
 
   return { path: null, source: null }
+}
+
+// ---------------------------------------------------------------------------
+// Policy decision routing (Epic 29-B Phase 1 — ccsc-me6.1/.2/.3)
+// ---------------------------------------------------------------------------
+
+/** Shape mirror of `PolicyDecision` from policy.ts, repeated here so
+ *  lib.ts stays framework-free (no policy.ts import — avoids a cycle
+ *  and keeps lib.ts pure). Discriminated on `kind`. */
+export type PolicyDecisionShape =
+  | { kind: 'allow'; rule?: string }
+  | { kind: 'deny'; rule: string; reason: string }
+  | { kind: 'require'; rule: string; approver: 'human_approver'; ttlMs: number }
+
+/** What the server handler should do with a policy decision. Four
+ *  outcomes, one per matrix cell in (decision.kind) × (rule matched or
+ *  default branch):
+ *
+ *   - `auto_allow`     — matched an auto_approve rule; server replies
+ *                        `allow` to Claude immediately, no Block Kit.
+ *   - `deny`           — matched a deny rule; server posts `reason` to
+ *                        the thread and replies `deny` to Claude.
+ *   - `require_human`  — matched a require_approval rule; server falls
+ *                        through to the existing Block Kit human-approver
+ *                        flow (Phase 2 adds policy-aware approval
+ *                        tracking). Journal emits a `policy.require`
+ *                        trace so the audit trail records the dispatch.
+ *   - `default_human`  — default branch `allow` with no rule match; the
+ *                        evaluator has no opinion. Fall through to the
+ *                        existing Block Kit flow unchanged. No trace
+ *                        event (silencing the no-opinion case keeps the
+ *                        journal legible on busy channels).
+ */
+export type PermissionRoute =
+  | { type: 'auto_allow'; ruleId: string }
+  | { type: 'deny'; ruleId: string; reason: string }
+  | { type: 'require_human'; ruleId: string }
+  | { type: 'default_human' }
+
+/** Pure mapping from a `PolicyDecision` to a `PermissionRoute`. Testable
+ *  without mocking MCP, Slack, or the journal.
+ *
+ *  Contract: every `PolicyDecision` maps to exactly one route. The
+ *  `default_human` case is triggered only by `{ kind: 'allow' }` with no
+ *  `rule` (the evaluator's default branch for tools outside
+ *  `requireAuthoredPolicy`). A matched `auto_approve` rule produces
+ *  `{ kind: 'allow', rule: <id> }` and routes to `auto_allow`.
+ */
+export function decidePermissionRoute(
+  decision: PolicyDecisionShape,
+): PermissionRoute {
+  switch (decision.kind) {
+    case 'allow':
+      return decision.rule !== undefined
+        ? { type: 'auto_allow', ruleId: decision.rule }
+        : { type: 'default_human' }
+    case 'deny':
+      return { type: 'deny', ruleId: decision.rule, reason: decision.reason }
+    case 'require':
+      return { type: 'require_human', ruleId: decision.rule }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/server.test.ts
+++ b/server.test.ts
@@ -5240,6 +5240,113 @@ describe('formatVerifyResult', () => {
 })
 
 // ---------------------------------------------------------------------------
+// decidePermissionRoute — ccsc-me6.1 / me6.2 / me6.3, Epic 29-B Phase 1
+//
+// Pure mapping from a PolicyDecision to a PermissionRoute. Each branch
+// of the evaluator's three-shape output must route to exactly one of
+// four outcomes: auto_allow, deny, require_human, default_human.
+// ---------------------------------------------------------------------------
+
+describe('decidePermissionRoute', () => {
+  const loadLib = async () => await import('./lib.ts')
+
+  test('matched auto_approve rule routes to auto_allow with the rule id', async () => {
+    const { decidePermissionRoute } = await loadLib()
+    expect(decidePermissionRoute({ kind: 'allow', rule: 'safe-reads' })).toEqual({
+      type: 'auto_allow',
+      ruleId: 'safe-reads',
+    })
+  })
+
+  test('default-branch allow (no rule) routes to default_human', async () => {
+    // The evaluator returns `{ kind: 'allow' }` with no `rule` when no
+    // rule matched AND the tool is not in requireAuthoredPolicy. In
+    // this case we fall through to the existing Block Kit flow — the
+    // evaluator has no opinion, so the human-approver UI stays in
+    // charge (Phase 1 doesn't auto-approve the no-opinion case).
+    const { decidePermissionRoute } = await loadLib()
+    expect(decidePermissionRoute({ kind: 'allow' })).toEqual({
+      type: 'default_human',
+    })
+  })
+
+  test('deny routes to deny with the rule id and reason propagated', async () => {
+    const { decidePermissionRoute } = await loadLib()
+    expect(
+      decidePermissionRoute({
+        kind: 'deny',
+        rule: 'no-shell',
+        reason: 'Shell execution is not permitted in this channel.',
+      }),
+    ).toEqual({
+      type: 'deny',
+      ruleId: 'no-shell',
+      reason: 'Shell execution is not permitted in this channel.',
+    })
+  })
+
+  test('default-deny (rule = "default") still routes to deny with the default reason', async () => {
+    // The evaluator's default branch for tools in requireAuthoredPolicy
+    // (e.g. upload_file with no authored rule) returns a deny with
+    // rule='default'. The route should still be 'deny' — the server
+    // handler has one deny path regardless of whether a user-authored
+    // or default rule produced the decision.
+    const { decidePermissionRoute } = await loadLib()
+    expect(
+      decidePermissionRoute({
+        kind: 'deny',
+        rule: 'default',
+        reason: "no policy authored for tool 'upload_file'",
+      }),
+    ).toEqual({
+      type: 'deny',
+      ruleId: 'default',
+      reason: "no policy authored for tool 'upload_file'",
+    })
+  })
+
+  test('require routes to require_human with the rule id (TTL is consumed by Phase 2, not Phase 1)', async () => {
+    // Phase 1 falls through to the existing Block Kit flow on require.
+    // Phase 2 (ccsc-me6.4) adds policy-aware approval tracking using
+    // the ttlMs; Phase 1 just needs to route correctly and emit the
+    // trace event.
+    const { decidePermissionRoute } = await loadLib()
+    expect(
+      decidePermissionRoute({
+        kind: 'require',
+        rule: 'dangerous-upload',
+        approver: 'human_approver',
+        ttlMs: 5 * 60 * 1000,
+      }),
+    ).toEqual({
+      type: 'require_human',
+      ruleId: 'dangerous-upload',
+    })
+  })
+
+  test('routing is exhaustive — every decision kind maps to exactly one route', async () => {
+    // Lock the matrix cells: allow/rule, allow/no-rule, deny, require.
+    // Four decisions in, four route types out. Regression-guard against
+    // a future refactor that accidentally collapses a case.
+    const { decidePermissionRoute } = await loadLib()
+    const routes = new Set([
+      decidePermissionRoute({ kind: 'allow', rule: 'r' }).type,
+      decidePermissionRoute({ kind: 'allow' }).type,
+      decidePermissionRoute({ kind: 'deny', rule: 'r', reason: 'x' }).type,
+      decidePermissionRoute({
+        kind: 'require',
+        rule: 'r',
+        approver: 'human_approver',
+        ttlMs: 1,
+      }).type,
+    ])
+    expect(routes).toEqual(
+      new Set(['auto_allow', 'default_human', 'deny', 'require_human']),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
 // verifyJournal — ccsc-5pi.10 + happy-path E2E from ccsc-5pi.8
 // ---------------------------------------------------------------------------
 

--- a/server.ts
+++ b/server.ts
@@ -48,12 +48,22 @@ import {
   resolveJournalPath,
   parseVerifyArg,
   formatVerifyResult,
+  decidePermissionRoute,
   EVENT_DEDUP_TTL_MS,
   PERMISSION_REPLY_RE,
   type Access,
   type GateResult,
 } from './lib.ts'
 import { JournalWriter, createBootAnchor, verifyJournal } from './journal.ts'
+import {
+  parsePolicyRules,
+  evaluate as policyEvaluate,
+  detectShadowing,
+  approvalKey,
+  type PolicyRule,
+  type ToolCall as PolicyToolCall,
+  type ApprovalKey,
+} from './policy.ts'
 
 // ---------------------------------------------------------------------------
 // --verify-audit-log subcommand (ccsc-t7j, Epic 30-A.15)
@@ -240,6 +250,69 @@ function getAccess(): Access {
   const access = loadAccess()
   pruneExpired(access)
   return access
+}
+
+// ---------------------------------------------------------------------------
+// Policy engine — Epic 29-B Phase 1 (ccsc-me6.1 / me6.2 / me6.3 / me6.11)
+//
+// Policy rules are loaded ONCE at module boot from access.json's `policy`
+// field, parsed + shadow-linted, and frozen into `policyRules`. Hot reload
+// is intentionally NOT wired (see 000-docs/v0.6.0-release-plan.md §R3 and
+// policy-evaluation-flow.md §234 — monotonicity check is the hot-reload
+// invariant, and operators restart to apply new rules).
+//
+// Policy approvals (short-lived TTL windows granted by human approvers
+// replying on Slack) live in a module-level Map keyed by approvalKey()
+// per policy-evaluation-flow.md §285-287. Phase 1 declares the map but
+// does NOT yet populate it from approval replies — that's me6.4/me6.5 in
+// Phase 2. Until then, a `require_approval` rule falls through to the
+// existing Block Kit human-approver flow unchanged, which is exactly the
+// right behavior for Phase 1.
+//
+// Error policy: a malformed access.json `policy` field is fatal at boot.
+// Policy enforcement is safety-critical; silent degradation to "no policy"
+// on a parse error would let calls through that the operator intended to
+// block. Fail loud so the operator fixes the config.
+// ---------------------------------------------------------------------------
+
+let policyRules: readonly PolicyRule[] = loadPolicyRulesAtBoot()
+const policyApprovals = new Map<ApprovalKey, { ttlExpires: number }>()
+
+function loadPolicyRulesAtBoot(): readonly PolicyRule[] {
+  const bootAccess = STATIC_MODE && staticAccess ? staticAccess : loadAccess()
+  const raw = bootAccess.policy
+  if (raw === undefined || (Array.isArray(raw) && raw.length === 0)) {
+    // Missing or empty `policy` field is the first-install path — no
+    // authored rules means the evaluator applies defaults (allow most
+    // tools, deny tools in requireAuthoredPolicy). Not an error.
+    return []
+  }
+  let parsed: PolicyRule[]
+  try {
+    parsed = parsePolicyRules(raw)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error(
+      `[slack] policy parse failed at boot: ${msg}\n` +
+        `  File: ${ACCESS_FILE}\n` +
+        `  Field: policy\n` +
+        `  Fix the rules or remove the policy field to boot without enforcement.`,
+    )
+    process.exit(1)
+  }
+  // detectShadowing is warn-not-block per policy-evaluation-flow.md §199
+  // — an operator may have intentionally authored an unreachable rule
+  // (e.g. as a placeholder during a refactor) and shouldn't be forced
+  // to delete it just to boot. Warnings go to stderr; a journal event
+  // is not emitted here because the journal writer isn't open yet.
+  const shadows = detectShadowing(parsed)
+  for (const warning of shadows) {
+    console.error(`[slack] policy shadow warning: ${warning.message}`)
+  }
+  console.error(
+    `[slack] policy: loaded ${parsed.length} rule(s), ${shadows.length} shadow warning(s)`,
+  )
+  return parsed
 }
 
 // ---------------------------------------------------------------------------
@@ -1016,6 +1089,118 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
     sessionKey: lastActiveThread !== undefined ? { channel: targetChannel, thread: lastActiveThread } : undefined,
     input: { channel: targetChannel, thread_ts: lastActiveThread },
   })
+
+  // ---------------------------------------------------------------------
+  // Policy evaluation (Epic 29-B Phase 1 — ccsc-me6.1/.2/.3/.11)
+  //
+  // Consult evaluate() before routing to the human approver. Three
+  // decision shapes, three routes:
+  //
+  //   allow + rule      → matched auto_approve; bypass Block Kit and
+  //                       reply 'allow' to Claude immediately.
+  //   deny              → post reason to thread, reply 'deny' to Claude.
+  //   allow (no rule)   → default-allow for non-safety-critical tools;
+  //     OR require        fall through to the existing human-approver
+  //                       Block Kit flow (Phase 2 = me6.4 adds the
+  //                       policy-aware approval-tracking for 'require').
+  //
+  // The permission_request notification carries `input_preview` (string)
+  // rather than structured args, so `argEquals` and `pathPrefix`
+  // predicates cannot match from this notification alone. Rules can
+  // still match on `tool`, `channel`, `thread_ts`, and `actor`. Filed
+  // for future work when the MCP surface carries structured input.
+  // ---------------------------------------------------------------------
+  const sessionThread = lastActiveThread ?? ''
+  const policyCall: PolicyToolCall = {
+    tool: params.tool_name,
+    input: {},
+    sessionKey: { channel: targetChannel, thread: sessionThread },
+    actor: 'claude_process',
+  }
+  const decision = policyEvaluate(
+    policyCall,
+    policyRules,
+    Date.now(),
+    { approvals: policyApprovals },
+  )
+  const route = decidePermissionRoute(decision)
+
+  const policySessionKey =
+    lastActiveThread !== undefined
+      ? { channel: targetChannel, thread: lastActiveThread }
+      : undefined
+  const policyInput = { tool: params.tool_name, channel: targetChannel, thread_ts: lastActiveThread }
+
+  if (route.type === 'auto_allow') {
+    // Matched auto_approve. Bypass Block Kit, reply to Claude directly.
+    journalWrite({
+      kind: 'policy.allow',
+      outcome: 'allow',
+      actor: 'claude_process',
+      sessionKey: policySessionKey,
+      toolName: params.tool_name,
+      input: policyInput,
+      ruleId: route.ruleId,
+    })
+    await mcp.notification({
+      method: 'notifications/claude/channel/permission',
+      params: { request_id: params.request_id, behavior: 'allow' },
+    })
+    return
+  }
+
+  if (route.type === 'deny') {
+    // Matched deny. Post reason to thread, reply 'deny' to Claude.
+    // No Block Kit, no pendingPermissions entry — the decision is final.
+    journalWrite({
+      kind: 'policy.deny',
+      outcome: 'deny',
+      actor: 'claude_process',
+      sessionKey: policySessionKey,
+      toolName: params.tool_name,
+      input: policyInput,
+      ruleId: route.ruleId,
+      reason: route.reason,
+    })
+    const safeTool = escMrkdwn(params.tool_name)
+    const safeReason = escMrkdwn(route.reason)
+    try {
+      await web.chat.postMessage({
+        channel: targetChannel,
+        thread_ts: lastActiveThread,
+        text: `🚫 Policy denied \`${safeTool}\`: ${safeReason}`,
+        unfurl_links: false,
+        unfurl_media: false,
+      })
+    } catch (postErr) {
+      // Surface the post failure but still deny to Claude — the policy
+      // decision is authoritative even if the user-facing notice fails.
+      console.error('[slack] policy.deny notice post failed:', postErr)
+    }
+    await mcp.notification({
+      method: 'notifications/claude/channel/permission',
+      params: { request_id: params.request_id, behavior: 'deny' },
+    })
+    return
+  }
+
+  // route.type === 'require_human' or 'default_human'. Either way, fall
+  // through to the existing Block Kit human-approver flow. Phase 1 emits
+  // a trace event for require_human so the journal records that a rule
+  // dispatched the request to a human; default_human is intentionally
+  // not traced (would 10x the journal on a busy channel for the no-
+  // opinion case — see release-plan R2).
+  if (route.type === 'require_human') {
+    journalWrite({
+      kind: 'policy.require',
+      outcome: 'require',
+      actor: 'claude_process',
+      sessionKey: policySessionKey,
+      toolName: params.tool_name,
+      input: policyInput,
+      ruleId: route.ruleId,
+    })
+  }
 
   pruneStalePermissions()
   // Pin the request to the thread it was issued from. The button /


### PR DESCRIPTION
## Summary

First enforcement PR. Follows the v0.6.0 release plan ([`000-docs/v0.6.0-release-plan.md`](./000-docs/v0.6.0-release-plan.md) §Phase 1): policy rules are loaded at boot from \`access.json\`, \`evaluate()\` is consulted at every permission request, and the decision routes downstream to one of four paths.

Closes the four bundled Phase 1 beads:

| Bead | What |
|------|------|
| \`ccsc-me6.1\` | Consult \`evaluate()\` at the permission-relay entry in \`server.ts\`. |
| \`ccsc-me6.2\` | \`auto_approve\` branch: bypass Block Kit, emit \`policy.allow\` trace. |
| \`ccsc-me6.3\` | \`deny\` branch: post reason to thread, emit \`policy.deny\` trace, no prompt, no exec. |
| \`ccsc-me6.11\` | Emit \`policy.decision\` trace events (uses existing \`policy.allow/deny/require\` EventKinds). |

Phase 2 (\`me6.4\`/\`me6.5\`) is the \`require\` branch — approval tracking on verified \`user_id\`. This PR falls through to the existing human-approver Block Kit flow on \`require\`, which is exactly right for Phase 1.

## Decision routing

Four routes, one per matrix cell in (decision.kind × rule matched or default):

| Route | Condition | Behavior |
|-------|-----------|----------|
| \`auto_allow\` | \`{ kind: 'allow', rule: <id> }\` (matched auto_approve) | Journal \`policy.allow\`, reply \`allow\` to Claude, no Slack post. |
| \`deny\` | \`{ kind: 'deny', ... }\` | Journal \`policy.deny\`, post reason to thread, reply \`deny\` to Claude. |
| \`require_human\` | \`{ kind: 'require', ... }\` | Journal \`policy.require\` trace, **fall through** to existing Block Kit flow. |
| \`default_human\` | \`{ kind: 'allow' }\` (no rule, evaluator has no opinion) | **Fall through** to existing Block Kit flow, no trace (silencing the no-opinion case keeps the journal legible — release-plan R2). |

Mapping extracted as \`decidePermissionRoute()\` in \`lib.ts\` — pure, unit-testable, no mocks.

## Design choices

- **Policy lives in \`access.json.policy\`.** Added \`policy?: unknown[]\` to \`Access\` in \`lib.ts\` as a typed escape hatch; \`server.ts\` calls \`parsePolicyRules()\` for the Zod parse. Keeps \`lib.ts\` decoupled from \`policy.ts\`.
- **Parse errors fatal at boot.** Policy is safety-critical. Silent degradation to "no policy" would let calls through that the operator intended to block. Missing/empty \`policy\` field is NOT an error (first-install path).
- **Shadow warnings** emitted to stderr. \`detectShadowing()\` is warn-not-block per \`policy-evaluation-flow.md\` §199.
- **Load-once at boot.** Hot reload intentionally deferred per release-plan R3. \`checkMonotonicity()\` is reserved for the eventual hot-reload path.
- **Journal events use existing EventKinds.** \`policy.allow/deny/require/approved\` were declared in \`journal.ts\` line 66-69 but never emitted until now. No schema change.
- **Input-preview gap.** \`permission_request\` carries \`input_preview\` (string) not structured args, so \`argEquals\` + \`pathPrefix\` predicates cannot match from this notification alone. Rules still match on \`tool\`, \`channel\`, \`thread_ts\`, \`actor\`. Documented in code and filed for future work when the MCP surface carries structured input.

## Files touched

| File | Change | LOC |
|------|--------|-----|
| \`lib.ts\` | \`Access.policy\` field; \`PolicyDecisionShape\`, \`PermissionRoute\`, \`decidePermissionRoute()\` pure helper | +71 |
| \`server.ts\` | Policy imports; module-level \`policyRules\` + \`policyApprovals\`; \`loadPolicyRulesAtBoot()\`; evaluator wiring in permission-relay handler | +185 |
| \`server.test.ts\` | 6 new tests for \`decidePermissionRoute\` — every decision shape locked to its route | +107 |
| \`ACCESS.md\` | §Where policies live updated — loader wired, file format frozen, parse errors fatal, hot reload deferred | +21 |

**Total: 383 insertions** — within release-plan estimate (200–400 LOC).

## Test plan

- [x] \`bun run typecheck\` — zero errors
- [x] \`bun test\` — 443 → 449 passing (+6 for \`decidePermissionRoute\`)
- [x] Existing permission-relay / gate / supervisor tests all still passing
- [x] Matrix coverage: auto_allow, default_human, deny (authored + default), require_human — every decision kind maps to exactly one route (regression-guarded)
- [x] Code review grounded: release plan cited for R2 (journal volume), R3 (hot reload deferred), phase boundary; design doc cited for default-branch semantics, shadow-detection policy, monotonicity reservation

## What Phase 2 adds (NOT this PR)

- \`me6.4\` — \`require\` branch: pending-approvers map keyed on \`(thread_ts, requestId)\`, populated from Slack approval replies
- \`me6.5\` — approver dedup on verified Slack \`user_id\` (issue #97 is the binding constraint)
- \`me6.6\` — UTC clock injection for \`auto_approve.window\` TTL
- \`me6.7\` — startup warning for rules with empty \`match\` + \`auto_approve\`

Jeremy made me do it
-claude