### PR TITLE
feat(manifest): add ManifestV1 Zod schema with magic header discriminator

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -1,0 +1,96 @@
+/**
+ * manifest.ts — Peer-bot manifest schema (Epic 31-A).
+ *
+ * A manifest is a JSON payload that a peer agent posts in-channel to advertise
+ * what it is: name, vendor, version, tools it exposes, channels it opts into,
+ * and a contact address. Other bots and humans read manifests as *information*;
+ * they are advertisements, never grants (Miller 2006, Robust Composition).
+ *
+ * This file intentionally has no imports from `policy.ts` or `lib.ts`'s
+ * policy-adjacent surface. The symmetric constraint — `policy.ts` does not
+ * import from this module — is enforced by the 31-A.4 invariant test in
+ * `server.test.ts`. See `000-docs/bot-manifest-protocol.md` §91-109 for the
+ * binding invariant and §17-55 for the on-wire schema this file encodes.
+ *
+ * Scope of this file for ccsc-s53.1:
+ *   - The `ManifestV1` Zod schema with magic-header discriminator.
+ *   - Inferred TypeScript type.
+ *
+ * Sibling beads add: size cap (s53.3), the `read_peer_manifests` MCP tool
+ * (s53.2), and the 5-minute per-channel read cache (s53.5).
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// ManifestV1 — on-channel advertisement schema
+// ---------------------------------------------------------------------------
+
+/**
+ * SemVer 2.0.0 subset accepted for `version`: `MAJOR.MINOR.PATCH` with an
+ * optional pre-release suffix `-<alnum/dot/hyphen>`. Build metadata (`+…`)
+ * is deliberately excluded — manifests that want to signal a build should
+ * surface it via `description`, not the version field. Keeping the regex
+ * narrow means downstream consumers that want to sort manifests can do so
+ * without a full SemVer parser.
+ */
+const SEMVER_RE = /^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/
+
+/**
+ * Slack public-channel ID shape. `C` + uppercase alphanumerics. DM IDs
+ * (`D…`) and private-group IDs (`G…`) are deliberately rejected — a
+ * manifest advertising participation in a DM or private group would leak
+ * non-public information about the bot's reach and is out of scope for
+ * the v1 protocol.
+ */
+const CHANNEL_ID_RE = /^C[A-Z0-9]+$/
+
+/**
+ * Zod schema for the v1 manifest payload.
+ *
+ * The literal `__claude_bot_manifest_v1__: true` property doubles as a
+ * version discriminator: future protocol revisions will mint a new key
+ * (e.g. `__claude_bot_manifest_v2__`) so consumers that understand only
+ * v1 can skip unknown versions without false-matching them. Matches the
+ * frozen contract in `000-docs/bot-manifest-protocol.md` §24-41.
+ *
+ * Validation failures (malformed JSON, missing fields, wrong types, size
+ * cap violations, or the magic header missing / not literally `true`) are
+ * silently dropped by the consumer — see the protocol doc §81 and bead
+ * ccsc-s53.13 ("Drop malformed, invalid, and oversized manifests
+ * silently"). This file only encodes the *shape*; the dropping happens in
+ * the read tool (ccsc-s53.2) and the size-cap layer (ccsc-s53.3).
+ */
+export const ManifestV1 = z.object({
+  __claude_bot_manifest_v1__: z.literal(true),
+  name: z.string().min(1).max(80),
+  vendor: z.string().min(1).max(80),
+  version: z.string().regex(SEMVER_RE),
+  description: z.string().max(1000),
+  tools: z
+    .array(
+      z.object({
+        name: z.string().min(1).max(80),
+        description: z.string().max(400),
+      }),
+    )
+    .max(50),
+  channels: z.array(z.string().regex(CHANNEL_ID_RE)).max(50).optional(),
+  contact: z.string().email().optional(),
+  publishedAt: z.string().datetime(),
+})
+
+/** Inferred type for a validated manifest payload. */
+export type ManifestV1 = z.infer<typeof ManifestV1>
+
+/**
+ * The magic header key. Exported so the read tool (ccsc-s53.2) and any
+ * pins.list discriminator can match on the same literal without repeating
+ * the string. Consumers MUST check that the key's value is exactly `true`
+ * before trusting the payload to be a v1 manifest — presence alone is not
+ * enough (a peer could post `{"__claude_bot_manifest_v1__": "yes"}` and
+ * that must not match).
+ */
+export const MANIFEST_V1_MAGIC_KEY = '__claude_bot_manifest_v1__' as const

