### PR TITLE
feat(lib): add assertPublishAllowed gate — only access.allowFrom may publish

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -976,6 +976,34 @@ export function assertOutboundAllowed(
 }
 
 /**
+ * Assert that a given user_id may publish a manifest (Epic 31-B.5).
+ *
+ * `publish_manifest` is an outbound act performed on behalf of the session
+ * owner. Only users in `access.allowFrom` — the top-level DM allowlist —
+ * may publish, giving operators one consistent authorization surface:
+ * the same list that gates DMs gates publishing.
+ *
+ * Throws on rejection so MCP tool handlers surface a clear failure to
+ * Claude and, via journal, to the operator. Default-safe: `allowFrom` of
+ * `[]` (the hardened default in `defaultAccess()`) rejects all callers.
+ *
+ * Epic 31-B ships conditionally on a stronger identity primitive than
+ * Slack's `bot_id`, so the `publish_manifest` MCP tool does not exist
+ * yet. This gate lands ahead of the tool so the authorization surface
+ * is fixed before any publish code is written — symmetric to the 31-A.4
+ * "manifest never reaches evaluate()" invariant on the read side.
+ *
+ * See bead ccsc-0qk.5 and the 31-B sub-epic ccsc-0qk.14.
+ */
+export function assertPublishAllowed(ownerId: string, access: Access): void {
+  if (access.allowFrom.includes(ownerId)) return
+  throw new Error(
+    `Publish gate: user_id '${ownerId}' is not in access.allowFrom — ` +
+      `only allowlisted users may publish a manifest.`,
+  )
+}
+
+/**
  * Returns true if `url` is a well-formed https URL on files.slack.com.
  *
  * Used before attaching the bot token to a fetch() of a Slack file URL.

--- a/lib.ts
+++ b/lib.ts
@@ -998,8 +998,7 @@ export function assertOutboundAllowed(
 export function assertPublishAllowed(ownerId: string, access: Access): void {
   if (access.allowFrom.includes(ownerId)) return
   throw new Error(
-    `Publish gate: user_id '${ownerId}' is not in access.allowFrom — ` +
-      `only allowlisted users may publish a manifest.`,
+    `Publish gate: user_id '${ownerId}' is not in access.allowFrom — only allowlisted users may publish a manifest.`,
   )
 }
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -908,6 +908,66 @@ describe('assertOutboundAllowed', () => {
 })
 
 // ---------------------------------------------------------------------------
+// assertPublishAllowed — publish-manifest gate (Epic 31-B.5, ccsc-0qk.5)
+//
+// Only user_ids in the top-level access.allowFrom may publish a manifest.
+// Same authorization surface that gates DMs. Default-safe: empty allowFrom
+// rejects everyone. Gate lands ahead of the publish_manifest MCP tool so
+// the authorization surface is fixed before any publish code is written —
+// symmetric to the 31-A.4 "manifest never reaches evaluate()" invariant.
+// ---------------------------------------------------------------------------
+
+describe('assertPublishAllowed (31-B.5)', () => {
+  test('allows user in access.allowFrom', async () => {
+    const { assertPublishAllowed } = await import('./lib.ts')
+    const access = makeAccess({ allowFrom: ['U_ALICE', 'U_BOB'] })
+    expect(() => assertPublishAllowed('U_ALICE', access)).not.toThrow()
+    expect(() => assertPublishAllowed('U_BOB', access)).not.toThrow()
+  })
+
+  test('rejects user not in access.allowFrom with a clear, ID-bearing error', async () => {
+    const { assertPublishAllowed } = await import('./lib.ts')
+    const access = makeAccess({ allowFrom: ['U_ALICE'] })
+    expect(() => assertPublishAllowed('U_EVE', access)).toThrow(/Publish gate/)
+    expect(() => assertPublishAllowed('U_EVE', access)).toThrow(/U_EVE/)
+    expect(() => assertPublishAllowed('U_EVE', access)).toThrow(/access\.allowFrom/)
+  })
+
+  test('rejects every caller when allowFrom is empty (hardened default)', async () => {
+    const { assertPublishAllowed } = await import('./lib.ts')
+    // defaultAccess() sets allowFrom: [] — nobody can publish until an
+    // operator explicitly adds a user. This test locks in the fail-closed
+    // posture so a future refactor that inverts the check breaks here.
+    const access = makeAccess() // allowFrom: []
+    expect(() => assertPublishAllowed('U_ALICE', access)).toThrow(/Publish gate/)
+    expect(() => assertPublishAllowed('U_BOB', access)).toThrow(/Publish gate/)
+    expect(() => assertPublishAllowed('', access)).toThrow(/Publish gate/)
+  })
+
+  test('is case-sensitive on user_id (Slack IDs are opaque and exact-match)', async () => {
+    const { assertPublishAllowed } = await import('./lib.ts')
+    const access = makeAccess({ allowFrom: ['U_ALICE'] })
+    // Slack user IDs are opaque and case-sensitive. A lookalike must fail.
+    expect(() => assertPublishAllowed('u_alice', access)).toThrow(/Publish gate/)
+    expect(() => assertPublishAllowed('U_ALICE ', access)).toThrow(/Publish gate/)
+  })
+
+  test('does not consult per-channel ChannelPolicy.allowFrom', async () => {
+    const { assertPublishAllowed } = await import('./lib.ts')
+    // Channel-level allowFrom governs inbound message delivery, not the
+    // workspace-level publish act. Operators managing the per-channel
+    // list cannot accidentally grant publish authority.
+    const access = makeAccess({
+      allowFrom: [], // top-level empty
+      channels: {
+        C_GENERAL: { requireMention: false, allowFrom: ['U_ALICE'] },
+      },
+    })
+    expect(() => assertPublishAllowed('U_ALICE', access)).toThrow(/Publish gate/)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Thread isolation — outbound gate (ccsc-xa3.5 landed → ccsc-xa3.6 fixed)
 // ---------------------------------------------------------------------------
 //


### PR DESCRIPTION
## Summary

Epic 31-B.5 (bead `ccsc-0qk.5`). Lands the publish-manifest authorization gate ahead of the `publish_manifest` MCP tool itself, symmetric to the 31-A.4 "manifest never reaches `evaluate()`" invariant on the read side.

- **`assertPublishAllowed(ownerId, access)`** in `lib.ts` — throws on any caller not in `access.allowFrom`.
- One allowlist governs both DM access AND publish authority. Operators have a single consistent place to manage who can act on behalf of the bot.
- Default-safe: `defaultAccess()` returns `allowFrom: []` so nobody can publish until an operator explicitly adds a user.

## Test coverage (5 new tests, 507/507 pass total)

- user in `allowFrom` → passes
- user not in `allowFrom` → throws with an ID- and field-bearing reason
- empty `allowFrom` rejects everyone (fail-closed default locked in)
- case-sensitive exact match (Slack IDs are opaque and exact-match)
- per-channel `ChannelPolicy.allowFrom` is deliberately NOT consulted — channel-level inbound allowlists cannot accidentally grant publish authority

Closes bead `ccsc-0qk.5`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 507/507 pass
- [x] `bun test -t "assertPublishAllowed"` — 5/5 pass

Jeremy made me do it
-claude