### PR TITLE
feat(lib): cap auditReceipts map at 500 entries (memory safety)

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -1612,7 +1612,7 @@ export function enforceAuditReceiptCap<V>(receipts: Map<string, V>, max: number)
     const oldestKey = receipts.keys().next().value
     if (oldestKey === undefined) break
     receipts.delete(oldestKey)
-    evicted += 1
+    evicted++
   }
   return evicted
 }

--- a/lib.ts
+++ b/lib.ts
@@ -22,6 +22,16 @@ export const MAX_PENDING = 3
 export const MAX_PAIRING_REPLIES = 2
 export const PAIRING_EXPIRY_MS = 60 * 60 * 1000 // 1 hour
 
+/** Upper bound on the in-memory auditReceipts map in server.ts. Pre-
+ *  execution receipts accumulate entries that would otherwise grow
+ *  unbounded on a long-running server — there's no MCP tool-
+ *  completion signal to clear them (see ccsc-4nm). When the map
+ *  exceeds this cap, the oldest entries are evicted FIFO via
+ *  `enforceAuditReceiptCap`. Eviction is silent (projection is
+ *  best-effort; the authoritative hash-chained journal already
+ *  captured the decision). */
+export const AUDIT_RECEIPTS_MAX = 500
+
 /** Matches permission relay replies (e.g. "y abcde", "no xyzwq").
  *  Used in gate() to block peer-bot messages that look like permission
  *  approvals, and in server.ts to route human permission replies. */
@@ -1580,6 +1590,31 @@ export async function buildAndPostAuditReceipt(
   } catch (err) {
     return reportError(err)
   }
