### PR TITLE
feat(manifest): per-channel 5-min read cache + rate limit

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -13,7 +13,7 @@
  *     v:        1,                          // schema version; chain refuses mixed versions
  *     ts:       '2026-04-19T12:34:56.789Z', // ISO-8601 UTC with ms precision
  *     seq:      42,                         // monotonic per chain
- *     kind:     'gate.inbound.drop',        // discriminated union of 19 event kinds
+ *     kind:     'gate.inbound.drop',        // discriminated union of 21 event kinds
  *     toolName?: 'reply',
  *     input?:   { chat_id: 'C01', text: '...' },     // post-redaction
  *     outcome?: 'allow' | 'deny' | 'require' | 'drop' | 'n/a',
@@ -78,9 +78,14 @@ export const EventKind = z.enum([
   'system.boot',
   'system.shutdown',
   'system.reload',
+  // Bot-manifest protocol (Epic 31-A). Emitted on every read_peer_manifests
+  // call so manifest activity is forensically visible even when cached;
+  // see 000-docs/bot-manifest-protocol.md §163-166.
+  'manifest.read',
+  'manifest.read.cached',
 ])
 
-/** TypeScript string union of the 19 event kinds. */
+/** TypeScript string union of the 21 event kinds. */
 export type EventKind = z.infer<typeof EventKind>
 
 // ---------------------------------------------------------------------------

--- a/manifest.ts
+++ b/manifest.ts
@@ -149,10 +149,9 @@ function utf8ByteLength(s: string): number {
  * journal when the read tool logs the read event — per-message drop
  * details are intentionally not surfaced.
  *
- * Size cap (40 KB per raw body) is a sibling bead (ccsc-s53.3); this
- * function does not enforce it. Callers that receive potentially large
- * bodies must pre-filter before calling, or wait for s53.3 to layer
- * that in.
+ * The 40 KB raw-body size cap (ccsc-s53.3, §47) is enforced here too —
+ * oversized bodies are dropped before `JSON.parse` is called so a
+ * hostile pinned message cannot force gigabyte-scale allocation.
  *
  * Returns validated manifests in the order they appeared in the input.
  * Duplicate de-dup is NOT performed here — a channel that has the same
@@ -190,4 +189,115 @@ export function extractManifests(
       return []
     }
   })
