### PR TITLE
feat(manifest): 40 KB raw-body size cap before JSON.parse

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -95,6 +95,19 @@ export type ManifestV1 = z.infer<typeof ManifestV1>
  */
 export const MANIFEST_V1_MAGIC_KEY = '__claude_bot_manifest_v1__' as const
 
+/**
+ * Hard cap on a single manifest's raw body, in bytes after UTF-8 encode
+ * (Epic 31-A.3). The doc (§47) phrases the cap as "≤ 40 KB"; we treat
+ * "KB" as 1024 bytes, the convention used everywhere else in this
+ * codebase for memory-safety constants. Anything over is silently
+ * dropped before `JSON.parse` is called — the point of the cap is to
+ * bound the cost of the parse step, which can blow up memory
+ * super-linearly on deeply-nested or hostile payloads. A peer that can
+ * make us allocate 100 MB to parse one pinned message is a cheap DoS
+ * otherwise.
+ */
+export const MAX_MANIFEST_BYTES = 40 * 1024
+
 // ---------------------------------------------------------------------------
 // extractManifests — pure filter/parse/validate for a batch of message texts
 // ---------------------------------------------------------------------------
@@ -109,6 +122,15 @@ export const MANIFEST_V1_MAGIC_KEY = '__claude_bot_manifest_v1__' as const
  */
 function looksLikeManifest(text: string): boolean {
   return text.includes(MANIFEST_V1_MAGIC_KEY)
+}
+
+/** UTF-8 byte length of a string. Uses TextEncoder so the count matches
+ *  what Slack's servers and the doc mean by "40 KB after UTF-8 encode"
+ *  (§47) — `string.length` would count UTF-16 code units and under-
+ *  report for multi-byte code points. */
+const utf8Encoder = new TextEncoder()
+function utf8ByteLength(s: string): number {
+  return utf8Encoder.encode(s).length
 }
 
 /**
@@ -145,6 +167,21 @@ export function extractManifests(
   return texts.flatMap((text) => {
     if (typeof text !== 'string' || text.length === 0) return []
     if (!looksLikeManifest(text)) return []
+    // 40 KB raw-body size cap (ccsc-s53.3). Checked *after* the
+    // pre-filter (so we only pay the byte-count walk on candidate
+    // payloads) but *before* `JSON.parse` (so the parser can't be
+    // weaponised to allocate gigabytes on a hostile pinned message).
+    // Oversized drops log a debug line because they are operator-
+    // actionable — a peer hitting the cap is either buggy or adversarial.
+    // Malformed-JSON and Zod-failure drops stay silent (see §81): common
+    // and not a signal.
+    const bytes = utf8ByteLength(text)
+    if (bytes > MAX_MANIFEST_BYTES) {
+      console.debug(
+        `[manifest] silent drop: oversized body ${bytes}B > ${MAX_MANIFEST_BYTES}B cap`,
+      )
+      return []
+    }
     try {
       const parsed: unknown = JSON.parse(text)
       const result = ManifestV1.safeParse(parsed)

--- a/server.test.ts
+++ b/server.test.ts
@@ -3559,6 +3559,94 @@ describe('extractManifests (31-A.2)', () => {
     expect(out[0]?.name).toBe('Dup')
     expect(out[1]?.name).toBe('Dup')
   })
+
+  // ── 40 KB size cap (ccsc-s53.3) ────────────────────────────────────────
+  //
+  // Cap is enforced on the raw body in bytes after UTF-8 encode, BEFORE
+  // JSON.parse. Trailing-whitespace padding keeps the body valid JSON while
+  // letting us hit exact byte counts — a body that differs from a
+  // known-good manifest only by whitespace padding isolates the size cap
+  // as the sole cause of any drop.
+
+  test('accepts a body at exactly the 40 KB cap (40960 bytes)', async () => {
+    const { extractManifests, MAX_MANIFEST_BYTES } = await import('./manifest.ts')
+    expect(MAX_MANIFEST_BYTES).toBe(40 * 1024)
+    const body = validManifestJson({ name: 'AtCap' })
+    const baseBytes = new TextEncoder().encode(body).length
+    const padded = body + ' '.repeat(MAX_MANIFEST_BYTES - baseBytes)
+    expect(new TextEncoder().encode(padded).length).toBe(MAX_MANIFEST_BYTES)
+    const out = extractManifests([padded])
+    expect(out).toHaveLength(1)
+    expect(out[0]?.name).toBe('AtCap')
+  })
+
+  test('silently drops a body one byte over the cap (40961 bytes)', async () => {
+    const { extractManifests, MAX_MANIFEST_BYTES, ManifestV1 } = await import('./manifest.ts')
+    // Start from a payload that WOULD be a valid manifest if parsed.
+    // The only difference vs. the at-cap test is one extra whitespace
+    // byte, so any drop here can only be the size cap.
+    const body = validManifestJson({ name: 'OverCap' })
+    const baseBytes = new TextEncoder().encode(body).length
+    const padded = body + ' '.repeat(MAX_MANIFEST_BYTES + 1 - baseBytes)
+    expect(new TextEncoder().encode(padded).length).toBe(MAX_MANIFEST_BYTES + 1)
+    // Sanity: if we somehow got past the cap, JSON.parse + Zod would
+    // produce a valid manifest. Proves the whitespace padding hasn't
+    // broken the payload shape.
+    expect(ManifestV1.safeParse(JSON.parse(padded)).success).toBe(true)
+    // Silence console.debug during this assertion so the DoS-signal log
+    // line doesn't pollute test output. Restore it after.
+    const origDebug = console.debug
+    const debugCalls: unknown[][] = []
+    console.debug = (...args: unknown[]) => {
+      debugCalls.push(args)
+    }
+    try {
+      expect(extractManifests([padded])).toEqual([])
+    } finally {
+      console.debug = origDebug
+    }
+    // The log must reference the oversize condition so an operator
+    // grepping logs for DoS signals can find it.
+    expect(debugCalls).toHaveLength(1)
+    expect(String(debugCalls[0]?.[0])).toMatch(/oversized/i)
+    expect(String(debugCalls[0]?.[0])).toMatch(String(MAX_MANIFEST_BYTES + 1))
+  })
+
+  test('size cap counts UTF-8 bytes, not UTF-16 code units (multi-byte safe)', async () => {
+    const { extractManifests, MAX_MANIFEST_BYTES } = await import('./manifest.ts')
+    // A 4-byte UTF-8 code point (emoji) counts as ONE string code-unit-
+    // pair but FOUR bytes. If the cap mistakenly used string.length it
+    // would accept up to ~4x too much data under hostile payloads.
+    // This test pads with 🔥 (4 bytes UTF-8 each, 2 UTF-16 units) to
+    // push byte count over cap while keeping .length well under.
+    const body = validManifestJson({ name: 'Emoji' })
+    const baseBytes = new TextEncoder().encode(body).length
+    const emoji = '🔥'
+    const emojiBytes = new TextEncoder().encode(emoji).length
+    expect(emojiBytes).toBe(4)
+    // Pad inside description (<= 1000 chars bound, so we can't reach
+    // cap through description alone). Instead, pad outside the JSON
+    // with emoji-as-whitespace — not valid JSON whitespace, so strip
+    // back to a direct byte-count test of the cap function.
+    const padBytesNeeded = MAX_MANIFEST_BYTES + 1 - baseBytes
+    const emojisNeeded = Math.ceil(padBytesNeeded / emojiBytes)
+    // Append as trailing whitespace + emoji; the emoji will make
+    // JSON.parse fail on the trailing junk. That's fine — even before
+    // JSON.parse is attempted the size cap must reject. Proves the cap
+    // is measured in bytes, not characters.
+    const tooBig = body + ' ' + emoji.repeat(emojisNeeded)
+    const totalBytes = new TextEncoder().encode(tooBig).length
+    expect(totalBytes).toBeGreaterThan(MAX_MANIFEST_BYTES)
+    // UTF-16 length is much smaller: baseBytes + 1 + 2*emojisNeeded.
+    expect(tooBig.length).toBeLessThan(totalBytes)
+    const origDebug = console.debug
+    console.debug = () => {}
+    try {
+      expect(extractManifests([tooBig])).toEqual([])
+    } finally {
+      console.debug = origDebug
+    }
+  })
 })
 
 describe('createSessionSupervisor.activate', () => {

--- a/server.test.ts
+++ b/server.test.ts
@@ -3640,12 +3640,20 @@ describe('extractManifests (31-A.2)', () => {
     // UTF-16 length is much smaller: baseBytes + 1 + 2*emojisNeeded.
     expect(tooBig.length).toBeLessThan(totalBytes)
     const origDebug = console.debug
-    console.debug = () => {}
+    const debugCalls: unknown[][] = []
+    console.debug = (...args: unknown[]) => {
+      debugCalls.push(args)
+    }
     try {
       expect(extractManifests([tooBig])).toEqual([])
     } finally {
       console.debug = origDebug
     }
+    // Same consistency check as the single-byte oversize test: the log
+    // must name the oversize condition and cite the actual byte count.
+    expect(debugCalls).toHaveLength(1)
+    expect(String(debugCalls[0]?.[0])).toMatch(/oversized/i)
+    expect(String(debugCalls[0]?.[0])).toMatch(String(totalBytes))
   })
 })
 


### PR DESCRIPTION
## Summary

Epic 31-A.3 (bead \`ccsc-s53.3\`). Bounds the cost of \`JSON.parse\` on a single peer-posted manifest so a hostile pinned message cannot force gigabyte-scale allocation. Design: [\`000-docs/bot-manifest-protocol.md\`](./000-docs/bot-manifest-protocol.md) §47-49.

- **\`MAX_MANIFEST_BYTES = 40 * 1024\`** — exported constant so tests and operators reference the same number.
- **UTF-8 byte count via \`TextEncoder\`** — not \`string.length\`, which would count UTF-16 code units and under-report for multi-byte code points. A 4-byte emoji is 4 bytes, not 2.
- **Layered after pre-filter, before \`JSON.parse\`** — only candidates pay the byte-count walk, and the parser never sees oversized input.
- **Oversize drops log \`console.debug\`** — malformed-JSON and Zod-failure drops stay silent per §81. Asymmetry is deliberate: oversize is operator-actionable (possible DoS); the others are noise.

## Test coverage (3 new tests, 536/536 total pass)

| Test | What it proves |
|---|---|
| At cap (40960 bytes, whitespace-padded) | Boundary is inclusive; whitespace-padded JSON still parses + validates |
| One byte over (40961) | Silent drop; sanity asserts the payload WOULD be a valid manifest if it got past the cap, isolating the cap as the cause; debug line verified to name "oversized" + actual byte count |
| Multi-byte (🔥 padding) | Cap measured in bytes, not characters — totalBytes > cap while totalString.length < totalBytes; still rejects |

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 536/536 pass
- [x] \`bun test -t "extractManifests"\` — 13/13 pass

Closes bead \`ccsc-s53.3\`.

Jeremy made me do it
-claude