+}
+
+/** Enforce a FIFO capacity cap on an auditReceipts-style Map. If size
+ *  exceeds `max`, evict oldest insertion-order entries until it fits.
+ *  Javascript Map preserves insertion order, so `keys().next().value`
+ *  is the oldest entry.
+ *
+ *  Pure with respect to external state (mutates only the passed map).
+ *  Silent eviction is intentional: the authoritative hash-chained
+ *  journal already captured the decision the evicted receipt was
+ *  projecting, so the operator loses no information — just the Slack-
+ *  side correlation affordance for that specific receipt. A long-
+ *  running server with 500+ concurrent approved tool calls either has
+ *  volume high enough that the thread is unreadable anyway, or has
+ *  had post-exec finalization (ccsc-4nm) wired by then to clear
+ *  entries as tools complete. */
+export function enforceAuditReceiptCap<V>(receipts: Map<string, V>, max: number): number {
+  let evicted = 0
+  while (receipts.size > max) {
+    const oldestKey = receipts.keys().next().value
+    if (oldestKey === undefined) break
+    receipts.delete(oldestKey)
+    evicted += 1
+  }
+  return evicted
 }
 
 /** Slack Block Kit context-block payload for the pre-execution receipt.

--- a/server.test.ts
+++ b/server.test.ts
@@ -31,6 +31,8 @@ import {
   shouldPostAuditReceipt,
   buildAuditReceiptMessage,
   buildAndPostAuditReceipt,
+  enforceAuditReceiptCap,
+  AUDIT_RECEIPTS_MAX,
   type Access,
   type AuditReceiptPostArgs,
   type AuditReceiptPostError,
@@ -7647,5 +7649,53 @@ describe('buildAndPostAuditReceipt (30-B.9)', () => {
     expect(result).toBeUndefined()
     expect(errors).toHaveLength(1)
     expect(errors[0]!.err).toBe('ok response missing ts')
+  })
+})
+
+describe('enforceAuditReceiptCap (audit-receipt memory safety)', () => {
+  test('under cap — no-op, returns 0', () => {
+    const m = new Map<string, number>()
+    m.set('a', 1)
+    m.set('b', 2)
+    expect(enforceAuditReceiptCap(m, 10)).toBe(0)
+    expect(m.size).toBe(2)
+  })
+
+  test('exactly at cap — no-op', () => {
+    const m = new Map<string, number>()
+    for (let i = 0; i < 5; i++) m.set(`k${i}`, i)
+    expect(enforceAuditReceiptCap(m, 5)).toBe(0)
+    expect(m.size).toBe(5)
+  })
+
+  test('over cap — evicts oldest FIFO until size equals cap, returns eviction count', () => {
+    const m = new Map<string, number>()
+    for (let i = 0; i < 10; i++) m.set(`k${i}`, i)
+    expect(enforceAuditReceiptCap(m, 3)).toBe(7)
+    expect(m.size).toBe(3)
+    // Only the last three inserted keys survive.
+    expect([...m.keys()]).toEqual(['k7', 'k8', 'k9'])
+  })
+
+  test('cap of zero — evicts everything', () => {
+    const m = new Map<string, number>()
+    m.set('a', 1)
+    m.set('b', 2)
+    expect(enforceAuditReceiptCap(m, 0)).toBe(2)
+    expect(m.size).toBe(0)
+  })
+
+  test('cap larger than size — returns 0', () => {
+    const m = new Map<string, number>([['x', 1]])
+    expect(enforceAuditReceiptCap(m, 100)).toBe(0)
+    expect(m.size).toBe(1)
+  })
+
+  test('AUDIT_RECEIPTS_MAX is a reasonable production value', () => {
+    // Guard against accidental regression (e.g. someone setting it to 0 or
+    // Number.MAX_SAFE_INTEGER). The production value should be high enough
+    // for bursty workloads but bounded for memory safety.
+    expect(AUDIT_RECEIPTS_MAX).toBeGreaterThanOrEqual(100)
+    expect(AUDIT_RECEIPTS_MAX).toBeLessThanOrEqual(10_000)
   })
 })

--- a/server.ts
+++ b/server.ts
@@ -54,6 +54,8 @@ import {
   PERMISSION_REPLY_RE,
   escMrkdwn,
   buildAndPostAuditReceipt,
+  enforceAuditReceiptCap,
+  AUDIT_RECEIPTS_MAX,
   type Access,
   type GateResult,
   type PendingPolicyApproval,
@@ -331,6 +333,7 @@ async function postAuditReceiptIfEnabled(
     tool,
     postedAt: Date.now(),
   })
+  enforceAuditReceiptCap(auditReceipts, AUDIT_RECEIPTS_MAX)
   return result.correlationId
 }
 


### PR DESCRIPTION
## Summary

Close a real memory leak in the pre-execution audit receipt path shipped in #106: `auditReceipts` grows unbounded because there's no MCP tool-completion signal to trigger removal (the post-execution finalization is deferred to `ccsc-4nm` — see rationale below).

## Fix

- `AUDIT_RECEIPTS_MAX = 500` (lib.ts constant, exported).
- `enforceAuditReceiptCap(receipts, max)` — pure FIFO eviction helper. JavaScript Map preserves insertion order, so `keys().next().value` is always the oldest entry. Returns the eviction count for test observation.
- `server.ts` calls it after every `auditReceipts.set(...)` so the cap is maintained as a Map invariant, not via a separate sweep.

## Why silent eviction is correct

The **authoritative** record is the hash-chained journal. The auditReceipts map exists only to let the post-execution edit hook (future `ccsc-4nm`) find the receipt ts to update. Evicting an entry means the bridge forgets one Slack-side ts; the journal entry remains intact. Operators investigating a specific tool call consult the journal regardless — projection loss is by design.

A server handling 500+ concurrent *unresolved* pre-exec receipts either has traffic so high the thread is unreadable anyway, or has had post-exec finalization wired by then to drain entries as tools complete.

## Why the post-exec edit is deferred (`ccsc-4nm`)

The original `dhh.3` scope was \"chat.update the receipt with exit code, path, summary.\" MCP's permission-relay protocol has no tool-completion notification: we send `permissions/response allow`, Claude executes in its own process, no outcome surfaces back. Synthesizing an outcome via timer heuristics or next-action proxy would produce receipts *less* trustworthy than the journal they project. Right answer: pre-exec receipt is the projection; outcome lives in the journal. File `ccsc-4nm` for when MCP adds a completion signal.

## Tests

+6 covering the cap invariants: 500 tests total, up from 494.

- Under cap → no-op, returns 0.
- Exactly at cap → no-op.
- Over cap → evicts oldest FIFO until size equals cap, returns correct eviction count, surviving keys are the last N inserted.
- Cap of 0 → evicts everything.
- Cap larger than current size → no-op.
- Sanity bound on `AUDIT_RECEIPTS_MAX` (100 ≤ max ≤ 10k) to catch accidental regression.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 500 pass, 0 fail.
- [ ] Merge after Gemini.

Jeremy made me do it
-claude