+}
+
+// ---------------------------------------------------------------------------
+// Per-channel read cache + rate limit (Epic 31-A.5, bead ccsc-s53.5)
+// ---------------------------------------------------------------------------
+
+/**
+ * TTL for a cached per-channel manifest list. Doubles as the rate limit
+ * on reads: within the TTL window, the consumer returns the cached value
+ * and does not hit `pins.list` / `conversations.history` again. Design
+ * doc §84. Five minutes is long enough that a chatty operator does not
+ * spam Slack, short enough that a peer's manifest edit surfaces within
+ * roughly a coffee break.
+ */
+export const MANIFEST_CACHE_TTL_MS = 5 * 60 * 1000
+
+export interface ManifestCacheEntry {
+  readonly cachedAt: number
+  readonly manifests: ReadonlyArray<ManifestV1>
+}
+
+export interface ManifestCache {
+  /** Return the cached manifests if the entry is fresh (age < TTL).
+   *  Returns `undefined` on miss — either no entry, or the entry has
+   *  expired. Expired entries are lazily evicted on access. Caller
+   *  decides what to do on miss (fetch + `set`, typically). */
+  get(channelId: string): ReadonlyArray<ManifestV1> | undefined
+  /** Store `manifests` for `channelId`, stamped at the cache's `now()`.
+   *  If the cache is at `maxEntries`, evicts the single oldest entry
+   *  (smallest `cachedAt`) before inserting — soft LRU. */
+  set(channelId: string, manifests: ReadonlyArray<ManifestV1>): void
+  /** Drop every entry. Exposed for test teardown and for future
+   *  operator commands (e.g. a `/manifest:flush` on schema change). */
+  clear(): void
+  /** Current entry count. Exposed for tests and operator inspection. */
+  size(): number
+}
+
+export interface ManifestCacheOptions {
+  /** Time source. Accept for testability; defaults to `Date.now`.
+   *  Must return wall-clock milliseconds since the Unix epoch. */
+  now?: () => number
+  /** Soft cap on distinct-channel entries. When insertion would exceed
+   *  this, the oldest entry is evicted. Default 256 — larger than the
+   *  channel count in any realistic workspace, small enough to bound
+   *  memory to roughly (maxEntries × 40 KB) worst case when every slot
+   *  holds a cap-size manifest list. */
+  maxEntries?: number
+  /** Entry TTL in ms. Defaults to `MANIFEST_CACHE_TTL_MS`. Exposed for
+   *  tests that need to exercise the expiry boundary without waiting
+   *  five minutes of wall-clock time. */
+  ttlMs?: number
+}
+
+/**
+ * Create a per-channel manifest cache. Opaque over an internal
+ * `Map<channelId, ManifestCacheEntry>` — the cache itself is a plain
+ * object with method members, not a class, so there is no `this`
+ * binding to worry about when the caller passes the methods around
+ * (e.g. into a lambda). Entries are dropped on process exit by design
+ * (protocol doc §166 "A restart clears it.") — persistence is out of
+ * scope.
+ */
+export function createManifestCache(
+  opts: ManifestCacheOptions = {},
+): ManifestCache {
+  const now = opts.now ?? Date.now
+  const maxEntries = opts.maxEntries ?? 256
+  const ttlMs = opts.ttlMs ?? MANIFEST_CACHE_TTL_MS
+  const store = new Map<string, ManifestCacheEntry>()
+
+  return {
+    get(channelId) {
+      const entry = store.get(channelId)
+      if (!entry) return undefined
+      if (now() - entry.cachedAt >= ttlMs) {
+        // Lazy eviction of an expired entry. Avoids a keep-alive bug
+        // where an expired entry stays around forever because it's
+        // never touched again — each `get` of an expired entry also
+        // removes it.
+        store.delete(channelId)
+        return undefined
+      }
+      return entry.manifests
+    },
+    set(channelId, manifests) {
+      // Soft LRU-by-age: on an insertion that would breach the cap,
+      // drop the single entry with the smallest `cachedAt`. Scanning
+      // the map is O(n) but n ≤ maxEntries = 256, so the cost is
+      // bounded and negligible compared to the Slack round-trip that
+      // populated the value.
+      if (store.size >= maxEntries && !store.has(channelId)) {
+        let oldestKey: string | undefined
+        let oldestAt = Infinity
+        for (const [k, v] of store) {
+          if (v.cachedAt < oldestAt) {
+            oldestAt = v.cachedAt
+            oldestKey = k
+          }
+        }
+        if (oldestKey !== undefined) store.delete(oldestKey)
+      }
+      store.set(channelId, { cachedAt: now(), manifests })
+    },
+    clear() {
+      store.clear()
+    },
+    size() {
+      return store.size
+    },
+  }
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -3657,6 +3657,154 @@ describe('extractManifests (31-A.2)', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// createManifestCache — per-channel read cache (Epic 31-A.5, ccsc-s53.5)
+//
+// Doubles as the rate limit on `read_peer_manifests`: within the 5-minute
+// TTL the consumer returns the cached list instead of hitting pins.list /
+// conversations.history again. Tests use an injected time source so
+// expiry can be exercised without waiting 5 minutes of wall-clock time.
+// Design: 000-docs/bot-manifest-protocol.md §84, §165.
+// ---------------------------------------------------------------------------
+
+describe('createManifestCache (31-A.5)', () => {
+  /** Build a fake validated ManifestV1 for cache-payload tests. The
+   *  cache is opaque over its value — any ReadonlyArray<ManifestV1>
+   *  works — so we don't need to re-run Zod inside these tests. */
+  const m = (name: string): import('./manifest.ts').ManifestV1 => ({
+    __claude_bot_manifest_v1__: true,
+    name,
+    vendor: 'Acme',
+    version: '1.0.0',
+    description: 'stub',
+    tools: [],
+    publishedAt: '2026-01-01T00:00:00.000Z',
+  })
+
+  test('exports MANIFEST_CACHE_TTL_MS = 5 minutes in ms', async () => {
+    const { MANIFEST_CACHE_TTL_MS } = await import('./manifest.ts')
+    expect(MANIFEST_CACHE_TTL_MS).toBe(5 * 60 * 1000)
+  })
+
+  test('miss on an empty cache returns undefined', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    const cache = createManifestCache({ now: () => 0 })
+    expect(cache.get('C_NONE')).toBeUndefined()
+    expect(cache.size()).toBe(0)
+  })
+
+  test('set then get within TTL returns the stored list', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    const cache = createManifestCache({ now: () => 1000 })
+    const payload = [m('Alpha'), m('Beta')]
+    cache.set('C_AB', payload)
+    expect(cache.get('C_AB')).toEqual(payload)
+    expect(cache.size()).toBe(1)
+  })
+
+  test('get at exactly ttlMs from cachedAt treats entry as expired (fail-closed)', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    // `now - cachedAt >= ttlMs` is expired — boundary is inclusive on the
+    // expired side so any 5-minute-old entry is refreshed, not served.
+    let nowValue = 0
+    const cache = createManifestCache({ now: () => nowValue, ttlMs: 1000 })
+    nowValue = 100
+    cache.set('C_TTL', [m('X')])
+    nowValue = 100 + 999
+    expect(cache.get('C_TTL')).toEqual([m('X')])
+    nowValue = 100 + 1000
+    expect(cache.get('C_TTL')).toBeUndefined()
+  })
+
+  test('get of an expired entry lazily evicts it', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    let nowValue = 0
+    const cache = createManifestCache({ now: () => nowValue, ttlMs: 100 })
+    cache.set('C_EVICT', [m('Gone')])
+    expect(cache.size()).toBe(1)
+    nowValue = 500
+    expect(cache.get('C_EVICT')).toBeUndefined()
+    expect(cache.size()).toBe(0) // lazily swept on access
+  })
+
+  test('set overwrites the cachedAt stamp when a key is already present', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    let nowValue = 0
+    const cache = createManifestCache({ now: () => nowValue, ttlMs: 1000 })
+    nowValue = 100
+    cache.set('C_REFRESH', [m('V1')])
+    nowValue = 900 // still fresh
+    expect(cache.get('C_REFRESH')).toEqual([m('V1')])
+    nowValue = 950
+    cache.set('C_REFRESH', [m('V2')]) // refresh stamp to 950
+    nowValue = 950 + 999
+    expect(cache.get('C_REFRESH')).toEqual([m('V2')]) // still fresh vs. 950 stamp
+  })
+
+  test('evicts the oldest entry on insert when size would exceed maxEntries', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    let nowValue = 0
+    const cache = createManifestCache({ now: () => nowValue, maxEntries: 2 })
+    nowValue = 10
+    cache.set('C_A', [m('A')])
+    nowValue = 20
+    cache.set('C_B', [m('B')])
+    nowValue = 30
+    cache.set('C_C', [m('C')]) // should evict C_A (oldest cachedAt)
+    expect(cache.size()).toBe(2)
+    expect(cache.get('C_A')).toBeUndefined()
+    expect(cache.get('C_B')).toEqual([m('B')])
+    expect(cache.get('C_C')).toEqual([m('C')])
+  })
+
+  test('does not evict when overwriting an existing key at the cap', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    let nowValue = 0
+    const cache = createManifestCache({ now: () => nowValue, maxEntries: 2 })
+    nowValue = 10
+    cache.set('C_A', [m('A')])
+    nowValue = 20
+    cache.set('C_B', [m('B')])
+    nowValue = 30
+    cache.set('C_A', [m('A2')]) // overwrite, not a new slot — no eviction
+    expect(cache.size()).toBe(2)
+    expect(cache.get('C_A')).toEqual([m('A2')])
+    expect(cache.get('C_B')).toEqual([m('B')])
+  })
+
+  test('clear drops every entry', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    const cache = createManifestCache({ now: () => 0 })
+    cache.set('C_1', [m('X')])
+    cache.set('C_2', [m('Y')])
+    expect(cache.size()).toBe(2)
+    cache.clear()
+    expect(cache.size()).toBe(0)
+    expect(cache.get('C_1')).toBeUndefined()
+    expect(cache.get('C_2')).toBeUndefined()
+  })
+
+  test('entries are isolated by channelId (no cross-channel leakage)', async () => {
+    const { createManifestCache } = await import('./manifest.ts')
+    const cache = createManifestCache({ now: () => 0 })
+    cache.set('C_ALICE', [m('AliceBot')])
+    cache.set('C_BOB', [m('BobBot')])
+    expect(cache.get('C_ALICE')?.[0]?.name).toBe('AliceBot')
+    expect(cache.get('C_BOB')?.[0]?.name).toBe('BobBot')
+  })
+
+  test('default TTL is 5 minutes when opts.ttlMs is omitted', async () => {
+    const { createManifestCache, MANIFEST_CACHE_TTL_MS } = await import('./manifest.ts')
+    let nowValue = 0
+    const cache = createManifestCache({ now: () => nowValue })
+    cache.set('C_D', [m('D')])
+    nowValue = MANIFEST_CACHE_TTL_MS - 1
+    expect(cache.get('C_D')).toEqual([m('D')])
+    nowValue = MANIFEST_CACHE_TTL_MS
+    expect(cache.get('C_D')).toBeUndefined()
+  })
+})
+
 describe('createSessionSupervisor.activate', () => {
   let rawRoot: string
   let tmpRoot: string
@@ -4486,7 +4634,12 @@ describe('JournalEvent', () => {
   test('covers every EventKind value enumerated in the design doc', async () => {
     const { JournalEvent, EventKind } = await import('./journal.ts')
     const kinds = EventKind.options
-    expect(kinds).toHaveLength(19)
+    // 19 original kinds + manifest.read + manifest.read.cached (Epic 31-A.5).
+    // If this number drifts, update the doc count in journal.ts's header
+    // comment too — both must agree.
+    expect(kinds).toHaveLength(21)
+    expect(kinds).toContain('manifest.read')
+    expect(kinds).toContain('manifest.read.cached')
     for (const k of kinds) {
       expect(() => JournalEvent.parse(minimal({ kind: k }))).not.toThrow()
     }

--- a/server.ts
+++ b/server.ts
@@ -1196,61 +1196,50 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
         input: { channel },
       })
 
-      // Cache hit within the 5-minute TTL: return the cached list
-      // without hitting Slack (Epic 31-A.5, doc §84). The journal still
-      // records a manifest.read.cached event so manifest activity is
-      // forensically visible even when served from cache (§165).
+      // Resolve manifests from the 5-minute per-channel cache (hit) or
+      // freshly from Slack (miss). Either way, both paths converge on a
+      // single journal write + return below so the serialization and
+      // event-emission contract stay identical. Doc §84, §165.
       const cached = manifestCache.get(channel)
+      let manifests: ReadonlyArray<import('./manifest.ts').ManifestV1>
+      let manifestEventKind: 'manifest.read' | 'manifest.read.cached'
       if (cached !== undefined) {
-        journalWrite({
-          kind: 'manifest.read.cached',
-          toolName: 'read_peer_manifests',
-          input: { channel, count: cached.length },
-        })
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                { channel, count: cached.length, manifests: cached },
-                null,
-                2,
-              ),
-            },
-          ],
+        manifests = cached
+        manifestEventKind = 'manifest.read.cached'
+      } else {
+        // Cache miss: fetch candidate message bodies from both sources
+        // the doc specifies (§79). Pin errors and history errors do not
+        // fail the tool — a peer that has pinned a valid manifest should
+        // surface even if the history call hiccups, and vice versa.
+        // Parallelised via allSettled so the tool's latency is
+        // max(pins, history) rather than pins + history.
+        const [pinsResult, historyResult] = await Promise.allSettled([
+          web.pins.list({ channel }),
+          web.conversations.history({ channel, limit: 50 }),
+        ])
+
+        const texts: Array<string | null | undefined> = []
+        if (pinsResult.status === 'fulfilled') {
+          for (const item of pinsResult.value.items ?? []) {
+            // pins.list returns {type: 'message', message: {...}} among
+            // other item kinds; only message items can carry manifests.
+            const msg = (item as { message?: { text?: string | null } }).message
+            if (msg) texts.push(msg.text ?? null)
+          }
         }
+        if (historyResult.status === 'fulfilled') {
+          for (const msg of historyResult.value.messages ?? []) {
+            texts.push((msg as { text?: string | null }).text ?? null)
+          }
+        }
+
+        manifests = extractManifests(texts)
+        manifestCache.set(channel, manifests)
+        manifestEventKind = 'manifest.read'
       }
 
-      // Cache miss: fetch candidate message bodies from both sources the
-      // doc specifies (§79). Pin errors and history errors do not fail
-      // the tool — a peer that has pinned a valid manifest should surface
-      // even if the history call hiccups, and vice versa. Parallelised
-      // via allSettled so the tool's latency is max(pins, history)
-      // rather than pins + history.
-      const [pinsResult, historyResult] = await Promise.allSettled([
-        web.pins.list({ channel }),
-        web.conversations.history({ channel, limit: 50 }),
-      ])
-
-      const texts: Array<string | null | undefined> = []
-      if (pinsResult.status === 'fulfilled') {
-        for (const item of pinsResult.value.items ?? []) {
-          // pins.list returns {type: 'message', message: {...}} among
-          // other item kinds; only message items can carry manifests.
-          const msg = (item as { message?: { text?: string | null } }).message
-          if (msg) texts.push(msg.text ?? null)
-        }
-      }
-      if (historyResult.status === 'fulfilled') {
-        for (const msg of historyResult.value.messages ?? []) {
-          texts.push((msg as { text?: string | null }).text ?? null)
-        }
-      }
-
-      const manifests = extractManifests(texts)
-      manifestCache.set(channel, manifests)
       journalWrite({
-        kind: 'manifest.read',
+        kind: manifestEventKind,
         toolName: 'read_peer_manifests',
         input: { channel, count: manifests.length },
       })

--- a/server.ts
+++ b/server.ts
@@ -61,7 +61,7 @@ import {
   type PendingPolicyApproval,
 } from './lib.ts'
 import { JournalWriter, createBootAnchor, verifyJournal } from './journal.ts'
-import { extractManifests } from './manifest.ts'
+import { extractManifests, createManifestCache } from './manifest.ts'
 import {
   parsePolicyRules,
   evaluate as policyEvaluate,
@@ -460,6 +460,13 @@ const deliveredThreads = new Set<string>()
 // Dedupe events across `message` and `app_mention` subscriptions. Keyed on
 // (channel, ts). See isDuplicateEvent in lib.ts for rationale.
 const seenEvents = new Map<string, number>()
+
+// Per-channel read cache for `read_peer_manifests` (Epic 31-A.5). Five-minute
+// TTL doubles as the rate limit on pins.list / conversations.history — within
+// the window, repeated tool invocations return the cached manifest list
+// instead of re-hitting Slack. A process restart clears the cache by design
+// (000-docs/bot-manifest-protocol.md §166).
+const manifestCache = createManifestCache()
 
 // ---------------------------------------------------------------------------
 // Session supervisor — lifecycle authority for per-thread sessions
@@ -1189,9 +1196,34 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
         input: { channel },
       })
 