--- a/server.test.ts
+++ b/server.test.ts
@@ -3224,8 +3224,223 @@ describe('31-A.4 invariant — manifest data never reaches evaluate()', () => {
 })
 
 // ---------------------------------------------------------------------------
-// SessionSupervisor.activate — 000-docs/session-state-machine.md §221-267
+// ManifestV1 — peer-bot manifest schema (Epic 31-A.1, ccsc-s53.1)
+//
+// Design: 000-docs/bot-manifest-protocol.md §17-55. The schema encodes the
+// on-wire contract exactly; validation failures are silently dropped by the
+// consumer (ccsc-s53.13), not raised to callers. These tests pin the schema
+// against its frozen contract so any drift is caught before a peer's well-
+// formed v1 payload starts failing validation in the wild.
 // ---------------------------------------------------------------------------
+
+describe('ManifestV1 schema (31-A.1)', () => {
+  /** Minimal valid manifest used as the base for parameterised rejection
+   *  tests — each test mutates one field to verify that specific constraint. */
+  function validManifest(): unknown {
+    return {
+      __claude_bot_manifest_v1__: true,
+      name: 'Example Bot',
+      vendor: 'Acme Corp',
+      version: '1.2.3',
+      description: 'A minimal example manifest for tests.',
+      tools: [{ name: 'reply', description: 'Post a reply to a message.' }],
+      publishedAt: '2026-01-01T00:00:00.000Z',
+    }
+  }
+
+  test('accepts a minimal valid manifest and preserves every field', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    const parsed = ManifestV1.parse(validManifest())
+    expect(parsed.__claude_bot_manifest_v1__).toBe(true)
+    expect(parsed.name).toBe('Example Bot')
+    expect(parsed.vendor).toBe('Acme Corp')
+    expect(parsed.version).toBe('1.2.3')
+    expect(parsed.description).toBe('A minimal example manifest for tests.')
+    expect(parsed.tools).toHaveLength(1)
+    expect(parsed.tools[0]).toEqual({
+      name: 'reply',
+      description: 'Post a reply to a message.',
+    })
+    expect(parsed.channels).toBeUndefined()
+    expect(parsed.contact).toBeUndefined()
+    expect(parsed.publishedAt).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  test('accepts optional channels[] and contact when well-formed', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    const parsed = ManifestV1.parse({
+      ...(validManifest() as Record<string, unknown>),
+      channels: ['C01234ABCD', 'C56789EFGH'],
+      contact: 'ops@example.com',
+    })
+    expect(parsed.channels).toEqual(['C01234ABCD', 'C56789EFGH'])
+    expect(parsed.contact).toBe('ops@example.com')
+  })
+
+  // ── Magic-header discriminator ─────────────────────────────────────────
+
+  test('rejects when the magic header key is missing', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    const m = validManifest() as Record<string, unknown>
+    delete m.__claude_bot_manifest_v1__
+    expect(() => ManifestV1.parse(m)).toThrow()
+  })
+
+  test('rejects when the magic header is a truthy non-true value (presence is not enough)', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    // The doc requires a literal `true` — a string, 1, or other truthy
+    // value must not match, otherwise any peer could post a payload that
+    // *looks* like a manifest without committing to the shape.
+    for (const imposter of ['yes', 1, 'true', {}, []] as const) {
+      expect(() =>
+        ManifestV1.parse({
+          ...(validManifest() as Record<string, unknown>),
+          __claude_bot_manifest_v1__: imposter,
+        }),
+      ).toThrow()
+    }
+  })
+
+  test('exports MANIFEST_V1_MAGIC_KEY matching the schema literal key', async () => {
+    const { MANIFEST_V1_MAGIC_KEY } = await import('./manifest.ts')
+    expect(MANIFEST_V1_MAGIC_KEY).toBe('__claude_bot_manifest_v1__')
+  })
+
+  // ── String-length bounds ───────────────────────────────────────────────
+
+  test('rejects name shorter than 1 or longer than 80 chars', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    expect(() => ManifestV1.parse({ ...validManifest() as object, name: '' })).toThrow()
+    expect(() =>
+      ManifestV1.parse({ ...validManifest() as object, name: 'x'.repeat(81) }),
+    ).toThrow()
+  })
+
+  test('rejects vendor shorter than 1 or longer than 80 chars', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    expect(() => ManifestV1.parse({ ...validManifest() as object, vendor: '' })).toThrow()
+    expect(() =>
+      ManifestV1.parse({ ...validManifest() as object, vendor: 'v'.repeat(81) }),
+    ).toThrow()
+  })
+
+  test('rejects description longer than 1000 chars', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    expect(() =>
+      ManifestV1.parse({ ...validManifest() as object, description: 'd'.repeat(1001) }),
+    ).toThrow()
+    // Exactly 1000 is OK.
+    expect(() =>
+      ManifestV1.parse({ ...validManifest() as object, description: 'd'.repeat(1000) }),
+    ).not.toThrow()
+  })
+
+  // ── Version regex (SemVer subset) ──────────────────────────────────────
+
+  test('accepts SemVer MAJOR.MINOR.PATCH and MAJOR.MINOR.PATCH-prerelease', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    for (const v of ['0.0.1', '10.20.30', '1.2.3-beta', '1.2.3-rc.1', '1.0.0-alpha-1']) {
+      expect(() =>
+        ManifestV1.parse({ ...validManifest() as object, version: v }),
+      ).not.toThrow()
+    }
+  })
+
+  test('rejects versions that are not MAJOR.MINOR.PATCH', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    for (const v of ['1.2', '1', '1.2.3.4', 'v1.2.3', '1.2.3+build', '']) {
+      expect(() =>
+        ManifestV1.parse({ ...validManifest() as object, version: v }),
+      ).toThrow()
+    }
+  })
+
+  // ── tools[] bounds ─────────────────────────────────────────────────────
+
+  test('accepts an empty tools list and rejects more than 50 entries', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    expect(() =>
+      ManifestV1.parse({ ...validManifest() as object, tools: [] }),
+    ).not.toThrow()
+    const fifty = Array.from({ length: 50 }, (_, i) => ({
+      name: `t${i}`,
+      description: 'd',
+    }))
+    expect(() =>
+      ManifestV1.parse({ ...validManifest() as object, tools: fifty }),
+    ).not.toThrow()
+    expect(() =>
+      ManifestV1.parse({
+        ...validManifest() as object,
+        tools: [...fifty, { name: 't50', description: 'd' }],
+      }),
+    ).toThrow()
+  })
+
+  test('rejects a tool with empty name, oversized name, or oversized description', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    for (const bad of [
+      { name: '', description: 'd' },
+      { name: 'x'.repeat(81), description: 'd' },
+      { name: 'ok', description: 'd'.repeat(401) },
+    ]) {
+      expect(() =>
+        ManifestV1.parse({ ...validManifest() as object, tools: [bad] }),
+      ).toThrow()
+    }
+  })
+
+  // ── channels[] bounds and regex ────────────────────────────────────────
+
+  test('rejects DM (D...) and private-group (G...) IDs in channels[]', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    // Deliberate: a manifest is a public advertisement; DM and private-
+    // group participation is not something a peer should advertise here.
+    for (const bad of ['D01234ABCD', 'G01234ABCD', 'c01234abcd', 'CABCabc', '', 'C']) {
+      expect(() =>
+        ManifestV1.parse({ ...validManifest() as object, channels: [bad] }),
+      ).toThrow()
+    }
+  })
+
+  test('rejects more than 50 channels', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    const fifty = Array.from({ length: 50 }, (_, i) =>
+      `C${i.toString().padStart(5, '0')}AAAA`,
+    )
+    expect(() =>
+      ManifestV1.parse({ ...validManifest() as object, channels: fifty }),
+    ).not.toThrow()
+    expect(() =>
+      ManifestV1.parse({
+        ...validManifest() as object,
+        channels: [...fifty, 'C99999ZZZZ'],
+      }),
+    ).toThrow()
+  })
+
+  // ── contact email ──────────────────────────────────────────────────────
+
+  test('rejects a malformed email in contact', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    for (const bad of ['not-an-email', 'user@', '@example.com', 'user@example']) {
+      expect(() =>
+        ManifestV1.parse({ ...validManifest() as object, contact: bad }),
+      ).toThrow()
+    }
+  })
+
+  // ── publishedAt ────────────────────────────────────────────────────────
+
+  test('rejects publishedAt that is not an ISO-8601 datetime', async () => {
+    const { ManifestV1 } = await import('./manifest.ts')
+    for (const bad of ['2026-01-01', '01/01/2026', 'yesterday', '', '2026-01-01 00:00:00']) {
+      expect(() =>
+        ManifestV1.parse({ ...validManifest() as object, publishedAt: bad }),
+      ).toThrow()
+    }
+  })
+})
 
 describe('createSessionSupervisor.activate', () => {
   let rawRoot: string

--- a/server.test.ts
+++ b/server.test.ts
@@ -3310,28 +3310,28 @@ describe('ManifestV1 schema (31-A.1)', () => {
 
   test('rejects name shorter than 1 or longer than 80 chars', async () => {
     const { ManifestV1 } = await import('./manifest.ts')
-    expect(() => ManifestV1.parse({ ...validManifest() as object, name: '' })).toThrow()
+    expect(() => ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), name: '' })).toThrow()
     expect(() =>
-      ManifestV1.parse({ ...validManifest() as object, name: 'x'.repeat(81) }),
+      ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), name: 'x'.repeat(81) }),
     ).toThrow()
   })
 
   test('rejects vendor shorter than 1 or longer than 80 chars', async () => {
     const { ManifestV1 } = await import('./manifest.ts')
-    expect(() => ManifestV1.parse({ ...validManifest() as object, vendor: '' })).toThrow()
+    expect(() => ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), vendor: '' })).toThrow()
     expect(() =>
-      ManifestV1.parse({ ...validManifest() as object, vendor: 'v'.repeat(81) }),
+      ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), vendor: 'v'.repeat(81) }),
     ).toThrow()
   })
 
   test('rejects description longer than 1000 chars', async () => {
     const { ManifestV1 } = await import('./manifest.ts')
     expect(() =>
-      ManifestV1.parse({ ...validManifest() as object, description: 'd'.repeat(1001) }),
+      ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), description: 'd'.repeat(1001) }),
     ).toThrow()
     // Exactly 1000 is OK.
     expect(() =>
-      ManifestV1.parse({ ...validManifest() as object, description: 'd'.repeat(1000) }),
+      ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), description: 'd'.repeat(1000) }),
     ).not.toThrow()
   })
 
