### PR TITLE
feat(manifest): publish_manifest MCP tool with replace semantics

### DIFF
--- a/journal.ts
+++ b/journal.ts
@@ -13,7 +13,7 @@
  *     v:        1,                          // schema version; chain refuses mixed versions
  *     ts:       '2026-04-19T12:34:56.789Z', // ISO-8601 UTC with ms precision
  *     seq:      42,                         // monotonic per chain
- *     kind:     'gate.inbound.drop',        // discriminated union of 21 event kinds
+ *     kind:     'gate.inbound.drop',        // discriminated union of 22 event kinds
  *     toolName?: 'reply',
  *     input?:   { chat_id: 'C01', text: '...' },     // post-redaction
  *     outcome?: 'allow' | 'deny' | 'require' | 'drop' | 'n/a',
@@ -83,9 +83,13 @@ export const EventKind = z.enum([
   // see 000-docs/bot-manifest-protocol.md §163-166.
   'manifest.read',
   'manifest.read.cached',
+  // Publisher side (Epic 31-B, ccsc-0qk.1/0qk.3). Emitted after a successful
+  // publish_manifest call, carrying the replaced-count so operators can see
+  // how many prior manifests were unpinned during the replace sweep.
+  'manifest.publish',
 ])
 
-/** TypeScript string union of the 21 event kinds. */
+/** TypeScript string union of the 22 event kinds. */
 export type EventKind = z.infer<typeof EventKind>
 
 // ---------------------------------------------------------------------------

