### PR TITLE
feat(policy): lock in 31-A.4 invariant — manifest never reaches evaluate()

### DIFF
--- a/policy.ts
+++ b/policy.ts
@@ -264,6 +264,36 @@ export function pathMatchesPrefix(resolvedPath: string, resolvedPrefix: string):
 }
 
 // ---------------------------------------------------------------------------
+// 31-A.4 Invariant — manifest data NEVER passed to evaluate()
+//
+// Design: 000-docs/bot-manifest-protocol.md §91-109 ("The binding invariant").
+//
+// Peer-bot manifests are advertisements, not grants (Miller 2006). Policy
+// decisions MUST use only verified signals carried on ToolCall (tool,
+// sessionKey.channel, actor) — never content a peer advertised about itself.
+// A peer claiming "I am an approver" in its manifest does not make it one;
+// allowBotIds and access.json are the only sources of role truth.
+//
+// Enforcement here is structural + contractual:
+//
+//   1. policy.ts imports NO manifest-module path, direct or re-exported.
+//      Enforced by the "31-A.4 invariant" test in server.test.ts, which
+//      parses this file's import specifiers on every CI run. A violation
+//      is a merge block, not a warning.
+//
+//   2. When the (future, conditionally-shipped) manifest consumer lands in
+//      Epic 31-A, its output flows to Claude only as MCP tool-call text —
+//      the same trust surface as a chat message. It does NOT flow into
+//      ToolCall.input, PolicyRule[], or EvaluateOptions. Reviewers of any
+//      31-A PR must confirm this before merge.
+//
+//   3. access.json mutation from manifest reads is forbidden (see the
+//      manifest protocol doc §190-203). That rule is enforced in the
+//      manifest-consumer module itself, not here — policy.ts's job is
+//      to stay unreachable from manifest content, full stop.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // evaluate() — first-applicable combining (XACML) per policy-evaluation-flow.md
 // ---------------------------------------------------------------------------
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -3104,6 +3104,64 @@ describe('checkMonotonicity() — hot-reload invariant (29-A.6)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// 31-A.4 invariant — manifest data NEVER passed to evaluate()
+//
+// Design: 000-docs/bot-manifest-protocol.md §91-109 ("The binding invariant").
+// policy.ts must not import from any manifest module, directly or via
+// re-export. This test parses policy.ts's import specifiers on every CI run.
+// A violation is a merge block, not a warning. Miller 2006: "advertisements
+// are not grants." The peer's manifest is content, never authority.
+// ---------------------------------------------------------------------------
+
+describe('31-A.4 invariant — manifest data never reaches evaluate()', () => {
+  /** Extract every module specifier from a TypeScript source file.
+   *  Handles `import … from 'x'`, `import('x')`, `require('x')`, and
+   *  `export … from 'x'` (re-exports). Comments are stripped first so
+   *  prose mentioning "manifest" does not false-positive. */
+  function extractImportSpecifiers(src: string): string[] {
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '')
+    const specs: string[] = []
+    const re = /(?:\bfrom|\bimport\s*\(|\brequire\s*\()\s*(['"])([^'"]+)\1/g
+    let m: RegExpExecArray | null
+    while ((m = re.exec(stripped)) !== null) specs.push(m[2]!)
+    return specs
+  }
+
+  test('policy.ts imports no manifest-module specifier', () => {
+    const src = readFileSync(join(import.meta.dir, 'policy.ts'), 'utf8')
+    const specs = extractImportSpecifiers(src)
+    const violators = specs.filter((s) => /manifest/i.test(s))
+    expect(
+      violators,
+      `policy.ts must not import from a manifest module — violates Epic 31-A.4 invariant ` +
+        `(see 000-docs/bot-manifest-protocol.md §91-109). Offending specifiers: ${JSON.stringify(violators)}`,
+    ).toEqual([])
+  })
+
+  test('extractImportSpecifiers catches from, import(), require(), re-export, case variants', () => {
+    // Sanity check on the parser so the guard above can't silently pass.
+    const fixture = [
+      `import { X } from './manifest.ts'`,
+      `import type { Y } from "./Manifest"`,
+      `const m = await import('./manifest-consumer')`,
+      `const r = require('./MANIFEST-reader')`,
+      `export { Z } from './manifest/index.ts'`,
+      `// mentions manifest in a comment — must not count`,
+      `/* also manifest in a block comment */`,
+      `import { safe } from './policy.ts' // trailing comment about manifest`,
+    ].join('\n')
+    const specs = extractImportSpecifiers(fixture)
+    const manifestSpecs = specs.filter((s) => /manifest/i.test(s))
+    expect(manifestSpecs.length).toBe(5)
+    // And the comment-only "mentions manifest" line must not appear.
+    expect(specs).toContain('./policy.ts')
+    expect(specs.every((s) => !/comment/i.test(s))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // SessionSupervisor.activate — 000-docs/session-state-machine.md §221-267
 // ---------------------------------------------------------------------------
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -79,6 +79,23 @@ function makeOpts(overrides: Partial<GateOptions> = {}): GateOptions {
   }
 }
 
+/** Extract every module specifier from a TypeScript source file.
+ *  Handles `import … from 'x'`, `import('x')`, `require('x')`, and
+ *  `export … from 'x'` (re-exports). Comments are stripped first so
+ *  prose mentioning a banned name (e.g. "manifest") does not false-
+ *  positive. Used by the 31-A.4 invariant test below and available
+ *  to any future import-graph lint in this suite. */
+function extractImportSpecifiers(src: string): string[] {
+  const stripped = src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '')
+  const specs: string[] = []
+  const re = /(?:\bfrom|\bimport\s*\(|\brequire\s*\()\s*(['"])([^'"]+)\1/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(stripped)) !== null) specs.push(m[2]!)
+  return specs
+}
+
 // ---------------------------------------------------------------------------
 // gate()
 // ---------------------------------------------------------------------------
@@ -3114,21 +3131,6 @@ describe('checkMonotonicity() — hot-reload invariant (29-A.6)', () => {
 // ---------------------------------------------------------------------------
 
 describe('31-A.4 invariant — manifest data never reaches evaluate()', () => {
-  /** Extract every module specifier from a TypeScript source file.
-   *  Handles `import … from 'x'`, `import('x')`, `require('x')`, and
-   *  `export … from 'x'` (re-exports). Comments are stripped first so
-   *  prose mentioning "manifest" does not false-positive. */
-  function extractImportSpecifiers(src: string): string[] {
-    const stripped = src
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/\/\/[^\n]*/g, '')
-    const specs: string[] = []
-    const re = /(?:\bfrom|\bimport\s*\(|\brequire\s*\()\s*(['"])([^'"]+)\1/g
-    let m: RegExpExecArray | null
-    while ((m = re.exec(stripped)) !== null) specs.push(m[2]!)
-    return specs
-  }
-
   test('policy.ts imports no manifest-module specifier', () => {
     const src = readFileSync(join(import.meta.dir, 'policy.ts'), 'utf8')
     const specs = extractImportSpecifiers(src)


### PR DESCRIPTION
## Summary

- Adds a module-level invariant doc block to `policy.ts` declaring that manifest data (from peer-bot advertisements) MUST NEVER be passed into `evaluate()`.
- Adds an import-graph lint test in `server.test.ts` that parses every import/require/re-export specifier in `policy.ts` and fails CI if any references a manifest module.
- Ships a sanity test proving the parser catches every specifier shape without false-positiving on prose in comments.

Miller 2006: advertisements are not grants. A peer's manifest is content, never authority. Role truth lives in `access.json` and `allowBotIds` — nowhere else.

No manifest module exists yet; Epic 31-A ships conditionally on a signing primitive. This bead establishes the guard *before* any 31-A code lands, so the first violation would be blocked at merge rather than discovered in production.

Closes bead `ccsc-s53.4` (Epic 31-A).

## Design references

- [`000-docs/bot-manifest-protocol.md`](./000-docs/bot-manifest-protocol.md) §91-109 — "The binding invariant"
- [`CLAUDE.md`](./CLAUDE.md) §Security Architecture — five defense layers

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 502/502 pass (up from 500)
- [x] `bun test -t "31-A.4 invariant"` — 2/2 pass
- [x] Sanity: the parser catches `import … from`, `import()`, `require()`, re-exports, case variants, and ignores manifest mentions inside comments

Jeremy made me do it
-claude