### PR TITLE
feat(policy): Epic 30-B.2 — pre-execution audit receipts

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -11,6 +11,7 @@
 import { resolve, sep, basename, join } from 'path'
 import { realpathSync, mkdirSync, readdirSync, readFileSync, statSync, existsSync } from 'fs'
 import { writeFile, chmod, rename, unlink, readFile } from 'fs/promises'
+import { randomBytes } from 'crypto'
 import { z } from 'zod'
 
 // ---------------------------------------------------------------------------
@@ -1456,6 +1457,76 @@ export function recordApprovalVote(
     return { kind: 'approved', state: newState }
   }
   return { kind: 'pending', state: newState }
+}
+
+// ---------------------------------------------------------------------------
+// Slack mrkdwn escaping (shared between policy notices and audit receipts)
+// ---------------------------------------------------------------------------
+
+/** Escape Slack mrkdwn special characters to prevent injection of
+ *  control sequences (link syntax, channel refs) via attacker-
+ *  controlled strings like tool names or policy reasons. Pure. */
+export function escMrkdwn(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+// ---------------------------------------------------------------------------
+// Epic 30-B — audit receipt projection (pre-execution receipt blocks)
+// ---------------------------------------------------------------------------
+
+/** Generate a short, URL-safe correlation ID for linking a pre-execution
+ *  receipt to its eventual outcome (30-B.3). Uses 6 bytes of CSPRNG
+ *  entropy → 8-char base64url output. Collision probability across the
+ *  pending-receipts map at realistic volumes (<1k concurrent tool
+ *  calls) is negligible.
+ *
+ *  Pure — no I/O beyond the crypto RNG read. Tested via the
+ *  "generates unique, URL-safe" test. */
+export function generateCorrelationId(): string {
+  return randomBytes(6).toString('base64url')
+}
+
+/** Decide whether a given channel's policy opts in to audit receipt
+ *  projection. Absent or `'off'` returns false (default-safe): no
+ *  receipts posted, no cost, no information leak. `'compact'` and
+ *  `'full'` both return true — the mode difference is the *content*
+ *  of the post-execution edit (30-B.4 / 30-B.5), not the presence of
+ *  the pre-execution receipt. */
+export function shouldPostAuditReceipt(policy: ChannelPolicy | undefined): boolean {
+  const mode = policy?.audit
+  return mode === 'compact' || mode === 'full'
+}
+
+/** Slack Block Kit context-block payload for the pre-execution receipt.
+ *  Intentionally minimal: `:receipt:` emoji + tool name (escaped) +
+ *  correlation ID. Kept pure so server.ts and tests share one builder.
+ *
+ *  The returned shape matches Slack's Block Kit JSON — safe to spread
+ *  into `chat.postMessage({ blocks: ... })`. The `text` field is the
+ *  accessible fallback for notifications. */
+export function buildAuditReceiptMessage(
+  tool: string,
+  correlationId: string,
+): { text: string; blocks: readonly unknown[] } {
+  const safeTool = escMrkdwn(tool)
+  const safeCid = escMrkdwn(correlationId)
+  return {
+    text: `:receipt: audit: ${tool} (${correlationId})`,
+    blocks: [
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `:receipt: \`${safeTool}\` • cid \`${safeCid}\``,
+          },
+        ],
+      },
+    ],
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/lib.ts
+++ b/lib.ts
@@ -1500,6 +1500,16 @@ export function shouldPostAuditReceipt(policy: ChannelPolicy | undefined): boole
   return mode === 'compact' || mode === 'full'
 }
 
