### PR TITLE
feat(policy): Epic 29-B Phase 2 — multi-approver quorum + footgun linter

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -172,14 +172,23 @@ A **policy** decides whether an MCP tool call proceeds, is denied, or requires a
 type PolicyRule =
   | { id: string; effect: 'auto_approve';     match: MatchSpec; priority?: number }
   | { id: string; effect: 'deny';             match: MatchSpec; priority?: number; reason: string }
-  | { id: string; effect: 'require_approval'; match: MatchSpec; priority?: number; ttlMs?: number }
+  | { id: string; effect: 'require_approval'; match: MatchSpec; priority?: number; ttlMs?: number; approvers?: number }
 ```
 
 - **`id`** — stable, human-readable. Shows up in the audit journal and any error surfaced to Claude. Duplicate ids are a load-time error.
-- **`effect`** — one of three: `auto_approve` (allow without prompting), `deny` (refuse with a non-sensitive reason string), `require_approval` (hold until a human approver responds on Slack within `ttlMs`).
+- **`effect`** — one of three: `auto_approve` (allow without prompting), `deny` (refuse with a non-sensitive reason string), `require_approval` (hold until human approver(s) respond on Slack within `ttlMs`).
 - **`priority`** — default `100`. Position in the policy array is the *primary* sort key (first-applicable). `priority` is a tie-breaker *within effect* when two rules would otherwise be equivalent — not a global sort.
 - **`reason`** (deny only) — 1–200 chars, surfaced to Claude so the model knows why the call was rejected. Keep non-sensitive.
 - **`ttlMs`** (require_approval only) — approval freshness window. Default 5 minutes, hard ceiling 24 hours. Once granted, an approval auto-approves subsequent matching calls in the same `(rule, sessionKey)` until expiry.
+- **`approvers`** (require_approval only) — quorum threshold. Default `1` (single-approver). Accepts 1–10. When ≥2, votes accumulate with NIST two-person integrity: the server dedups on verified Slack `user_id` (never display name) so the same human cannot double-satisfy quorum. A single `deny` vote from any allowlisted user rejects the request immediately regardless of the quorum count — one "no" overrides any number of "yes" answers.
+
+#### Boot-time linters
+
+The loader runs three checks at boot; all are warn-not-block except parse errors:
+
+1. **Duplicate-id detection** — fatal at boot. Two rules sharing an `id` cannot coexist.
+2. **Shadow detection** — warning. Flags later rules made unreachable by an earlier, less-specific rule. Operators may intentionally author unreachable rules (placeholders during refactors) so this is informational.
+3. **Broad-auto-approve linter** (ccsc-me6.7) — warning. Flags `auto_approve` rules whose `match` lacks both `tool` and `pathPrefix`. Without one of those, the rule auto-approves *any* tool call within its scope — almost always a misconfiguration. Narrow the rule or convert to `require_approval`.
 
 ### MatchSpec
 

--- a/lib.ts
+++ b/lib.ts
@@ -1352,6 +1352,93 @@ export function decidePermissionRoute(
 }
 
 // ---------------------------------------------------------------------------
+// Multi-approver quorum state (ccsc-me6.4 / me6.5 — Epic 29-B Phase 2)
+// ---------------------------------------------------------------------------
+
+/** Pending multi-approver state for a single require_approval request.
+ *  Attached to the `pendingPermissions` entry (server.ts) when the
+ *  matching rule's effect is `require_approval`. While pending, Slack
+ *  approval votes accumulate in `approvedBy` (a Set of verified Slack
+ *  `user_id`s — NEVER display names, per NIST two-person integrity).
+ *
+ *  Quorum is reached when `approvedBy.size >= approversNeeded`. At
+ *  that moment the server grants a TTL-windowed approval in the
+ *  `policyApprovals` map so that future calls matching the same
+ *  (rule, session) within `ttlMs` auto-allow without re-prompting.
+ *
+ *  A single deny vote (from any allowlisted user) rejects the request
+ *  immediately — no deny-quorum. That's the conservative posture: one
+ *  "no" overrides any number of "yes" answers. The multi-approver
+ *  invariant is about requiring multiple humans to say yes, not about
+ *  blocking a dissenter.
+ */
+export interface PendingPolicyApproval {
+  /** Rule id of the matching `require_approval` rule. Used to scope
+   *  the granted approval in the `policyApprovals` map. */
+  ruleId: string
+  /** How long the granted approval is fresh for once quorum is
+   *  reached. Propagated from `RequireApprovalRule.ttlMs`. */
+  ttlMs: number
+  /** Quorum threshold. ≥1. A rule with `approvers: 1` is single-
+   *  approver (the common case, and the default). */
+  approversNeeded: number
+  /** Set of verified Slack `user_id`s that have approved so far.
+   *  Adding the same id twice is a no-op (the underlying Set dedups),
+   *  which is the NIST two-person integrity invariant. */
+  approvedBy: Set<string>
+  /** The (channel, thread) this request belongs to. Stamped on the
+   *  granted approval so `approvalKey(ruleId, sessionKey)` in
+   *  `policyApprovals` matches the one `evaluate()` looks up on
+   *  subsequent calls. */
+  sessionKey: { channel: string; thread: string }
+}
+
+/** Outcome of recording an approval vote. Three cases, exhaustively
+ *  covered — the caller switches on `kind` and acts accordingly.
+ *
+ *   - `approved` — this vote reached quorum. Caller grants the TTL
+ *     window in `policyApprovals`, notifies Claude with `allow`, and
+ *     deletes the pending entry.
+ *   - `pending` — the vote was recorded but quorum is not yet met.
+ *     Caller updates the Block Kit message to reflect the new count
+ *     (`N/M approvals`) and keeps the pending entry alive.
+ *   - `duplicate` — the voter has already voted. Per NIST two-person
+ *     integrity the same human cannot double-satisfy a quorum, so the
+ *     repeat vote is ignored. Caller may surface a message to the
+ *     user explaining why their click was a no-op.
+ */
+export type ApprovalVoteOutcome =
+  | { kind: 'approved'; state: PendingPolicyApproval }
+  | { kind: 'pending'; state: PendingPolicyApproval }
+  | { kind: 'duplicate'; state: PendingPolicyApproval }
+
+/** Record a verified Slack `user_id`'s approval vote into the pending
+ *  state. Pure — returns a new state object, never mutates `state`.
+ *
+ *  The `now` parameter is unused in the current logic (TTL math happens
+ *  at quorum time in the caller, with a fresh `clock()` read), but the
+ *  signature carries it so the contract is clock-injected from day one
+ *  — when we add "expired pending" handling in a follow-up we only
+ *  change the implementation, not every call site.
+ */
+export function recordApprovalVote(
+  state: PendingPolicyApproval,
+  voterId: string,
+  _now: number,
+): ApprovalVoteOutcome {
+  if (state.approvedBy.has(voterId)) {
+    return { kind: 'duplicate', state }
+  }
+  const newApprovedBy = new Set(state.approvedBy)
+  newApprovedBy.add(voterId)
+  const newState: PendingPolicyApproval = { ...state, approvedBy: newApprovedBy }
+  if (newApprovedBy.size >= state.approversNeeded) {
+    return { kind: 'approved', state: newState }
+  }
+  return { kind: 'pending', state: newState }
+}
+
+// ---------------------------------------------------------------------------
 // --verify-audit-log CLI subcommand (ccsc-t7j, Epic 30-A.15)
 // ---------------------------------------------------------------------------
 

--- a/policy.ts
+++ b/policy.ts
@@ -100,10 +100,17 @@ export const DenyRule = z.object({
   reason: z.string().min(1).max(200),
 })
 
-/** `require_approval`: hold the call until a human approver responds on
+/** `require_approval`: hold the call until human approver(s) respond on
  *  Slack. `ttlMs` is how long an approval remains valid after it
  *  arrives; future calls that match the same rule + session within the
- *  window are auto-approved. Default = 5 minutes. */
+ *  window are auto-approved. Default = 5 minutes.
+ *
+ *  `approvers` is the quorum threshold (NIST two-person integrity when
+ *  ≥2). Same Slack `user_id` cannot double-satisfy — the server tracks
+ *  approvedBy as a Set<user_id> and dedups on that. Display name is
+ *  never used (spoofable). Hard ceiling of 10 is anti-footgun: no real
+ *  workflow needs more than that, and an operator typo like `100`
+ *  should be loud, not a deadlock. */
 export const RequireApprovalRule = z.object({
   ...RuleBase,
   effect: z.literal('require_approval'),
@@ -113,6 +120,7 @@ export const RequireApprovalRule = z.object({
     .positive()
     .max(24 * 60 * 60 * 1000) // 24h hard ceiling
     .default(5 * 60 * 1000),
+  approvers: z.number().int().min(1).max(10).default(1),
 })
 
 /** Discriminated union over the three effects. evaluate() (29-A.3)
@@ -186,6 +194,10 @@ export type PolicyDecision =
       /** How long an approval, once granted, is fresh for. Propagated
        *  from the matching `RequireApprovalRule.ttlMs`. */
       ttlMs: number
+      /** Quorum threshold — how many distinct Slack `user_id`s must
+       *  approve before the decision flips to allow. Propagated from
+       *  `RequireApprovalRule.approvers` (default 1). */
+      approvers: number
     }
 
 // ---------------------------------------------------------------------------
@@ -325,6 +337,7 @@ export function evaluate(
           rule: rule.id,
           approver: 'human_approver',
           ttlMs: rule.ttlMs,
+          approvers: rule.approvers,
         }
       }
     }
@@ -497,4 +510,52 @@ export function checkMonotonicity(
   }
 
   return violations
+}
+
+// ---------------------------------------------------------------------------
+// detectBroadAutoApprove() — boot-time footgun warning per ccsc-me6.7
+// ---------------------------------------------------------------------------
+
+export interface BroadMatchWarning {
+  ruleId: string
+  message: string
+}
+
+/** Flag `auto_approve` rules whose `match` is too broad to be intentional.
+ *  The heuristic: a narrow auto_approve must scope itself with at least
+ *  one of `tool` or `pathPrefix`. Without either, the rule auto-approves
+ *  based on `channel` / `actor` / `thread_ts` / `argEquals` alone — which
+ *  means any tool, on any path, in that scope gets a green light.
+ *
+ *  That's almost always a misconfiguration: the operator meant to bound
+ *  the rule to a specific safe operation and forgot. Warn loud at boot
+ *  so the operator catches it before a silent over-grant lands in prod.
+ *  Warn-not-block (same posture as `detectShadowing`) — an operator who
+ *  intentionally wants "trust claude_process fully in this channel" can
+ *  still boot; they just see the warning in logs.
+ *
+ *  Not shadow-detection (which flags unreachable rules) and not
+ *  monotonicity (which flags weakening reloads). This is a separate
+ *  axis: "this rule IS reachable and would be monotone, but its shape
+ *  means it probably matches far more than you think."
+ */
+export function detectBroadAutoApprove(
+  rules: readonly PolicyRule[],
+): BroadMatchWarning[] {
+  const warnings: BroadMatchWarning[] = []
+  for (const rule of rules) {
+    if (rule.effect !== 'auto_approve') continue
+    const hasNarrow =
+      rule.match.tool !== undefined || rule.match.pathPrefix !== undefined
+    if (!hasNarrow) {
+      warnings.push({
+        ruleId: rule.id,
+        message:
+          `auto_approve rule '${rule.id}' has no 'tool' or 'pathPrefix' in its match — ` +
+          `this rule auto-approves ANY tool call within its scope, which is almost always ` +
+          `a misconfiguration. Narrow the rule or convert to require_approval.`,
+      })
+    }
+  }
+  return warnings
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -2461,17 +2461,19 @@ describe('PolicyDecision shape (29-A.2)', () => {
     }
   })
 
-  test('require decision carries rule + approver + ttlMs', async () => {
+  test('require decision carries rule + approver + ttlMs + approvers', async () => {
     type PD = import('./policy.ts').PolicyDecision
     const r: PD = {
       kind: 'require',
       rule: 'upload-approval',
       approver: 'human_approver',
       ttlMs: 5 * 60 * 1000,
+      approvers: 1,
     }
     expect(r.kind).toBe('require')
     if (r.kind === 'require') {
       expect(r.approver).toBe('human_approver')
+      expect(r.approvers).toBe(1)
       expect(r.ttlMs).toBeGreaterThan(0)
     }
   })
@@ -2629,15 +2631,16 @@ describe('evaluate() — policy engine (29-A.3)', () => {
     expect(decision).toEqual({ kind: 'deny', rule: 'r1', reason: 'nope' })
   })
 
-  test('require_approval rule → require with ttlMs', async () => {
+  test('require_approval rule → require with ttlMs + approvers default 1', async () => {
     const { evaluate } = await import('./policy.ts')
-    const rules = [rule({ id: 'r1', effect: 'require_approval', ttlMs: 60_000 } as never)]
+    const rules = [rule({ id: 'r1', effect: 'require_approval', ttlMs: 60_000, approvers: 1 } as never)]
     const decision = evaluate(baseCall(), rules, 0)
     expect(decision).toEqual({
       kind: 'require',
       rule: 'r1',
       approver: 'human_approver',
       ttlMs: 60_000,
+      approvers: 1,
     })
   })
 
@@ -5343,6 +5346,231 @@ describe('decidePermissionRoute', () => {
     expect(routes).toEqual(
       new Set(['auto_allow', 'default_human', 'deny', 'require_human']),
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// recordApprovalVote — ccsc-me6.4 / me6.5, Epic 29-B Phase 2
+//
+// Multi-approver quorum with NIST two-person integrity (user_id dedup).
+// ---------------------------------------------------------------------------
+
+describe('recordApprovalVote', () => {
+  const loadLib = async () => await import('./lib.ts')
+
+  const pending = (
+    approversNeeded: number,
+    approvedBy: string[] = [],
+  ): import('./lib.ts').PendingPolicyApproval => ({
+    ruleId: 'upload-approval',
+    ttlMs: 5 * 60 * 1000,
+    approversNeeded,
+    approvedBy: new Set(approvedBy),
+    sessionKey: { channel: 'C0123456789', thread: '1712345678.001100' },
+  })
+
+  test('single-approver: first vote reaches quorum immediately', async () => {
+    const { recordApprovalVote } = await loadLib()
+    const out = recordApprovalVote(pending(1), 'U_ALICE', 0)
+    expect(out.kind).toBe('approved')
+    expect(out.state.approvedBy.has('U_ALICE')).toBe(true)
+    expect(out.state.approvedBy.size).toBe(1)
+  })
+
+  test('two-approver: first vote is pending, second distinct vote approves', async () => {
+    const { recordApprovalVote } = await loadLib()
+    const first = recordApprovalVote(pending(2), 'U_ALICE', 0)
+    expect(first.kind).toBe('pending')
+    expect(first.state.approvedBy.size).toBe(1)
+    const second = recordApprovalVote(first.state, 'U_BOB', 0)
+    expect(second.kind).toBe('approved')
+    expect(second.state.approvedBy.size).toBe(2)
+    expect(second.state.approvedBy.has('U_ALICE')).toBe(true)
+    expect(second.state.approvedBy.has('U_BOB')).toBe(true)
+  })
+
+  test('duplicate vote by same user_id is ignored (NIST two-person integrity)', async () => {
+    // Same human cannot double-satisfy a 2-approver quorum. The second
+    // vote returns 'duplicate' and leaves the state unchanged.
+    const { recordApprovalVote } = await loadLib()
+    const first = recordApprovalVote(pending(2), 'U_ALICE', 0)
+    expect(first.kind).toBe('pending')
+    const second = recordApprovalVote(first.state, 'U_ALICE', 0)
+    expect(second.kind).toBe('duplicate')
+    expect(second.state.approvedBy.size).toBe(1)
+    expect(second.state).toBe(first.state) // unchanged reference
+  })
+
+  test('three-approver: needs three DISTINCT user_ids, dedup pushes total back', async () => {
+    const { recordApprovalVote } = await loadLib()
+    let st = pending(3)
+    let out = recordApprovalVote(st, 'U_ALICE', 0)
+    expect(out.kind).toBe('pending')
+    st = out.state
+    // Alice tries again
+    out = recordApprovalVote(st, 'U_ALICE', 0)
+    expect(out.kind).toBe('duplicate')
+    st = out.state
+    out = recordApprovalVote(st, 'U_BOB', 0)
+    expect(out.kind).toBe('pending')
+    st = out.state
+    out = recordApprovalVote(st, 'U_CAROL', 0)
+    expect(out.kind).toBe('approved')
+    expect(out.state.approvedBy.size).toBe(3)
+  })
+
+  test('is pure — input state is never mutated', async () => {
+    const { recordApprovalVote } = await loadLib()
+    const initial = pending(2)
+    const initialSize = initial.approvedBy.size
+    const out = recordApprovalVote(initial, 'U_ALICE', 0)
+    expect(out.kind).toBe('pending')
+    // Initial Set was not modified
+    expect(initial.approvedBy.size).toBe(initialSize)
+    expect(initial.approvedBy.has('U_ALICE')).toBe(false)
+    // New state has the vote
+    expect(out.state.approvedBy.has('U_ALICE')).toBe(true)
+  })
+
+  test('clock parameter accepted but unused in current logic (signature locked for expiry follow-up)', async () => {
+    // The `now` parameter exists so a future change adding "pending
+    // expired" handling doesn't need to touch every call site. Confirm
+    // the current logic ignores it by varying it across calls.
+    const { recordApprovalVote } = await loadLib()
+    const a = recordApprovalVote(pending(1), 'U_X', 0)
+    const b = recordApprovalVote(pending(1), 'U_X', Number.MAX_SAFE_INTEGER)
+    expect(a.kind).toBe(b.kind)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RequireApprovalRule.approvers — ccsc-me6.4 schema extension
+// ---------------------------------------------------------------------------
+
+describe('RequireApprovalRule approvers field', () => {
+  const loadPolicyModule = async () => await import('./policy.ts')
+
+  test('defaults to 1 when omitted', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    const parsed = PolicyRule.parse({
+      id: 'r1',
+      effect: 'require_approval',
+      match: { tool: 'upload_file' },
+    }) as { effect: 'require_approval'; approvers: number }
+    expect(parsed.approvers).toBe(1)
+  })
+
+  test('accepts explicit quorum up to 10', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    for (const n of [1, 2, 3, 5, 10]) {
+      expect(() =>
+        PolicyRule.parse({
+          id: 'r1',
+          effect: 'require_approval',
+          match: { tool: 'upload_file' },
+          approvers: n,
+        }),
+      ).not.toThrow()
+    }
+  })
+
+  test('rejects approvers < 1', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'require_approval',
+        match: { tool: 'upload_file' },
+        approvers: 0,
+      }),
+    ).toThrow()
+  })
+
+  test('rejects approvers > 10 (anti-footgun ceiling)', async () => {
+    const { PolicyRule } = await loadPolicyModule()
+    expect(() =>
+      PolicyRule.parse({
+        id: 'r1',
+        effect: 'require_approval',
+        match: { tool: 'upload_file' },
+        approvers: 11,
+      }),
+    ).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectBroadAutoApprove — ccsc-me6.7 footgun linter
+// ---------------------------------------------------------------------------
+
+describe('detectBroadAutoApprove', () => {
+  const loadPolicyModule = async () => await import('./policy.ts')
+
+  test('warns on auto_approve with no tool or pathPrefix', async () => {
+    const { detectBroadAutoApprove, parsePolicyRules } = await loadPolicyModule()
+    const rules = parsePolicyRules([
+      {
+        id: 'too-broad',
+        effect: 'auto_approve',
+        match: { actor: 'claude_process' },
+      },
+    ])
+    const warnings = detectBroadAutoApprove(rules)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]!.ruleId).toBe('too-broad')
+    expect(warnings[0]!.message).toMatch(/no 'tool' or 'pathPrefix'/)
+  })
+
+  test('no warning when auto_approve has a tool match', async () => {
+    const { detectBroadAutoApprove, parsePolicyRules } = await loadPolicyModule()
+    const rules = parsePolicyRules([
+      { id: 'safe', effect: 'auto_approve', match: { tool: 'read_file' } },
+    ])
+    expect(detectBroadAutoApprove(rules)).toEqual([])
+  })
+
+  test('no warning when auto_approve has a pathPrefix match', async () => {
+    const { detectBroadAutoApprove, parsePolicyRules } = await loadPolicyModule()
+    const rules = parsePolicyRules([
+      {
+        id: 'scoped',
+        effect: 'auto_approve',
+        match: { pathPrefix: '/workspace/safe' },
+      },
+    ])
+    expect(detectBroadAutoApprove(rules)).toEqual([])
+  })
+
+  test('does not warn on deny or require_approval rules (scope: auto_approve only)', async () => {
+    // A broad deny is the opposite of a footgun — it fails closed. A
+    // broad require_approval pulls a human into the loop, also safe.
+    // The linter only flags the auto-grant path.
+    const { detectBroadAutoApprove, parsePolicyRules } = await loadPolicyModule()
+    const rules = parsePolicyRules([
+      {
+        id: 'broad-deny',
+        effect: 'deny',
+        match: { actor: 'claude_process' },
+        reason: 'kill switch',
+      },
+      {
+        id: 'broad-require',
+        effect: 'require_approval',
+        match: { actor: 'claude_process' },
+      },
+    ])
+    expect(detectBroadAutoApprove(rules)).toEqual([])
+  })
+
+  test('flags multiple offenders in one pass', async () => {
+    const { detectBroadAutoApprove, parsePolicyRules } = await loadPolicyModule()
+    const rules = parsePolicyRules([
+      { id: 'ok', effect: 'auto_approve', match: { tool: 'read_file' } },
+      { id: 'bad-1', effect: 'auto_approve', match: { channel: 'C0000000000' } },
+      { id: 'bad-2', effect: 'auto_approve', match: { actor: 'session_owner' } },
+    ])
+    const warnings = detectBroadAutoApprove(rules)
+    expect(warnings.map((w) => w.ruleId).sort()).toEqual(['bad-1', 'bad-2'])
   })
 })
 

--- a/server.ts
+++ b/server.ts
@@ -49,16 +49,19 @@ import {
   parseVerifyArg,
   formatVerifyResult,
   decidePermissionRoute,
+  recordApprovalVote,
   EVENT_DEDUP_TTL_MS,
   PERMISSION_REPLY_RE,
   type Access,
   type GateResult,
+  type PendingPolicyApproval,
 } from './lib.ts'
 import { JournalWriter, createBootAnchor, verifyJournal } from './journal.ts'
 import {
   parsePolicyRules,
   evaluate as policyEvaluate,
   detectShadowing,
+  detectBroadAutoApprove,
   approvalKey,
   type PolicyRule,
   type ToolCall as PolicyToolCall,
@@ -278,6 +281,19 @@ function getAccess(): Access {
 let policyRules: readonly PolicyRule[] = loadPolicyRulesAtBoot()
 const policyApprovals = new Map<ApprovalKey, { ttlExpires: number }>()
 
+/** Grant a TTL-windowed approval for the (rule, session) pair. Called
+ *  when a quorum of approvers has voted Allow on a `require_approval`
+ *  request. Future calls matching the same rule + session within the
+ *  window auto-allow without re-prompting (see evaluate() §310-321 in
+ *  policy.ts for the lookup side of this contract). */
+function grantPolicyApproval(
+  pending: PendingPolicyApproval,
+  now: number,
+): void {
+  const key = approvalKey(pending.ruleId, pending.sessionKey)
+  policyApprovals.set(key, { ttlExpires: now + pending.ttlMs })
+}
+
 function loadPolicyRulesAtBoot(): readonly PolicyRule[] {
   const bootAccess = STATIC_MODE && staticAccess ? staticAccess : loadAccess()
   const raw = bootAccess.policy
@@ -309,8 +325,16 @@ function loadPolicyRulesAtBoot(): readonly PolicyRule[] {
   for (const warning of shadows) {
     console.error(`[slack] policy shadow warning: ${warning.message}`)
   }
+  // detectBroadAutoApprove (ccsc-me6.7) — footgun linter for auto_approve
+  // rules that don't specify `tool` or `pathPrefix`. Warn-not-block for
+  // the same reasons as shadow detection.
+  const broads = detectBroadAutoApprove(parsed)
+  for (const warning of broads) {
+    console.error(`[slack] policy footgun warning: ${warning.message}`)
+  }
   console.error(
-    `[slack] policy: loaded ${parsed.length} rule(s), ${shadows.length} shadow warning(s)`,
+    `[slack] policy: loaded ${parsed.length} rule(s), ` +
+      `${shadows.length} shadow warning(s), ${broads.length} footgun warning(s)`,
   )
   return parsed
 }
@@ -1025,7 +1049,21 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 // from authorizing a different thread's tool call even when the
 // requestIds genuinely differ. The composite key closes that gap.
 const PERM_TTL_MS = 5 * 60 * 1000
-const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; createdAt: number }>()
+/** Pending permission entries. The optional `policy` field is populated
+ *  only for `require_approval`-matched requests (Epic 29-B Phase 2 —
+ *  ccsc-me6.4). When present, the button / text-reply resolvers take
+ *  the multi-approver code path: record the voter's `user_id`, check
+ *  quorum, grant a TTL window on success. When absent, the single-
+ *  approver fast path applies (any allowlisted reply resolves the
+ *  request immediately, preserving pre-29-B behavior). */
+type PendingPermissionEntry = {
+  tool_name: string
+  description: string
+  input_preview: string
+  createdAt: number
+  policy?: PendingPolicyApproval
+}
+const pendingPermissions = new Map<string, PendingPermissionEntry>()
 
 function pruneStalePermissions(): void {
   const cutoff = Date.now() - PERM_TTL_MS
@@ -1185,21 +1223,34 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
   }
 
   // route.type === 'require_human' or 'default_human'. Either way, fall
-  // through to the existing Block Kit human-approver flow. Phase 1 emits
-  // a trace event for require_human so the journal records that a rule
-  // dispatched the request to a human; default_human is intentionally
-  // not traced (would 10x the journal on a busy channel for the no-
-  // opinion case — see release-plan R2).
-  if (route.type === 'require_human') {
+  // through to the existing Block Kit human-approver flow. Phase 2
+  // (ccsc-me6.4 / me6.5) attaches a PendingPolicyApproval to the pending
+  // entry for the require_human case so the button / text-reply
+  // resolvers can run the multi-approver quorum + NIST user_id dedup
+  // logic. default_human keeps the legacy single-approver fast path.
+  //
+  // Phase 1 emits a trace event for require_human so the journal
+  // records that a rule dispatched the request to a human;
+  // default_human is intentionally not traced (would 10x the journal
+  // on a busy channel for the no-opinion case — see release-plan R2).
+  let pendingPolicy: PendingPolicyApproval | undefined
+  if (route.type === 'require_human' && decision.kind === 'require') {
     journalWrite({
       kind: 'policy.require',
       outcome: 'require',
       actor: 'claude_process',
       sessionKey: policySessionKey,
       toolName: params.tool_name,
-      input: policyInput,
+      input: { ...policyInput, approversNeeded: decision.approvers },
       ruleId: route.ruleId,
     })
+    pendingPolicy = {
+      ruleId: decision.rule,
+      ttlMs: decision.ttlMs,
+      approversNeeded: decision.approvers,
+      approvedBy: new Set<string>(),
+      sessionKey: { channel: targetChannel, thread: sessionThread },
+    }
   }
 
   pruneStalePermissions()
@@ -1213,6 +1264,7 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
     description: params.description,
     input_preview: params.input_preview,
     createdAt: Date.now(),
+    policy: pendingPolicy,
   })
 
   const safeTool = escMrkdwn(params.tool_name)
@@ -1378,6 +1430,85 @@ socket.on('interactive', async ({ body, ack }: { body: any; ack: () => Promise<v
         } catch { /* non-critical */ }
       }
       return
+    }
+
+    // Multi-approver path (ccsc-me6.4 / me6.5). When a PendingPolicyApproval
+    // is attached, votes accumulate with NIST `user_id` dedup until quorum.
+    // Deny always wins immediately — one "no" overrides any number of yeses.
+    if (details.policy && verb === 'allow') {
+      const vote = recordApprovalVote(details.policy, userId, Date.now())
+      if (vote.kind === 'duplicate') {
+        // Same user_id already approved; surface an ephemeral note and
+        // leave the pending entry unchanged. Block Kit stays as-is.
+        try {
+          await web.chat.postEphemeral({
+            channel: channelId,
+            user: userId,
+            text: 'You have already approved this request. A different approver must vote to reach quorum.',
+          })
+        } catch { /* non-critical */ }
+        return
+      }
+      if (vote.kind === 'pending') {
+        // Record the vote but don't resolve yet.
+        details.policy = vote.state
+        const safeTool = escMrkdwn(details.tool_name)
+        const safeDesc = escMrkdwn(details.description)
+        const progress = `${vote.state.approvedBy.size}/${vote.state.approversNeeded} approvals`
+        if (channelId && messageTs) {
+          try {
+            await web.chat.update({
+              channel: channelId,
+              ts: messageTs,
+              text: `Claude wants to run ${safeTool} — ${progress}`,
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: `🟡 *Claude wants to run \`${safeTool}\`*\n${safeDesc}\n\n_${progress} — awaiting additional approver(s)._`,
+                  },
+                },
+                {
+                  type: 'actions',
+                  elements: [
+                    {
+                      type: 'button',
+                      text: { type: 'plain_text', text: '✅ Allow' },
+                      style: 'primary',
+                      action_id: `perm:allow:${requestId}`,
+                    },
+                    {
+                      type: 'button',
+                      text: { type: 'plain_text', text: '❌ Deny' },
+                      style: 'danger',
+                      action_id: `perm:deny:${requestId}`,
+                    },
+                  ],
+                },
+              ],
+            })
+          } catch { /* non-critical */ }
+        }
+        return
+      }
+      // vote.kind === 'approved' — quorum reached. Grant TTL window and
+      // fall through to the resolve path below with behavior='allow'.
+      details.policy = vote.state
+      grantPolicyApproval(vote.state, Date.now())
+      journalWrite({
+        kind: 'policy.approved',
+        outcome: 'allow',
+        actor: 'human_approver',
+        sessionKey: vote.state.sessionKey,
+        toolName: details.tool_name,
+        input: {
+          tool: details.tool_name,
+          approversNeeded: vote.state.approversNeeded,
+          approvers: Array.from(vote.state.approvedBy),
+        },
+        ruleId: vote.state.ruleId,
+      })
     }
 
     const behavior = verb === 'allow' ? 'allow' : 'deny'
