### PR TITLE
feat(policy): Epic 30-B.1 — audit field on ChannelPolicy

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -32,12 +32,26 @@ export const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 
 export type DmPolicy = 'pairing' | 'allowlist' | 'disabled'
 
+/** Audit-log projection mode for a channel. See ChannelPolicy.audit.
+ *  The authoritative record remains the local hash-chained journal at
+ *  `~/.claude/channels/slack/audit.log`; this mode controls a
+ *  best-effort projection of events into Slack threads. See
+ *  `000-docs/audit-journal-architecture.md` for the projection vs.
+ *  authoritative-log distinction. */
+export type AuditMode = 'off' | 'compact' | 'full'
+
 export interface ChannelPolicy {
   requireMention: boolean
   allowFrom: string[]
   /** Opt-in list of bot user IDs allowed to deliver messages in this channel.
    *  Absent or empty = all bot messages dropped (default-safe). */
   allowBotIds?: string[]
+  /** Audit-log projection into this channel's Slack threads. Absent or
+   *  `'off'` = no projection (default-safe). `'compact'` projects tool
+   *  name + outcome only. `'full'` projects redacted inputs + outcome
+   *  (redaction lives in the 30-A journal layer). Projection failures
+   *  are log-only and never block tool execution. */
+  audit?: AuditMode
 }
 
 export interface PendingEntry {


### PR DESCRIPTION
## Summary

- Add optional `audit: 'off' | 'compact' | 'full'` to `ChannelPolicy` in `lib.ts`.
- Export `AuditMode` type for downstream consumers.
- Schema-only landing — the pre/post-execution hooks that read this field land in `ccsc-dhh.2` / `ccsc-dhh.3`.

## Why schema-first

Same pattern that worked for `thread_ts` on `MatchSpec` (#96 before the evaluator wiring in #100): land the field shape ahead of the consumer so operators can author values against a stable v1 surface, and later beads in the tree target a frozen type.

## Design contract

The authoritative record remains the local hash-chained journal at `~/.claude/channels/slack/audit.log` — `audit` on `ChannelPolicy` controls a best-effort **projection** of events into Slack threads. Per the design doctrine in [`000-docs/audit-journal-architecture.md`](000-docs/audit-journal-architecture.md), projection is not authoritative; hash-chain verification is always against the local log. Projection failures will be log-only and never block tool execution (enforced by `ccsc-dhh.6`).

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 471 pass, 0 fail (no change; field is optional).
- [ ] Merge after Gemini review.

Closes `ccsc-dhh.1`.

Jeremy made me do it
-claude