@@ -3341,7 +3341,7 @@ describe('ManifestV1 schema (31-A.1)', () => {
     const { ManifestV1 } = await import('./manifest.ts')
     for (const v of ['0.0.1', '10.20.30', '1.2.3-beta', '1.2.3-rc.1', '1.0.0-alpha-1']) {
       expect(() =>
-        ManifestV1.parse({ ...validManifest() as object, version: v }),
+        ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), version: v }),
       ).not.toThrow()
     }
   })
@@ -3350,7 +3350,7 @@ describe('ManifestV1 schema (31-A.1)', () => {
     const { ManifestV1 } = await import('./manifest.ts')
     for (const v of ['1.2', '1', '1.2.3.4', 'v1.2.3', '1.2.3+build', '']) {
       expect(() =>
-        ManifestV1.parse({ ...validManifest() as object, version: v }),
+        ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), version: v }),
       ).toThrow()
     }
   })
@@ -3360,18 +3360,18 @@ describe('ManifestV1 schema (31-A.1)', () => {
   test('accepts an empty tools list and rejects more than 50 entries', async () => {
     const { ManifestV1 } = await import('./manifest.ts')
     expect(() =>
-      ManifestV1.parse({ ...validManifest() as object, tools: [] }),
+      ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), tools: [] }),
     ).not.toThrow()
     const fifty = Array.from({ length: 50 }, (_, i) => ({
       name: `t${i}`,
       description: 'd',
     }))
     expect(() =>
-      ManifestV1.parse({ ...validManifest() as object, tools: fifty }),
+      ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), tools: fifty }),
     ).not.toThrow()
     expect(() =>
       ManifestV1.parse({
-        ...validManifest() as object,
+        ...(validManifest() as Record<string, unknown>),
         tools: [...fifty, { name: 't50', description: 'd' }],
       }),
     ).toThrow()