@@ -1590,7 +1721,8 @@ async function handleMessage(event: unknown): Promise<void> {
 
         // Skip if already resolved (e.g. by a button click) OR if the
         // requestId is not pending in THIS thread.
-        if (!pendingPermissions.has(replyKey)) {
+        const replyDetails = pendingPermissions.get(replyKey)
+        if (!replyDetails) {
           try {
             await web.reactions.add({
               channel: channelId,
@@ -1601,11 +1733,59 @@ async function handleMessage(event: unknown): Promise<void> {
           return
         }
 
+        const replyIsAllow = permMatch[1].toLowerCase().startsWith('y')
+
+        // Multi-approver path (ccsc-me6.4 / me6.5) via text reply. Mirrors
+        // the button handler: allow votes accumulate with user_id dedup
+        // until quorum; deny wins immediately.
+        if (replyDetails.policy && replyIsAllow) {
+          const voterId = ev['user'] as string
+          const vote = recordApprovalVote(replyDetails.policy, voterId, Date.now())
+          if (vote.kind === 'duplicate') {
+            try {
+              await web.reactions.add({
+                channel: channelId,
+                timestamp: ev['ts'] as string,
+                name: 'no_entry_sign',
+              })
+            } catch { /* non-critical */ }
+            return
+          }
+          if (vote.kind === 'pending') {
+            replyDetails.policy = vote.state
+            try {
+              await web.reactions.add({
+                channel: channelId,
+                timestamp: ev['ts'] as string,
+                name: 'ballot_box_with_check',
+              })
+            } catch { /* non-critical */ }
+            return
+          }
+          // vote.kind === 'approved' — fall through to the resolve block
+          // below with behavior='allow'.
+          replyDetails.policy = vote.state
+          grantPolicyApproval(vote.state, Date.now())
+          journalWrite({
+            kind: 'policy.approved',
+            outcome: 'allow',
+            actor: 'human_approver',
+            sessionKey: vote.state.sessionKey,
+            toolName: replyDetails.tool_name,
+            input: {
+              tool: replyDetails.tool_name,
+              approversNeeded: vote.state.approversNeeded,
+              approvers: Array.from(vote.state.approvedBy),
+            },
+            ruleId: vote.state.ruleId,
+          })
+        }
+
         await mcp.notification({
           method: 'notifications/claude/channel/permission',
           params: {
             request_id: requestId,
-            behavior: permMatch[1].toLowerCase().startsWith('y') ? 'allow' : 'deny',
+            behavior: replyIsAllow ? 'allow' : 'deny',
           },
         })
         pendingPermissions.delete(replyKey)


### PR DESCRIPTION
## Summary

Closes four Phase 2 beads per [`000-docs/v0.6.0-release-plan.md`](./000-docs/v0.6.0-release-plan.md):

| Bead | Feature |
|------|---------|
| \`ccsc-me6.4\` | \`require\` branch: pending-approvers map keyed \`(thread_ts, requestId)\`, multi-approver quorum tracked until success or timeout |
| \`ccsc-me6.5\` | NIST two-person integrity: approver dedup on verified Slack \`user_id\`, **never** \`display_name\` |
| \`ccsc-me6.6\` | Clock injection: \`recordApprovalVote(state, voterId, now)\` pure helper, tests inject fixed time |
| \`ccsc-me6.7\` | Boot-time \`detectBroadAutoApprove()\` footgun linter for \`auto_approve\` rules missing \`tool\`/\`pathPrefix\` |

## Schema change

\`RequireApprovalRule\` gains an \`approvers: number\` field (default \`1\`, accepts 1–10, hard ceiling anti-footgun). Existing single-approver rules are unchanged behaviorally — the new field is backward-compatible.

\`\`\`ts
{ id, effect: 'require_approval', match, ttlMs?, approvers? }  // approvers default 1
\`\`\`

The \`PolicyDecision\` for \`kind: 'require'\` now carries \`approvers\` alongside \`ttlMs\`; the server uses it to stamp the quorum threshold on the pending state.

## State machine

Each \`require_approval\` request attaches a \`PendingPolicyApproval\` to its \`pendingPermissions\` entry (new optional \`policy?:\` field):

\`\`\`ts
interface PendingPolicyApproval {
  ruleId: string
  ttlMs: number
  approversNeeded: number
  approvedBy: Set<string>          // verified Slack user_ids
  sessionKey: { channel, thread }
}
\`\`\`

Both resolvers (Block Kit button handler, text-reply handler) check for the \`policy\` field on vote. When present and vote is \`allow\`:

\`\`\`
recordApprovalVote(state, userId, Date.now())
  kind='duplicate' → ephemeral note / reaction, no state change
  kind='pending'   → update Block Kit "N/M approvals" / reaction, stay pending
  kind='approved'  → grantPolicyApproval() writes TTL window into
                     policyApprovals map, journalWrite policy.approved
                     with approvers array, fall through to resolve
\`\`\`

A \`deny\` vote from any allowlisted user rejects immediately regardless of quorum count. One "no" overrides any number of "yeses" — conservative and symmetric with single-approver.

## Pure helpers (the testable core)

Three pure functions unit-test the decision logic without mocking MCP, Slack, or the journal:

- **\`recordApprovalVote\`** (lib.ts) — state, voterId, now → { kind: approved | pending | duplicate, state }
- **\`decidePermissionRoute\`** (lib.ts, Phase 1) — decision → route discriminator
- **\`detectBroadAutoApprove\`** (policy.ts) — rules → BroadMatchWarning[]

## Files touched

| File | Change | LOC |
|------|--------|-----|
| \`policy.ts\` | \`approvers\` field, \`PolicyDecision.approvers\`, \`detectBroadAutoApprove\` linter | +65 |
| \`lib.ts\` | \`PendingPolicyApproval\`, \`ApprovalVoteOutcome\`, \`recordApprovalVote\` | +87 |
| \`server.ts\` | Extended \`pendingPermissions\` type, require-branch populates \`policy\`, quorum logic in both resolvers, grant helper, boot-time linter wired | +202 |
| \`server.test.ts\` | 15 new tests (6 recordApprovalVote, 4 approvers schema, 5 detectBroadAutoApprove); 2 existing \`require\` decision tests updated with \`approvers: 1\` | +234 |
| \`ACCESS.md\` | \`approvers\` field + boot-time linters section | +7 |

**Total: 583 insertions**. Above the plan's 300–500 estimate by ~15%, but the multi-approver state machine carries real surface area (two resolver paths, three outcome kinds, clock injection, dedup invariant). The extra LOC is in tests — 15 new tests = +234 lines.

## Test plan

- [x] \`bun run typecheck\` — zero errors
- [x] \`bun test\` — 449 → 464 passing (+15)
- [x] NIST dedup: same user_id votes twice → \`kind: 'duplicate'\`, state unchanged
- [x] Quorum math: 3-of-3 requires 3 distinct user_ids (one dedup round between)
- [x] Pure helper is truly pure: input state reference-equal after call
- [x] Clock parameter flows through (signature locked for future expiry handling)
- [x] Schema: approvers range 1–10 accepted, 0 rejected, 11 rejected
- [x] Linter: broad \`auto_approve\` (only \`actor\`, only \`channel\`) flagged; \`tool\`-scoped or \`pathPrefix\`-scoped not flagged; \`deny\` and \`require_approval\` not flagged regardless of broadness

## What Phase 3 adds (NOT this PR)

- \`me6.8\` — integration test: auto_approve for read_file /safe does NOT prompt
- \`me6.9\` — integration test: \`require: 2\` needs two distinct user_ids
- \`me6.10\` — integration test: deny surfaces reason in thread, no exec

## What Phase 4 adds (NOT this PR)

- \`ccsc-4an\` — wire pairing.accepted + pairing.expired journal events
- \`me6.12\` — CHANGELOG [Unreleased] policy engine entries
- \`me6.16\` — v0.6.0 changelog entry at release time

Jeremy made me do it
-claude