--- a/server.test.ts
+++ b/server.test.ts
@@ -4740,12 +4740,14 @@ describe('JournalEvent', () => {
   test('covers every EventKind value enumerated in the design doc', async () => {
     const { JournalEvent, EventKind } = await import('./journal.ts')
     const kinds = EventKind.options
-    // 19 original kinds + manifest.read + manifest.read.cached (Epic 31-A.5).
-    // If this number drifts, update the doc count in journal.ts's header
-    // comment too — both must agree.
-    expect(kinds).toHaveLength(21)
+    // 19 original kinds + manifest.read + manifest.read.cached (Epic
+    // 31-A.5) + manifest.publish (Epic 31-B.1/.3). If this number
+    // drifts, update the doc count in journal.ts's header comment too —
+    // both must agree.
+    expect(kinds).toHaveLength(22)
     expect(kinds).toContain('manifest.read')
     expect(kinds).toContain('manifest.read.cached')
+    expect(kinds).toContain('manifest.publish')
     for (const k of kinds) {
       expect(() => JournalEvent.parse(minimal({ kind: k }))).not.toThrow()
     }
@@ -7746,6 +7748,125 @@ describe('MCP tool input schemas (S5)', () => {
     test('rejects any extra field (.strict() on empty object)', () => {
       const result = ListSessionsInput.safeParse({ foo: 'bar' })
       expect(result.success).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // publish_manifest (Epic 31-B.1/.3, ccsc-0qk.1 + ccsc-0qk.3)
+  //
+  // Duplicated from server.ts. Unlike the other schemas, this one refers
+  // to the real ManifestV1 (manifest.ts) so the test can exercise the
+  // full nested-validation path. Construction lives inside beforeAll so
+  // the dynamic import only runs once per process.
+  // -------------------------------------------------------------------------
+  describe('PublishManifestInput', () => {
+    let PublishManifestInput: z.ZodTypeAny
+
+    beforeAll(async () => {
+      const { ManifestV1 } = await import('./manifest.ts')
+      PublishManifestInput = z
+        .object({
+          channel: z.string().regex(/^C[A-Z0-9]+$/),
+          caller_user_id: z.string().regex(/^U[A-Z0-9]+$/),
+          manifest: ManifestV1,
+        })
+        .strict()
+    })
+
+    const validManifest = () => ({
+      __claude_bot_manifest_v1__: true,
+      name: 'Example Bot',
+      vendor: 'Acme Corp',
+      version: '1.0.0',
+      description: 'stub',
+      tools: [],
+      publishedAt: '2026-01-01T00:00:00.000Z',
+    })
+
+    test('accepts a minimal valid publish request', () => {
+      const result = PublishManifestInput.safeParse({
+        channel: 'C01234ABCD',
+        caller_user_id: 'U0ABCDEF',
+        manifest: validManifest(),
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test('rejects DM ids (D...) and private-group ids (G...) in channel', () => {
+      for (const bad of ['D01234ABCD', 'G01234ABCD', 'c01234abcd', '']) {
+        const result = PublishManifestInput.safeParse({
+          channel: bad,
+          caller_user_id: 'U0ABCDEF',
+          manifest: validManifest(),
+        })
+        expect(result.success).toBe(false)
+      }
+    })
+
+    test('rejects caller_user_id that is not a Slack user_id (U...)', () => {
+      for (const bad of ['u0abcdef', 'B0ABCDEF', 'W0ABCDEF', '', 'USPACE  ']) {
+        const result = PublishManifestInput.safeParse({
+          channel: 'C01234ABCD',
+          caller_user_id: bad,
+          manifest: validManifest(),
+        })
+        expect(result.success).toBe(false)
+      }
+    })
+
+    test('rejects a manifest missing the magic header (nested Zod)', () => {
+      const bad = { ...validManifest() } as Record<string, unknown>
+      delete bad.__claude_bot_manifest_v1__
+      const result = PublishManifestInput.safeParse({
+        channel: 'C01234ABCD',
+        caller_user_id: 'U0ABCDEF',
+        manifest: bad,
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        // Error path drills into the nested manifest object.
+        expect(
+          result.error.issues.some((i) => i.path[0] === 'manifest'),
+        ).toBe(true)
+      }
+    })
+
+    test('rejects a manifest with a non-SemVer version (nested Zod)', () => {
+      const bad = { ...validManifest(), version: 'not-a-version' }
+      const result = PublishManifestInput.safeParse({
+        channel: 'C01234ABCD',
+        caller_user_id: 'U0ABCDEF',
+        manifest: bad,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test('rejects unknown top-level fields (.strict() contract)', () => {
+      const result = PublishManifestInput.safeParse({
+        channel: 'C01234ABCD',
+        caller_user_id: 'U0ABCDEF',
+        manifest: validManifest(),
+        extra: 'nope',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.code === 'unrecognized_keys'),
+        ).toBe(true)
+      }
+    })
+
+    test('rejects each missing required field individually', () => {
+      for (const field of ['channel', 'caller_user_id', 'manifest'] as const) {
+        const input: Record<string, unknown> = {
+          channel: 'C01234ABCD',
+          caller_user_id: 'U0ABCDEF',
+          manifest: validManifest(),
+        }
+        delete input[field]
+        const result = PublishManifestInput.safeParse(input)
+        expect(result.success).toBe(false)
+      }
     })
   })
 })

--- a/server.ts
+++ b/server.ts
@@ -35,6 +35,7 @@ import {
   parseSendableRoots,
   validateSendableRoots,
   assertOutboundAllowed as libAssertOutboundAllowed,
+  assertPublishAllowed,
   deliveredThreadKey as libDeliveredThreadKey,
   permissionPairingKey as permKey,
   listSessions as libListSessions,
@@ -61,7 +62,12 @@ import {
   type PendingPolicyApproval,
 } from './lib.ts'
 import { JournalWriter, createBootAnchor, verifyJournal } from './journal.ts'
-import { extractManifests, createManifestCache } from './manifest.ts'
+import {
+  extractManifests,
+  createManifestCache,
+  ManifestV1,
+  MANIFEST_V1_MAGIC_KEY,
+} from './manifest.ts'
 import {
   parsePolicyRules,
   evaluate as policyEvaluate,
@@ -655,6 +661,25 @@ const ReadPeerManifestsInput = z
   })
   .strict()
 
+const PublishManifestInput = z
+  .object({
+    // Public channels only (C...) — same posture as read. A manifest is
+    // a public advertisement; posting one into a DM or private group is
+    // out of scope for v1.
+    channel: z.string().regex(/^C[A-Z0-9]+$/),
+    // Claude must pass the Slack user_id of the human on whose behalf
+    // this publish is performed. The publish gate (assertPublishAllowed,
+    // bead ccsc-0qk.5) verifies this against access.allowFrom — the same
+    // workspace-level allowlist that gates DMs. A caller outside the
+    // allowlist is rejected with a clear error.
+    caller_user_id: z.string().regex(/^U[A-Z0-9]+$/),
+    // Manifest body. Validated against the full ManifestV1 schema; any
+    // deviation (missing magic header, wrong types, oversize field) is
+    // rejected with Zod's standard error before any Slack side effects.
+    manifest: ManifestV1,
+  })
+  .strict()
+
 // NOTE: These schemas are duplicated for isolated testing in `server.test.ts`.
 // If you update a schema here, please update the corresponding copy there.
 export const toolSchemas = {
@@ -665,6 +690,7 @@ export const toolSchemas = {
   download_attachment: DownloadAttachmentInput,
   list_sessions: ListSessionsInput,
   read_peer_manifests: ReadPeerManifestsInput,
+  publish_manifest: PublishManifestInput,
 } as const
 
 mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -778,6 +804,31 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           },
         },
         required: ['channel'],
+      },
+    },
+    {
+      name: 'publish_manifest',
+      description:
+        "Publish this bot's manifest in a Slack channel as a pinned message. Replaces any prior manifest this bot posted in that channel (pins.list → unpin prior → post → pins.add). Only users in access.allowFrom may publish; caller_user_id is the authorizing human's user_id. The manifest must match the v1 schema (magic header, SemVer version, tools/channels bounds, ISO datetime). Channel must be opted-in.",
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          channel: {
+            type: 'string',
+            description: 'Public channel ID (C...) to publish into.',
+          },
+          caller_user_id: {
+            type: 'string',
+            description:
+              "Slack user_id of the human on whose behalf the publish is performed. Must be in access.allowFrom.",
+          },
+          manifest: {
+            type: 'object',
+            description:
+              'v1 manifest body (see 000-docs/bot-manifest-protocol.md §17-55). Must include __claude_bot_manifest_v1__: true plus name, vendor, SemVer version, description, tools[], publishedAt.',
+          },
+        },
+        required: ['channel', 'caller_user_id', 'manifest'],
       },
     },
   ],
@@ -1248,6 +1299,140 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
           {
             type: 'text',
             text: JSON.stringify({ channel, count: manifests.length, manifests }, null, 2),
+          },
+        ],
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // publish_manifest — Epic 31-B.1 + 31-B.3 (ccsc-0qk.1, ccsc-0qk.3)
+    //
+    // Post this bot's manifest into a Slack channel with "replace"
+    // semantics: before posting, unpin any prior manifest this bot
+    // published in the same channel, so at most one pinned manifest from
+    // us exists per channel. Flow per the bead: pins.list → filter to
+    // our own prior manifests → unpin each → chat.postMessage → pins.add.
+    //
+    // Two gates run before any Slack side effects:
+    //
+    //   1. assertPublishAllowed(caller_user_id, access) — only humans in
+    //      access.allowFrom may authorise a publish (ccsc-0qk.5).
+    //   2. assertOutboundAllowed(channel, undefined) — channel must be
+    //      opted-in, same gate used for reply/read_peer_manifests.
+    //
+    // The manifest body itself is already Zod-validated by toolSchemas
+    // (PublishManifestInput) before the handler is entered, so
+    // oversized fields, wrong types, and missing magic header are all
+    // caught pre-dispatch.
+    //
+    // Size cap (8 KB, stricter than read's 40 KB) and the 1-publish-per-
+    // channel-per-hour rate limit are sibling beads (ccsc-0qk.2,
+    // ccsc-0qk.4); they layer on without changing this surface.
+    // -----------------------------------------------------------------------
+    case 'publish_manifest': {
+      const channel: string = args.channel
+      const callerUserId: string = args.caller_user_id
+      const manifest = args.manifest as import('./manifest.ts').ManifestV1
+
+      // Gate 1: only allowlisted humans may publish.
+      try {
+        assertPublishAllowed(callerUserId, getAccess())
+      } catch (publishErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'publish_manifest',
+          input: { channel, caller_user_id: callerUserId },
+          reason: publishErr instanceof Error ? publishErr.message : String(publishErr),
+        })
+        throw publishErr
+      }
+
+      // Gate 2: channel must be opted in, same as any outbound write.
+      try {
+        assertOutboundAllowed(channel, undefined)
+      } catch (outboundErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'publish_manifest',
+          input: { channel, caller_user_id: callerUserId },
+          reason: outboundErr instanceof Error ? outboundErr.message : String(outboundErr),
+        })
+        throw outboundErr
+      }
+      journalWrite({
+        kind: 'gate.outbound.allow',
+        outcome: 'allow',
+        toolName: 'publish_manifest',
+        input: { channel, caller_user_id: callerUserId },
+      })
+
+      // Replace semantics: unpin any prior manifest this bot posted in
+      // this channel before posting the new one. Best-effort — if the
+      // pins.list or a pins.remove fails, log and continue so a flaky
+      // Slack call doesn't break the publish. Worst case, the channel
+      // accumulates an extra pinned manifest from us; a subsequent
+      // publish will sweep it up.
+      let replaced = 0
+      try {
+        const pins = await web.pins.list({ channel })
+        for (const item of pins.items ?? []) {
+          const msg = (item as {
+            message?: { text?: string | null; bot_id?: string; user?: string; ts?: string }
+          }).message
+          if (!msg || !msg.ts) continue
+          const text = msg.text ?? ''
+          const isOurs =
+            (selfBotId && msg.bot_id === selfBotId) ||
+            (botUserId && msg.user === botUserId)
+          if (!isOurs) continue
+          if (!text.includes(MANIFEST_V1_MAGIC_KEY)) continue
+          try {
+            await web.pins.remove({ channel, timestamp: msg.ts })
+            replaced += 1
+          } catch (unpinErr) {
+            console.warn('[publish_manifest] pins.remove failed — continuing', {
+              channel,
+              ts: msg.ts,
+              error: unpinErr instanceof Error ? unpinErr.message : String(unpinErr),
+            })
+          }
+        }
+      } catch (pinsListErr) {
+        console.warn('[publish_manifest] pins.list failed — skipping replace sweep', {
+          channel,
+          error: pinsListErr instanceof Error ? pinsListErr.message : String(pinsListErr),
+        })
+      }
+
+      // Post + pin. If either fails the whole publish fails — a posted-
+      // but-unpinned manifest would be invisible to read_peer_manifests
+      // consumers anyway (they default to pins + last 50 messages, so
+      // the post would eventually surface via history, but the replace-
+      // semantics contract is pinned-message only). Fail loud here.
+      const postRes = await web.chat.postMessage({
+        channel,
+        text: JSON.stringify(manifest, null, 2),
+        unfurl_links: false,
+        unfurl_media: false,
+      })
+      const ts = (postRes.ts as string) || ''
+      if (!ts) {
+        throw new Error('publish_manifest: chat.postMessage returned no ts')
+      }
+      await web.pins.add({ channel, timestamp: ts })
+
+      journalWrite({
+        kind: 'manifest.publish',
+        toolName: 'publish_manifest',
+        input: { channel, caller_user_id: callerUserId, replaced },
+      })
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ channel, ts, replaced }, null, 2),
           },
         ],
       }