+/** Structural shape for a Slack Block Kit context block carrying a
+ *  single mrkdwn element. Declared here rather than importing from
+ *  `@slack/web-api` so `lib.ts` stays decoupled from the Slack SDK —
+ *  structural typing lets the Slack client accept this at the call
+ *  site in `server.ts` without an `as any` / `as never` escape. */
+export interface AuditReceiptContextBlock {
+  type: 'context'
+  elements: Array<{ type: 'mrkdwn'; text: string }>
+}
+
 /** Slack Block Kit context-block payload for the pre-execution receipt.
  *  Intentionally minimal: `:receipt:` emoji + tool name (escaped) +
  *  correlation ID. Kept pure so server.ts and tests share one builder.
@@ -1510,7 +1520,7 @@ export function shouldPostAuditReceipt(policy: ChannelPolicy | undefined): boole
 export function buildAuditReceiptMessage(
   tool: string,
   correlationId: string,
-): { text: string; blocks: readonly unknown[] } {
+): { text: string; blocks: AuditReceiptContextBlock[] } {
   const safeTool = escMrkdwn(tool)
   const safeCid = escMrkdwn(correlationId)
   return {

--- a/lib.ts
+++ b/lib.ts
@@ -1483,8 +1483,7 @@ export function escMrkdwn(text: string): string {
  *  pending-receipts map at realistic volumes (<1k concurrent tool
  *  calls) is negligible.
  *
- *  Pure — no I/O beyond the crypto RNG read. Tested via the
- *  "generates unique, URL-safe" test. */
+ *  Pure — no I/O beyond the crypto RNG read. */
 export function generateCorrelationId(): string {
   return randomBytes(6).toString('base64url')
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -26,10 +26,15 @@ import {
   MAX_PAIRING_REPLIES,
   PAIRING_EXPIRY_MS,
   SessionSchema,
+  escMrkdwn,
+  generateCorrelationId,
+  shouldPostAuditReceipt,
+  buildAuditReceiptMessage,
   type Access,
   type GateOptions,
   type Session,
   type SessionKey,
+  type ChannelPolicy,
 } from './lib.ts'
 import { createSessionSupervisor } from './supervisor.ts'
 import {
@@ -7346,5 +7351,82 @@ describe('Journal event wiring (ccsc-3fo)', () => {
     // Session file must have been created on disk.
     const { sessionPath: sPath } = await import('./lib.ts')
     expect(existsSync(sPath(rawRoot, key))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Epic 30-B.2 — audit receipt helpers
+// ---------------------------------------------------------------------------
+
+describe('escMrkdwn (lib move)', () => {
+  test('escapes &, <, > used in Slack mrkdwn injection', () => {
+    expect(escMrkdwn('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(escMrkdwn('A & B')).toBe('A &amp; B')
+  })
+  test('passes through unaffected characters', () => {
+    expect(escMrkdwn('simple text')).toBe('simple text')
+    expect(escMrkdwn('backtick `code`')).toBe('backtick `code`')
+  })
+})
+
+describe('generateCorrelationId (30-B.2)', () => {
+  test('returns a non-empty URL-safe string', () => {
+    const cid = generateCorrelationId()
+    expect(typeof cid).toBe('string')
+    expect(cid.length).toBeGreaterThan(0)
+    expect(cid).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+  test('produces unique IDs across successive calls', () => {
+    const ids = new Set<string>()
+    for (let i = 0; i < 1000; i++) ids.add(generateCorrelationId())
+    expect(ids.size).toBe(1000)
+  })
+})
+
+describe('shouldPostAuditReceipt (30-B.2)', () => {
+  const base: ChannelPolicy = { requireMention: false, allowFrom: [] }
+
+  test('returns false when policy is undefined (default-safe)', () => {
+    expect(shouldPostAuditReceipt(undefined)).toBe(false)
+  })
+  test('returns false when audit is absent', () => {
+    expect(shouldPostAuditReceipt(base)).toBe(false)
+  })
+  test("returns false when audit is 'off'", () => {
+    expect(shouldPostAuditReceipt({ ...base, audit: 'off' })).toBe(false)
+  })
+  test("returns true when audit is 'compact'", () => {
+    expect(shouldPostAuditReceipt({ ...base, audit: 'compact' })).toBe(true)
+  })
+  test("returns true when audit is 'full'", () => {
+    expect(shouldPostAuditReceipt({ ...base, audit: 'full' })).toBe(true)
+  })
+})
+
+describe('buildAuditReceiptMessage (30-B.2)', () => {
+  test('includes tool name and correlation ID in a context block', () => {
+    const msg = buildAuditReceiptMessage('Bash', 'abc123xy')
+    expect(msg.text).toContain('Bash')
+    expect(msg.text).toContain('abc123xy')
+    expect(msg.blocks).toHaveLength(1)
+    const block = msg.blocks[0] as { type: string; elements: Array<{ type: string; text: string }> }
+    expect(block.type).toBe('context')
+    expect(block.elements[0]!.type).toBe('mrkdwn')
+    expect(block.elements[0]!.text).toContain('Bash')
+    expect(block.elements[0]!.text).toContain('abc123xy')
+    expect(block.elements[0]!.text).toContain(':receipt:')
+  })
+  test('escapes mrkdwn in attacker-controlled tool names (injection defense)', () => {
+    const msg = buildAuditReceiptMessage('<script>x</script>', 'cid1')
+    const block = msg.blocks[0] as { elements: Array<{ text: string }> }
+    expect(block.elements[0]!.text).not.toContain('<script>')
+    expect(block.elements[0]!.text).toContain('&lt;script&gt;')
+  })
+  test('escapes mrkdwn in correlation ID (defense in depth — even though RNG output is safe)', () => {
+    // A future cid scheme changing to include >/< would not compromise output.
+    const msg = buildAuditReceiptMessage('tool', '<evil>')
+    const block = msg.blocks[0] as { elements: Array<{ text: string }> }
+    expect(block.elements[0]!.text).not.toContain('<evil>')
+    expect(block.elements[0]!.text).toContain('&lt;evil&gt;')
   })
 })

--- a/server.ts
+++ b/server.ts
@@ -52,6 +52,10 @@ import {
   recordApprovalVote,
   EVENT_DEDUP_TTL_MS,
   PERMISSION_REPLY_RE,
+  escMrkdwn,
+  generateCorrelationId,
+  shouldPostAuditReceipt,
+  buildAuditReceiptMessage,
   type Access,
   type GateResult,
   type PendingPolicyApproval,
@@ -275,6 +279,71 @@ function getAccess(): Access {
 
 let policyRules: readonly PolicyRule[] = loadPolicyRulesAtBoot()
 const policyApprovals = new Map<ApprovalKey, { ttlExpires: number }>()
+
+/** Pre-execution audit receipts awaiting their post-execution edit.
+ *  Keyed by correlation ID. Populated when a tool call passes policy
+ *  (auto_allow or quorum-approved) and the originating channel's
+ *  `audit` mode is `'compact'` or `'full'`. Consumed by the
+ *  post-execution edit hook (Epic 30-B.3) to update the receipt
+ *  with outcome. Entries with no matching post-execution signal
+ *  persist as stubs; Epic 30-B.6 adds reaper logic for these. */
+interface PendingAuditReceipt {
+  channel: string
+  thread: string | undefined
+  ts: string
+  tool: string
+  postedAt: number
+}
+const auditReceipts = new Map<string, PendingAuditReceipt>()
+
+/** Post a pre-execution audit receipt if the channel opts in via
+ *  `ChannelPolicy.audit`. Returns the generated correlation ID when
+ *  posted, or `undefined` when projection is off (default-safe) or
+ *  the Slack post failed.
+ *
+ *  Projection is best-effort by design: a failed post must never
+ *  block the tool call it was meant to witness. Errors are logged to
+ *  stderr only (enforced fully by Epic 30-B.6 reaper/backoff work).
+ *  The authoritative audit record remains the hash-chained local
+ *  journal — this is the *projection* surface per
+ *  [`000-docs/audit-journal-architecture.md`](000-docs/audit-journal-architecture.md). */
+async function postAuditReceiptIfEnabled(
+  client: WebClient,
+  accessSnapshot: Access,
+  channel: string,
+  thread: string | undefined,
+  tool: string,
+): Promise<string | undefined> {
+  const channelPolicy = accessSnapshot.channels[channel]
+  if (!shouldPostAuditReceipt(channelPolicy)) return undefined
+  const correlationId = generateCorrelationId()
+  const { text, blocks } = buildAuditReceiptMessage(tool, correlationId)
+  try {
+    const posted = await client.chat.postMessage({
+      channel,
+      thread_ts: thread,
+      text,
+      blocks: blocks as never,
+      unfurl_links: false,
+      unfurl_media: false,
+    })
+    if (!posted.ok || typeof posted.ts !== 'string') {
+      console.error('[slack] audit receipt post returned non-ok', { channel, tool })
+      return undefined
+    }
+    auditReceipts.set(correlationId, {
+      channel,
+      thread,
+      ts: posted.ts,
+      tool,
+      postedAt: Date.now(),
+    })
+    return correlationId
+  } catch (err) {
+    console.error('[slack] audit receipt post failed (non-blocking):', err)
+    return undefined
+  }
+}
 
 /** Grant a TTL-windowed approval for the (rule, session) pair. Called
  *  when a quorum of approvers has voted Allow on a `require_approval`
@@ -1099,6 +1168,14 @@ type PendingPermissionEntry = {
   description: string
   input_preview: string
   createdAt: number
+  /** Channel the tool call was issued against. Captured at entry
+   *  creation so the post-approval audit receipt (Epic 30-B.2) posts
+   *  in the originating channel even if the approver clicks from a
+   *  different surface. */
+  channel: string
+  /** Thread the tool call was issued in. `undefined` for top-level
+   *  messages. Used alongside `channel` for receipt posting. */
+  thread: string | undefined
   policy?: PendingPolicyApproval
 }
 const pendingPermissions = new Map<string, PendingPermissionEntry>()
@@ -1108,14 +1185,6 @@ function pruneStalePermissions(): void {
   for (const [id, entry] of pendingPermissions) {
     if (entry.createdAt < cutoff) pendingPermissions.delete(id)
   }
-}
-
-/** Escape Slack mrkdwn special characters to prevent injection. */
-function escMrkdwn(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
 }
 
 // Type assertion avoids TS2589 (excessively deep type instantiation) caused
@@ -1205,6 +1274,13 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
   const policyInput = { tool: params.tool_name, channel: targetChannel, thread_ts: lastActiveThread }
 
   if (route.type === 'auto_allow') {
+    const correlationId = await postAuditReceiptIfEnabled(
+      web,
+      access,
+      targetChannel,
+      lastActiveThread,
+      params.tool_name,
+    )
     journalWrite({
       kind: 'policy.allow',
       outcome: 'allow',
@@ -1213,6 +1289,7 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
       toolName: params.tool_name,
       input: policyInput,
       ruleId: route.ruleId,
+      correlationId,
     })
     await mcp.notification({
       method: 'notifications/claude/channel/permission',
@@ -1292,6 +1369,8 @@ mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }: { params:
     description: params.description,
     input_preview: params.input_preview,
     createdAt: Date.now(),
+    channel: targetChannel,
+    thread: lastActiveThread,
     policy: pendingPolicy,
   })
 
@@ -1525,6 +1604,20 @@ socket.on('interactive', async ({ body, ack }: { body: any; ack: () => Promise<v
     const behavior = verb === 'allow' ? 'allow' : 'deny'
     const verdict = behavior === 'allow' ? 'allowed' : 'denied'
     const safeTool = escMrkdwn(details.tool_name)
+
+    // Post the pre-execution audit receipt into the originating
+    // thread before releasing Claude to execute. Only fires on
+    // 'allow' since no execution follows a deny. No-op when the
+    // channel's policy opts out via audit: undefined | 'off'.
+    if (behavior === 'allow') {
+      await postAuditReceiptIfEnabled(
+        web,
+        access,
+        details.channel,
+        details.thread,
+        details.tool_name,
+      )
+    }
 
     await mcp.notification({
       method: 'notifications/claude/channel/permission',
@@ -1774,6 +1867,20 @@ async function handleMessage(event: unknown): Promise<void> {
           }
           // result.kind === 'approved' — fall through to the resolve
           // block below with behavior='allow'.
+        }
+
+        // Post the pre-execution audit receipt into the originating
+        // thread before releasing Claude. Same guardrails as the button
+        // path: only on allow, only when the channel opts in, never
+        // blocks tool execution on projection failure.
+        if (replyIsAllow) {
+          await postAuditReceiptIfEnabled(
+            web,
+            result.access!,
+            replyDetails.channel,
+            replyDetails.thread,
+            replyDetails.tool_name,
+          )
         }
 
         await mcp.notification({

--- a/server.ts
+++ b/server.ts
@@ -323,7 +323,7 @@ async function postAuditReceiptIfEnabled(
       channel,
       thread_ts: thread,
       text,
-      blocks: blocks as never,
+      blocks,
       unfurl_links: false,
       unfurl_media: false,
     })

--- a/server.ts
+++ b/server.ts
@@ -328,7 +328,11 @@ async function postAuditReceiptIfEnabled(
       unfurl_media: false,
     })
     if (!posted.ok || typeof posted.ts !== 'string') {
-      console.error('[slack] audit receipt post returned non-ok', { channel, tool })
+      console.error('[slack] audit receipt post returned non-ok', {
+        channel,
+        tool,
+        correlationId,
+      })
       return undefined
     }
     auditReceipts.set(correlationId, {
@@ -340,7 +344,12 @@ async function postAuditReceiptIfEnabled(
     })
     return correlationId
   } catch (err) {
-    console.error('[slack] audit receipt post failed (non-blocking):', err)
+    console.error('[slack] audit receipt post failed (non-blocking):', {
+      channel,
+      tool,
+      correlationId,
+      err,
+    })
     return undefined
   }
 }


### PR DESCRIPTION
## Summary

Post a threaded `:receipt:` Block Kit context block into the originating channel whenever a tool call passes policy (auto_allow or quorum-approved) and the channel opts in via `ChannelPolicy.audit` (`'compact'` or `'full'`). The receipt carries a correlation ID that `ccsc-dhh.3` (post-execution edit hook) will use to locate the message for the outcome update.

## What ships

**Pure helpers in `lib.ts`:**
- `generateCorrelationId()` — 8-char base64url from `crypto.randomBytes(6)`.
- `shouldPostAuditReceipt(policy)` — true only for `'compact'`/`'full'`.
- `buildAuditReceiptMessage(tool, cid)` — Block Kit context block with escaped tool name + cid.
- `escMrkdwn()` relocated from `server.ts` to `lib.ts` — was already pure; now shared between the policy-deny notice and the audit receipt.

**`server.ts` wiring:**
- Module-level `auditReceipts: Map<cid, {channel, thread, ts, tool, postedAt}>`. Populated here, consumed by `ccsc-dhh.3`.
- `postAuditReceiptIfEnabled()` — guards on `shouldPostAuditReceipt`, catches every Slack error so projection failure **never** blocks tool execution (fundamental invariant; `ccsc-dhh.6` adds backoff/reaper on top).
- Wired at three pre-execution points:
  1. `auto_allow` branch in the permission-relay — also stamps `correlationId` onto the `policy.allow` journal event.
  2. Button-handler post-quorum-approval, before the MCP allow response.
  3. Text-reply-handler post-quorum-approval, same contract.
- `PendingPermissionEntry` gains `channel` + `thread` so the receipt posts in the *originating* thread even if the approver clicks from a different UI surface.

## What this PR does NOT do

- No `correlationId` on `policy.approved` journal events — `processApprovalVote` writes the journal internally, and threading the cid through without duplicating the DRY'd helper is a separate refactor (fold into `ccsc-dhh.3` where the cid-to-journal linkage becomes load-bearing).
- No post-execution edit — that's `ccsc-dhh.3`.
- No compact/full mode differentiation — the pre-exec stub is mode-agnostic; the content of the *edit* is where mode matters (`ccsc-dhh.4`/`ccsc-dhh.5`).
- No graceful-failure reaper for orphaned receipts — `ccsc-dhh.6` territory. Current code is log-only on Slack errors.

## Invariants preserved

- **Projection never blocks execution** — all `postAuditReceiptIfEnabled` paths catch and log, never throw.
- **Default-safe** — absent `audit` field = no projection, matching every other opt-in field in this codebase.
- **mrkdwn injection defense** — tool name and cid both run through `escMrkdwn` before inclusion in the context block. Covered by dedicated tests.
- **Authoritative record unchanged** — the hash-chained local journal at `~/.claude/channels/slack/audit.log` remains the source of truth per [`000-docs/audit-journal-architecture.md`](000-docs/audit-journal-architecture.md); this PR only adds a *projection* surface.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — **483 pass** (up from 471; +12 for the new helpers).
- [ ] Merge after Gemini review.

Closes `ccsc-dhh.2`.

Jeremy made me do it
-claude