### PR TITLE
chore(release): v0.6.0 — policy engine enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-20
+
+### Added
+
+- **Declarative policy enforcement at the permission-relay boundary.** Operators author rules in `access.json.policy`; the server consults `evaluate()` on every tool-call permission request and routes to one of four outcomes: `auto_allow` (matched `auto_approve`, no human prompt), `deny` (posts reason to thread, no exec), `require_human` (quorum tracking), `default_human` (no rule, legacy Block Kit flow). See [`ACCESS.md`](ACCESS.md#policy-rules) for the schema and [`000-docs/policy-evaluation-flow.md`](000-docs/policy-evaluation-flow.md) for the decision procedure (#100).
+- **Multi-approver quorum with NIST two-person integrity** (#101). `require_approval` rules accept an optional `approvers` field (1–10, default 1). Votes accumulate on the verified Slack `user_id` — the same human cannot double-satisfy quorum regardless of display name. A single deny from any allowlisted user rejects the request immediately, regardless of quorum count. Block Kit message updates show progress (`N/M approvals`). Binding rationale tracked in issue #97.
+- **Four new journal EventKinds now emit at enforcement time:** `policy.allow`, `policy.deny`, `policy.require`, `policy.approved`. Declared in v0.5.0; now wired. Every enforcement decision produces a hash-chained audit record with rule id, session key, and (for `require`/`approved`) the verified approver `user_id`s.
+- **`thread_ts` predicate on `MatchSpec`.** Policies scope to a specific thread within a channel. Schema landed in #96 before the evaluator wiring so operators can ship thread-scoped rules against a stable v1 shape.
+- **Boot-time policy footgun linter** (`detectBroadAutoApprove`) (#101). Warns on `auto_approve` rules that lack both `tool` and `pathPrefix` — almost always a misconfiguration.
+- **`--verify-audit-log` CLI subcommand** (#98). `bun server.ts --verify-audit-log <path>` runs `verifyJournal()` before any state setup (no `.env`, no tokens needed). Exit codes 0/1/2 for ok / break / unexpected. Closes a design-doc gap where [`000-docs/audit-journal-architecture.md`](000-docs/audit-journal-architecture.md) specified the CLI but only the programmatic form shipped.
+- **Compile-time shape-drift guards** (#102). `lib.ts` duplicates `PolicyDecision` / `VerifyResult` shapes (`PolicyDecisionShape` / `VerifyResultShape`) to stay decoupled from `policy.ts` / `journal.ts`. Bidirectional `extends` checks in `policy.ts` and `journal.ts` break the build the moment either side drifts — already caught one real drift at review time.
+- **End-to-end contract tests for the policy enforcement chain** (#103). Seven integration tests covering `auto_approve` bypass, `deny` reason surfacing, `require:2` quorum with NIST `user_id` dedup, and the `default_human` fallback when no rule matches.
+- **Frozen [`000-docs/v0.6.0-release-plan.md`](000-docs/v0.6.0-release-plan.md)** (#99) — design-in-public commitment to what's in v0.6.0, what's out, and why.
+- **471 tests** — up from 430 in v0.5.1 (+41 covering policy enforcement, multi-approver quorum, NIST dedup, route mapping, boot-time linter, and the full end-to-end policy chain).
+
+### Changed
+
+- **Policy rules now load at boot.** A malformed `access.json.policy` field is fatal at boot — policy is safety-critical, silent degradation is not offered. Missing / empty policy is NOT an error (first-install path is preserved). Hot reload intentionally deferred per [release plan §R3](000-docs/v0.6.0-release-plan.md).
+- **Vote-handling DRY refactor** (#102). The Block Kit button handler and the text-reply handler now share a `processApprovalVote()` helper — the state transition (`recordApprovalVote` → `grantPolicyApproval` → `journalWrite`) lives in one place; per-resolver UX stays separate.
+
+### Known Limitations
+
+- `pairing.accepted` and `pairing.expired` EventKinds remain unwired (P3, [`ccsc-4an`](https://github.com/jeremylongshore/claude-code-slack-channel/issues) — tracked for v0.6.1). Current journal captures `pairing.issued` so the pairing lifecycle is reconstructible from `issued` + absence of `claim`.
+- No operator CLI for rule authoring; edit `access.json.policy` directly. A `/slack-channel:policy` skill is on the v0.6.1 roadmap.
+- Rules match on `tool`, `channel`, `thread_ts`, and `actor`; the `argEquals` / `pathPrefix` predicates in the schema do not yet match from `permission_request` notifications because the MCP surface carries `input_preview` (string) rather than structured tool args. Tracked as a v0.7.x evolution.
+
 ## [0.5.1] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# claude-code-slack-channel v0.5.1
+# claude-code-slack-channel v0.6.0
 
 Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channels, just like you'd chat in the terminal. Per-thread session isolation, hash-chained tamper-evident audit journal, policy-gated tools, five-layer prompt-injection defense.
 
@@ -6,7 +6,7 @@ Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channe
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jeremylongshore/claude-code-slack-channel/badge)](https://scorecard.dev/viewer/?uri=github.com/jeremylongshore/claude-code-slack-channel)
 
-**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.5.1)
+**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/2bef9c630d4269d2858a666ae75fca53) · [GitHub Pages](https://jeremylongshore.github.io/claude-code-slack-channel/) · [Release Notes](https://github.com/jeremylongshore/claude-code-slack-channel/releases/tag/v0.6.0)
 
 > **Research Preview** — Channels require Claude Code v2.1.80+ and `claude.ai` login.
 
@@ -85,6 +85,43 @@ claude --channels plugin:slack-channel@claude-code-plugins
 1. DM the bot in Slack — you'll get a 6-character pairing code
 2. In your terminal: `/slack-channel:access pair <code>`
 3. You're connected. Chat away.
+
+## Policy Engine (v0.6.0+)
+
+Author rules in `access.json.policy` to automate permission decisions for Claude Code tool calls. Three rule effects, first-applicable ordering:
+
+```json
+{
+  "policy": [
+    {
+      "id": "safe-reads",
+      "effect": "auto_approve",
+      "match": { "tool": "read_file", "pathPrefix": "/workspace/docs" }
+    },
+    {
+      "id": "no-shell",
+      "effect": "deny",
+      "match": { "tool": "run_shell" },
+      "reason": "Shell execution is not permitted."
+    },
+    {
+      "id": "dangerous-delete",
+      "effect": "require_approval",
+      "match": { "tool": "delete_project" },
+      "approvers": 2,
+      "ttlMs": 300000
+    }
+  ]
+}
+```
+
+- **`auto_approve`** — skip the Block Kit prompt; the tool call runs immediately and a `policy.allow` event is journaled.
+- **`deny`** — the reason is posted back into the originating thread and the call is rejected. `policy.deny` is journaled.
+- **`require_approval`** — route through human approver(s). `approvers: 2` requires two **distinct** Slack `user_id`s (NIST two-person integrity; the same user cannot double-satisfy quorum by clicking twice). A single deny from any allowlisted user rejects the request immediately regardless of quorum count.
+- Successful approvals grant a TTL window scoped to `(rule, channel, thread)` so a chain of similar calls doesn't re-prompt.
+- Parse errors in `access.json.policy` are **fatal at boot** — policy is safety-critical, silent degradation is not offered. Missing or empty `policy` is fine (first-install path).
+
+Full schema reference: [`ACCESS.md`](ACCESS.md#policy-rules). Decision procedure: [`000-docs/policy-evaluation-flow.md`](000-docs/policy-evaluation-flow.md). Release scope and what was deliberately deferred: [`000-docs/v0.6.0-release-plan.md`](000-docs/v0.6.0-release-plan.md).
 
 ## Access Control
 

--- a/README.md
+++ b/README.md
@@ -94,20 +94,20 @@ Author rules in `access.json.policy` to automate permission decisions for Claude
 {
   "policy": [
     {
-      "id": "safe-reads",
+      "id": "safe-reads-in-ops",
       "effect": "auto_approve",
-      "match": { "tool": "read_file", "pathPrefix": "/workspace/docs" }
+      "match": { "tool": "Read", "channel": "C_OPS_DOCS" }
     },
     {
       "id": "no-shell",
       "effect": "deny",
-      "match": { "tool": "run_shell" },
+      "match": { "tool": "Bash" },
       "reason": "Shell execution is not permitted."
     },
     {
-      "id": "dangerous-delete",
+      "id": "dangerous-writes",
       "effect": "require_approval",
-      "match": { "tool": "delete_project" },
+      "match": { "tool": "Write", "channel": "C_DEPLOY" },
       "approvers": 2,
       "ttlMs": 300000
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-channel-slack",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Slack channel for Claude Code — two-way chat via Socket Mode",
   "type": "module",
   "bin": "./server.ts",


### PR DESCRIPTION
## Summary

- Promote CHANGELOG `[Unreleased]` → `[0.6.0] - 2026-04-20` with an honest Added / Changed / Known Limitations set (pairing events still unwired, no policy CLI yet, `argEquals`/`pathPrefix` predicates not yet matched from `input_preview`).
- Add a **Policy Engine** section to `README.md` between Quick Start and Access Control — the v0.6.0 headline feature is now discoverable in the first scroll, with a minimal three-rule `access.json.policy` example and cross-links to `ACCESS.md`, `000-docs/policy-evaluation-flow.md`, and `000-docs/v0.6.0-release-plan.md`.
- Bump `package.json` 0.5.1 → 0.6.0 and retarget the README release-notes link to the v0.6.0 tag.

## What this PR does NOT do

Per the [frozen v0.6.0 release plan](000-docs/v0.6.0-release-plan.md):

- `pairing.accepted` / `pairing.expired` journal wiring (continuation of `ccsc-4an`) — the acceptance path lives in the `/slack-channel:access` CLI skill, outside the server process. Requires either IPC or relocating acceptance into `server.ts`. **P3**, filed as a v0.6.1 follow-up.
- Policy authoring CLI (`/slack-channel:policy` skill) — operators hand-edit `access.json.policy` in v0.6.0; filed as a v0.6.1 follow-up.
- Policy hot reload — deliberately deferred per release plan §R3.

## Beads closed by this PR

Parent epics with all children already closed by #100 / #101 / #103, plus the changelog-entry beads this PR fulfils:

- `ccsc-me6` — Epic 29-B root (all four sub-epics complete).
- `ccsc-me6.13` — Hook policy decisions into the server reply path (4/4 children closed by #100).
- `ccsc-me6.14` — Track multiple human approvers without loops or bypass (4/4 closed by #101).
- `ccsc-me6.15` — Integration tests across the approval flow (3/3 closed by #103).
- `ccsc-me6.16` / `ccsc-me6.12` — v0.6.0 changelog entry (this PR **is** the closure).

## Test plan

- [x] `bun run typecheck` — clean (no code changes; ran anyway).
- [x] `bun test` — 471 pass, 0 fail (unchanged from main).
- [ ] Wait for Gemini review; address 🟡/🔴 if any, resolve 🟢.
- [ ] Merge with `--squash --admin --delete-branch`.
- [ ] Post-merge: tag `v0.6.0`, push tag, `gh release create v0.6.0` from the CHANGELOG v0.6.0 block.
- [ ] Post-merge: close the six parent epics listed above; close `ccsc-4an` as superseded by the v0.6.1 continuation bead; file two v0.6.1 beads (pairing event wiring, `/slack-channel:policy` authoring skill).

Jeremy made me do it
-claude