--- a/server.ts
+++ b/server.ts
@@ -1330,9 +1330,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
     // ccsc-0qk.4); they layer on without changing this surface.
     // -----------------------------------------------------------------------
     case 'publish_manifest': {
-      const channel: string = args.channel
-      const callerUserId: string = args.caller_user_id
-      const manifest = args.manifest as import('./manifest.ts').ManifestV1
+      // Re-parse with the tool's own schema so TypeScript sees proper
+      // types for the rest of the handler instead of the dispatcher's
+      // `Record<string, any>`. The top-level safeParse at dispatch has
+      // already validated shape; this second parse is essentially a
+      // typed destructure and will not throw on reachable input.
+      const {
+        channel,
+        caller_user_id: callerUserId,
+        manifest,
+      } = PublishManifestInput.parse(args)
 
       // Gate 1: only allowlisted humans may publish.
       try {
@@ -1378,9 +1385,15 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       try {
         const pins = await web.pins.list({ channel })
         for (const item of pins.items ?? []) {
-          const msg = (item as {
-            message?: { text?: string | null; bot_id?: string; user?: string; ts?: string }
-          }).message
+          // pins.list returns items of several kinds (message, file,
+          // file_comment); only message items carry a manifest. Narrow
+          // on `type` first so we don't optimistically cast file items
+          // into a message shape that Slack never promised.
+          const narrowed = item as { type?: string; message?: unknown }
+          if (narrowed.type !== 'message') continue
+          const msg = narrowed.message as
+            | { text?: string | null; bot_id?: string; user?: string; ts?: string }
+            | undefined
           if (!msg || !msg.ts) continue
           const text = msg.text ?? ''
           const isOurs =
@@ -1417,7 +1430,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
         unfurl_links: false,
         unfurl_media: false,
       })
-      const ts = (postRes.ts as string) || ''
+      const ts = postRes.ts || ''
       if (!ts) {
         throw new Error('publish_manifest: chat.postMessage returned no ts')
       }


### PR DESCRIPTION
## Summary

Epic 31-B.1 + 31-B.3 (beads \`ccsc-0qk.1\` + \`ccsc-0qk.3\`). Ships both together because a publish_manifest without replace semantics would accumulate duplicate pinned manifests on every call — they are one correctness unit.

## Flow

Per the design doc (§78-87 symmetric for publish):

1. **Zod-validate input** — channel must be public \`C...\`, \`caller_user_id\` must be \`U...\`, \`manifest\` must pass the full \`ManifestV1\` schema.
2. **assertPublishAllowed(caller_user_id, access)** — ccsc-0qk.5 gate; only humans in \`access.allowFrom\` may authorise.
3. **assertOutboundAllowed(channel, undefined)** — channel must be opted-in.
4. **Replace sweep** (best-effort): \`pins.list\` → filter to our own pins carrying the magic header → \`pins.remove\` each. Failures here are logged and skipped so a flaky \`pins.list\` never blocks the publish.
5. **\`chat.postMessage\`** with \`JSON.stringify(manifest, null, 2)\`.
6. **\`pins.add\`** on the returned \`ts\`.
7. **Journal \`manifest.publish\`** with \`{channel, caller_user_id, replaced}\`.

## Changes

- \`server.ts\` — new \`PublishManifestInput\` Zod + registered in \`toolSchemas\` + \`ListTools\` entry + switch case. Imports \`assertPublishAllowed\` and \`MANIFEST_V1_MAGIC_KEY\`.
- \`journal.ts\` — adds \`manifest.publish\` event kind (22 total, up from 21).
- \`server.test.ts\` — 7 new \`PublishManifestInput\` schema tests + \`EventKind\` count-pin updated.

## Test coverage (7 new, 557/557 total)

- Accepts a minimal valid publish
- Rejects \`D...\` and \`G...\` channel IDs
- Rejects caller_user_id not matching \`U...\`
- Rejects manifest missing magic header (nested Zod error drills into \`manifest.\*\`)
- Rejects non-SemVer version
- Rejects unknown top-level fields (\`.strict()\`)
- Rejects each missing required field individually

Size cap (8 KB, \`ccsc-0qk.2\`) and rate limit (1/channel/hour, \`ccsc-0qk.4\`) are sibling beads — they layer on without changing this surface. End-to-end tests with a mocked WebClient land in \`ccsc-0qk.7\`-\`.10\`.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 557/557 pass
- [x] \`bun test -t "PublishManifestInput"\` — 7/7 pass

Closes beads \`ccsc-0qk.1\` and \`ccsc-0qk.3\`.

Jeremy made me do it
-claude