@@ -3385,7 +3385,7 @@ describe('ManifestV1 schema (31-A.1)', () => {
       { name: 'ok', description: 'd'.repeat(401) },
     ]) {
       expect(() =>
-        ManifestV1.parse({ ...validManifest() as object, tools: [bad] }),
+        ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), tools: [bad] }),
       ).toThrow()
     }
   })
@@ -3398,7 +3398,7 @@ describe('ManifestV1 schema (31-A.1)', () => {
     // group participation is not something a peer should advertise here.
     for (const bad of ['D01234ABCD', 'G01234ABCD', 'c01234abcd', 'CABCabc', '', 'C']) {
       expect(() =>
-        ManifestV1.parse({ ...validManifest() as object, channels: [bad] }),
+        ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), channels: [bad] }),
       ).toThrow()
     }
   })
@@ -3409,11 +3409,11 @@ describe('ManifestV1 schema (31-A.1)', () => {
       `C${i.toString().padStart(5, '0')}AAAA`,
     )
     expect(() =>
-      ManifestV1.parse({ ...validManifest() as object, channels: fifty }),
+      ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), channels: fifty }),
     ).not.toThrow()
     expect(() =>
       ManifestV1.parse({
-        ...validManifest() as object,
+        ...(validManifest() as Record<string, unknown>),
         channels: [...fifty, 'C99999ZZZZ'],
       }),
     ).toThrow()