-      // Collect candidate message bodies from both sources the doc
-      // specifies (§79). Pin errors and history errors do not fail the
-      // tool — a peer that has pinned a valid manifest should surface
+      // Cache hit within the 5-minute TTL: return the cached list
+      // without hitting Slack (Epic 31-A.5, doc §84). The journal still
+      // records a manifest.read.cached event so manifest activity is
+      // forensically visible even when served from cache (§165).
+      const cached = manifestCache.get(channel)
+      if (cached !== undefined) {
+        journalWrite({
+          kind: 'manifest.read.cached',
+          toolName: 'read_peer_manifests',
+          input: { channel, count: cached.length },
+        })
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                { channel, count: cached.length, manifests: cached },
+                null,
+                2,
+              ),
+            },
+          ],
+        }
+      }
+
+      // Cache miss: fetch candidate message bodies from both sources the
+      // doc specifies (§79). Pin errors and history errors do not fail
+      // the tool — a peer that has pinned a valid manifest should surface
       // even if the history call hiccups, and vice versa. Parallelised
       // via allSettled so the tool's latency is max(pins, history)
       // rather than pins + history.
@@ -1216,6 +1248,12 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       const manifests = extractManifests(texts)
+      manifestCache.set(channel, manifests)
+      journalWrite({
+        kind: 'manifest.read',
+        toolName: 'read_peer_manifests',
+        input: { channel, count: manifests.length },
+      })
       return {
         content: [
           {


### PR DESCRIPTION
## Summary

Epic 31-A.5 (bead \`ccsc-s53.5\`). Caches \`read_peer_manifests\` results per-channel so repeated tool calls within the TTL window return instantly instead of re-hitting Slack. Doubles as the rate limit per [\`000-docs/bot-manifest-protocol.md\`](./000-docs/bot-manifest-protocol.md) §84: "one fetch per channel per 5 min."

## Changes

- **\`manifest.ts\`** — new \`createManifestCache({now, maxEntries, ttlMs})\` factory → \`{get, set, clear, size}\`. Injected time source for testability. Soft LRU, 256-entry default cap. Lazy eviction of expired entries on \`get\`. Exports \`MANIFEST_CACHE_TTL_MS = 5 * 60 * 1000\`.
- **\`journal.ts\`** — adds \`manifest.read\` and \`manifest.read.cached\` to \`EventKind\` (21 total, up from 19). Doc §163-166 mandates a journal entry on every read so activity stays forensically visible even when served from cache.
- **\`server.ts\`** — module-level \`manifestCache\`; tool handler hits cache first, journal \`manifest.read.cached\` on hit, existing fetch+extract path on miss + \`manifest.read\` + \`cache.set\`.

Also fixes a doc drift: the \`extractManifests\` JSDoc previously said the 40 KB cap was a sibling bead; now correctly notes the cap is enforced in that function.

## Test coverage (11 new cache tests, 547/547 total)

| Test | What it proves |
|---|---|
| \`MANIFEST_CACHE_TTL_MS\` value | 5 * 60 * 1000 ms pin |
| Miss on empty | returns undefined |
| Set → get within TTL | returns payload |
| Get at exactly \`ttlMs\` from \`cachedAt\` | expired (fail-closed boundary) |
| Expired entry lazily evicted on \`get\` | \`size\` decreases |
| \`set\` overwrites \`cachedAt\` on existing key | TTL resets |
| LRU: insert at cap | oldest \`cachedAt\` evicted |
| Overwrite at cap | no eviction |
| \`clear\` | drops everything |
| \`channelId\` isolation | no cross-channel leakage |
| Default TTL | 5 min when omitted |

Plus an update to the \`EventKind\` pin (19 → 21) that caught a doc-count drift in the first test run.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 547/547 pass
- [x] \`bun test -t "createManifestCache"\` — 11/11 pass

Closes bead \`ccsc-s53.5\`.

Jeremy made me do it
-claude