@@ -3425,7 +3425,7 @@ describe('ManifestV1 schema (31-A.1)', () => {
     const { ManifestV1 } = await import('./manifest.ts')
     for (const bad of ['not-an-email', 'user@', '@example.com', 'user@example']) {
       expect(() =>
-        ManifestV1.parse({ ...validManifest() as object, contact: bad }),
+        ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), contact: bad }),
       ).toThrow()
     }
   })
@@ -3436,7 +3436,7 @@ describe('ManifestV1 schema (31-A.1)', () => {
     const { ManifestV1 } = await import('./manifest.ts')
     for (const bad of ['2026-01-01', '01/01/2026', 'yesterday', '', '2026-01-01 00:00:00']) {
       expect(() =>
-        ManifestV1.parse({ ...validManifest() as object, publishedAt: bad }),
+        ManifestV1.parse({ ...(validManifest() as Record<string, unknown>), publishedAt: bad }),
       ).toThrow()
     }
   })


### PR DESCRIPTION
## Summary

Epic 31-A.1 (bead `ccsc-s53.1`). Lands the on-wire schema for peer-bot manifests exactly as frozen in [`000-docs/bot-manifest-protocol.md`](./000-docs/bot-manifest-protocol.md) §17-55.

- New module **`manifest.ts`** — imports only zod, deliberately isolated from `policy.ts`.
- Symmetric constraint (policy.ts imports nothing from manifest.ts) is already enforced by the 31-A.4 invariant test landed in #111.
- Exports both the schema and `MANIFEST_V1_MAGIC_KEY` so the read tool (ccsc-s53.2) and any `pins.list` discriminator can match on the same literal without repeating the string.

## Schema coverage

Every field the doc specifies, with bounds:

| Field | Constraint |
|---|---|
| `__claude_bot_manifest_v1__` | literal `true` — version discriminator |
| `name`, `vendor` | 1..80 chars |
| `version` | SemVer `MAJOR.MINOR.PATCH[-prerelease]`; build metadata (`+…`) rejected |
| `description` | ≤ 1000 chars |
| `tools[]` | ≤ 50 entries, `{name ≤80, description ≤400}` |
| `channels[]` | optional, ≤ 50 public IDs (`C…`); DM (`D…`) and private-group (`G…`) IDs rejected |
| `contact` | optional email |
| `publishedAt` | ISO-8601 datetime |

## Test coverage

16 new tests pinning the schema against its frozen contract:

- Minimal happy path + optional fields round-trip
- Magic-header discriminator rejects truthy imposters (presence ≠ grant)
- Length bounds on every string field
- SemVer accepted vs rejected forms
- `tools[]` and `channels[]` array bounds
- Email and ISO-8601 rejection cases

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 523/523 pass (up from 507)
- [x] `bun test -t "ManifestV1 schema"` — 16/16 pass

Pre-existing flake noted in passing: `verifyJournal 1000-event chain` (ccsc-5pi.8) can exceed bun's 5000 ms default timeout under I/O contention. Filed as `ccsc-80e`. Not caused by this PR.

Closes bead `ccsc-s53.1`.

Jeremy made me do it
-claude