### PR TITLE
feat(manifest): 8 KB publish-side size cap

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -330,8 +330,8 @@ export function createManifestCache(
  * directly. Keeping serialization and size-check in one function
  * guarantees the bytes we measure are the bytes we post — a split
  * signature (`assertPublishSize(manifest)` + separate
- * `JSON.stringify` in the caller) would leave room for a formatter
- * drift to silently raise the effective cap.
+ * `JSON.stringify` in the caller) would leave room for formatting
+ * differences to silently raise the effective cap.
  *
  * Stricter than the 40 KB read-side cap (Postel's Law — strict on
  * output, liberal on input). See `MAX_PUBLISH_MANIFEST_BYTES` for the

--- a/manifest.ts
+++ b/manifest.ts
@@ -108,6 +108,19 @@ export const MANIFEST_V1_MAGIC_KEY = '__claude_bot_manifest_v1__' as const
  */
 export const MAX_MANIFEST_BYTES = 40 * 1024
 
+/**
+ * Publish-side cap on the serialized manifest (Epic 31-B.2, bead
+ * ccsc-0qk.2). Deliberately stricter than `MAX_MANIFEST_BYTES` by a
+ * factor of 5 — Postel's Law: "be conservative in what you send,
+ * liberal in what you receive." A publisher writes what it controls;
+ * a reader tolerates what the peer happens to post. 8 KB is plenty
+ * for a well-formed v1 manifest (the schema caps description at 1000
+ * chars, up to 50 tools with ≤ 480 chars each, up to 50 channels) and
+ * surfaces operator mistakes (e.g. a pasted API payload that should
+ * have been a manifest) loudly at publish time.
+ */
+export const MAX_PUBLISH_MANIFEST_BYTES = 8 * 1024
+
 // ---------------------------------------------------------------------------
 // extractManifests — pure filter/parse/validate for a batch of message texts
 // ---------------------------------------------------------------------------
@@ -300,4 +313,38 @@ export function createManifestCache(
       return store.size
     },
   }
+}
+
+// ---------------------------------------------------------------------------
+// Publish-size gate (Epic 31-B.2, bead ccsc-0qk.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a validated manifest to its on-wire JSON form and assert
+ * the UTF-8 byte count is within the 8 KB publish cap. Throws on
+ * violation with a message that names both the actual byte count and
+ * the cap, so an operator debugging a rejected publish knows exactly
+ * which field to shrink.
+ *
+ * Returns the serialized string on success so the caller can post it
+ * directly. Keeping serialization and size-check in one function
+ * guarantees the bytes we measure are the bytes we post — a split
+ * signature (`assertPublishSize(manifest)` + separate
+ * `JSON.stringify` in the caller) would leave room for a formatter
+ * drift to silently raise the effective cap.
+ *
+ * Stricter than the 40 KB read-side cap (Postel's Law — strict on
+ * output, liberal on input). See `MAX_PUBLISH_MANIFEST_BYTES` for the
+ * reasoning.
+ */
+export function assertPublishSizeAndSerialize(manifest: ManifestV1): string {
+  const body = JSON.stringify(manifest, null, 2)
+  const bytes = utf8ByteLength(body)
+  if (bytes > MAX_PUBLISH_MANIFEST_BYTES) {
+    throw new Error(
+      `Publish size: manifest serializes to ${bytes}B > ${MAX_PUBLISH_MANIFEST_BYTES}B cap. ` +
+        `Shrink description, tools[], or channels[] before republishing.`,
+    )
+  }
+  return body
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -3764,6 +3764,174 @@ describe('extractManifests (31-A.2)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// assertPublishSizeAndSerialize — publish-side 8 KB cap (Epic 31-B.2, ccsc-0qk.2)
+//
+// Postel's Law: stricter than the 40 KB read cap because a publisher
+// writes what it controls. Serializes + measures UTF-8 bytes in one
+// function so the bytes we validate are exactly the bytes that go on
+// the wire. Errors name both actual and cap so an operator debugging
+// a rejected publish sees which field to shrink.
+// ---------------------------------------------------------------------------
+
+describe('assertPublishSizeAndSerialize (31-B.2)', () => {
+  /** Minimal valid manifest. Small enough to always pass the cap
+   *  (serializes to ~170 bytes), so tests can pad upward from here. */
+  function minimalManifest(): import('./manifest.ts').ManifestV1 {
+    return {
+      __claude_bot_manifest_v1__: true,
+      name: 'Tiny',
+      vendor: 'Acme',
+      version: '1.0.0',
+      description: '',
+      tools: [],
+      publishedAt: '2026-01-01T00:00:00.000Z',
+    }
+  }
+
+  test('exports MAX_PUBLISH_MANIFEST_BYTES = 8 KB', async () => {
+    const { MAX_PUBLISH_MANIFEST_BYTES } = await import('./manifest.ts')
+    expect(MAX_PUBLISH_MANIFEST_BYTES).toBe(8 * 1024)
+  })
+
+  test('cap is stricter than the read-side cap (Postel\'s Law)', async () => {
+    const { MAX_PUBLISH_MANIFEST_BYTES, MAX_MANIFEST_BYTES } = await import(
+      './manifest.ts'
+    )
+    expect(MAX_PUBLISH_MANIFEST_BYTES).toBeLessThan(MAX_MANIFEST_BYTES)
+  })
+
+  test('returns the serialized JSON for a manifest well under cap', async () => {
+    const { assertPublishSizeAndSerialize } = await import('./manifest.ts')
+    const body = assertPublishSizeAndSerialize(minimalManifest())
+    // Round-trip parseability is the invariant a caller relies on.
+    expect(() => JSON.parse(body)).not.toThrow()
+    expect(JSON.parse(body).__claude_bot_manifest_v1__).toBe(true)
+  })
+
+  test('accepts a manifest tuned to land just under the 8 KB cap', async () => {
+    const { assertPublishSizeAndSerialize, MAX_PUBLISH_MANIFEST_BYTES } = await import(
+      './manifest.ts'
+    )
+    // A well-formed v1 manifest CAN reach the cap if an operator packs
+    // the optional channels[] array, since the regex doesn't bound
+    // per-channel string length. Pad channel IDs with enough trailing
+    // alnum so the serialized body lands at (cap - 1). That proves the
+    // cap is inclusive on the passing side.
+    const enc = new TextEncoder()
+    const encodeSize = (m: import('./manifest.ts').ManifestV1) =>
+      enc.encode(JSON.stringify(m, null, 2)).length
+    const base = minimalManifest()
+    // Build one channel long enough that a single entry pushes us near
+    // the cap; binary-search the suffix length.
+    let lo = 1
+    let hi = MAX_PUBLISH_MANIFEST_BYTES
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi + 1) / 2)
+      const candidate: import('./manifest.ts').ManifestV1 = {
+        ...base,
+        channels: [`C${'A'.repeat(mid)}`],
+      }
+      if (encodeSize(candidate) <= MAX_PUBLISH_MANIFEST_BYTES) {
+        lo = mid
+      } else {
+        hi = mid - 1
+      }
+    }
+    const nearCap: import('./manifest.ts').ManifestV1 = {
+      ...base,
+      channels: [`C${'A'.repeat(lo)}`],
+    }
+    const bytes = encodeSize(nearCap)
+    // Within one character of the cap — that's as tight as the search
+    // can get at byte granularity.
+    expect(bytes).toBeLessThanOrEqual(MAX_PUBLISH_MANIFEST_BYTES)
+    expect(bytes).toBeGreaterThan(MAX_PUBLISH_MANIFEST_BYTES - 2)
+    const body = assertPublishSizeAndSerialize(nearCap)
+    expect(JSON.parse(body)).toEqual(nearCap)
+  })
+
+  test('rejects a manifest one byte over the cap', async () => {
+    const { assertPublishSizeAndSerialize, MAX_PUBLISH_MANIFEST_BYTES } = await import(
+      './manifest.ts'
+    )
+    const enc = new TextEncoder()
+    const base = minimalManifest()
+    // Grow a single channel suffix one byte at a time until the encoded
+    // body exceeds the cap — first payload that exceeds is our "one
+    // over" witness.
+    let suffix = 1
+    let candidate: import('./manifest.ts').ManifestV1 = {
+      ...base,
+      channels: [`C${'A'.repeat(suffix)}`],
+    }
+    while (enc.encode(JSON.stringify(candidate, null, 2)).length <= MAX_PUBLISH_MANIFEST_BYTES) {
+      suffix += 1
+      candidate = { ...base, channels: [`C${'A'.repeat(suffix)}`] }
+    }
+    expect(
+      enc.encode(JSON.stringify(candidate, null, 2)).length,
+    ).toBeGreaterThan(MAX_PUBLISH_MANIFEST_BYTES)
+    expect(() => assertPublishSizeAndSerialize(candidate)).toThrow(/Publish size/)
+  })
+
+  test('rejects a manifest that serializes above the cap with a clear error', async () => {
+    const { assertPublishSizeAndSerialize, MAX_PUBLISH_MANIFEST_BYTES } = await import(
+      './manifest.ts'
+    )
+    // Max out every array: 50 tools × {name 80 chars, description 400 chars}.
+    // Per tool ≈ 520 bytes after JSON formatting. 50 × 520 ≈ 26 KB — well
+    // above the 8 KB cap.
+    const huge: import('./manifest.ts').ManifestV1 = {
+      ...minimalManifest(),
+      tools: Array.from({ length: 50 }, (_, i) => ({
+        name: `tool_${i.toString().padStart(5, '0')}_${'n'.repeat(50)}`,
+        description: 'd'.repeat(400),
+      })),
+    }
+    const expectedBytes = new TextEncoder().encode(JSON.stringify(huge, null, 2)).length
+    expect(expectedBytes).toBeGreaterThan(MAX_PUBLISH_MANIFEST_BYTES)
+
+    let caught: Error | undefined
+    try {
+      assertPublishSizeAndSerialize(huge)
+    } catch (err) {
+      caught = err instanceof Error ? err : new Error(String(err))
+    }
+    expect(caught).toBeDefined()
+    expect(caught?.message).toMatch(/Publish size/)
+    expect(caught?.message).toMatch(String(expectedBytes))
+    expect(caught?.message).toMatch(String(MAX_PUBLISH_MANIFEST_BYTES))
+    // Message points at the fields an operator can actually shrink so
+    // a rejection is actionable without doc-diving.
+    expect(caught?.message).toMatch(/tools|channels|description/)
+  })
+
+  test('cap is measured in UTF-8 bytes, not string length (multi-byte safe)', async () => {
+    const { assertPublishSizeAndSerialize, MAX_PUBLISH_MANIFEST_BYTES } = await import(
+      './manifest.ts'
+    )
+    // Same posture as the read-side cap test: emoji are 4 UTF-8 bytes
+    // but 2 UTF-16 code units. A string-length-based cap would under-
+    // report by half; the TextEncoder path must catch it. Use tools[]
+    // entries padded with emoji to push byte count over cap while
+    // keeping string length well under.
+    const emoji = '🔥' // 4 UTF-8 bytes, 2 UTF-16 units
+    const huge: import('./manifest.ts').ManifestV1 = {
+      ...minimalManifest(),
+      tools: Array.from({ length: 50 }, (_, i) => ({
+        name: `tool_${i}`,
+        description: emoji.repeat(80), // 320 bytes, 160 UTF-16 units
+      })),
+    }
+    const body = JSON.stringify(huge, null, 2)
+    const bytes = new TextEncoder().encode(body).length
+    expect(bytes).toBeGreaterThan(MAX_PUBLISH_MANIFEST_BYTES)
+    expect(body.length).toBeLessThan(bytes) // multi-byte distinction
+    expect(() => assertPublishSizeAndSerialize(huge)).toThrow(/Publish size/)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // createManifestCache — per-channel read cache (Epic 31-A.5, ccsc-s53.5)
 //
 // Doubles as the rate limit on `read_peer_manifests`: within the 5-minute

--- a/server.test.ts
+++ b/server.test.ts
@@ -3891,19 +3891,19 @@ describe('assertPublishSizeAndSerialize (31-B.2)', () => {
     const expectedBytes = new TextEncoder().encode(JSON.stringify(huge, null, 2)).length
     expect(expectedBytes).toBeGreaterThan(MAX_PUBLISH_MANIFEST_BYTES)
 
-    let caught: Error | undefined
-    try {
-      assertPublishSizeAndSerialize(huge)
-    } catch (err) {
-      caught = err instanceof Error ? err : new Error(String(err))
-    }
-    expect(caught).toBeDefined()
-    expect(caught?.message).toMatch(/Publish size/)
-    expect(caught?.message).toMatch(String(expectedBytes))
-    expect(caught?.message).toMatch(String(MAX_PUBLISH_MANIFEST_BYTES))
+    // Consistent with the rest of the suite: chain multiple toThrow()
+    // regex matchers on the same call. Each regex must match the same
+    // error message, so we pin four distinct facets of the diagnostic
+    // (prefix, actual bytes, cap, shrinkable-fields hint) without the
+    // ceremony of a try/catch + captured-variable pattern.
+    expect(() => assertPublishSizeAndSerialize(huge)).toThrow(/Publish size/)
+    expect(() => assertPublishSizeAndSerialize(huge)).toThrow(String(expectedBytes))
+    expect(() => assertPublishSizeAndSerialize(huge)).toThrow(
+      String(MAX_PUBLISH_MANIFEST_BYTES),
+    )
     // Message points at the fields an operator can actually shrink so
     // a rejection is actionable without doc-diving.
-    expect(caught?.message).toMatch(/tools|channels|description/)
+    expect(() => assertPublishSizeAndSerialize(huge)).toThrow(/tools|channels|description/)
   })
 
   test('cap is measured in UTF-8 bytes, not string length (multi-byte safe)', async () => {

--- a/server.ts
+++ b/server.ts
@@ -67,6 +67,7 @@ import {
   createManifestCache,
   ManifestV1,
   MANIFEST_V1_MAGIC_KEY,
+  assertPublishSizeAndSerialize,
 } from './manifest.ts'
 import {
   parsePolicyRules,
@@ -1375,6 +1376,25 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
         input: { channel, caller_user_id: callerUserId },
       })
 
+      // Gate 3 (ccsc-0qk.2): 8 KB serialized-body cap. Runs after the
+      // auth gates so an unauthorised caller gets the auth error, not
+      // a size error (no info leak about payload contents). Serialize
+      // once here and reuse the string below so the bytes we measured
+      // are exactly the bytes that go on the wire.
+      let serialized: string
+      try {
+        serialized = assertPublishSizeAndSerialize(manifest)
+      } catch (sizeErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'publish_manifest',
+          input: { channel, caller_user_id: callerUserId },
+          reason: sizeErr instanceof Error ? sizeErr.message : String(sizeErr),
+        })
+        throw sizeErr
+      }
+
       // Replace semantics: unpin any prior manifest this bot posted in
       // this channel before posting the new one. Best-effort — if the
       // pins.list or a pins.remove fails, log and continue so a flaky
@@ -1426,7 +1446,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       // semantics contract is pinned-message only). Fail loud here.
       const postRes = await web.chat.postMessage({
         channel,
-        text: JSON.stringify(manifest, null, 2),
+        text: serialized,
         unfurl_links: false,
         unfurl_media: false,
       })


### PR DESCRIPTION
## Summary

Epic 31-B.2 (bead \`ccsc-0qk.2\`). Adds a stricter size cap on outgoing manifests than the 40 KB read cap — Postel's Law: *be conservative in what you send, liberal in what you receive*. A publisher writes content it controls; tightening the cap catches operator mistakes (e.g. an accidentally pasted API payload) at publish time.

## Changes

- **\`manifest.ts\`** — new \`MAX_PUBLISH_MANIFEST_BYTES = 8 * 1024\` constant + \`assertPublishSizeAndSerialize(manifest)\` helper that serializes with \`JSON.stringify(..., null, 2)\` (same format as the publisher), measures UTF-8 bytes via \`TextEncoder\`, throws on over-cap with an ID-bearing message, and returns the serialized string on success so the caller can post it directly.
- **\`server.ts\`** — \`publish_manifest\` handler calls \`assertPublishSizeAndSerialize\` after auth gates and before the replace sweep. The returned string is passed to \`chat.postMessage\`. Rejection journals a \`gate.outbound.deny\`.

## "Bytes measured = bytes on the wire"

Keeping the serialize + size-check in one function guarantees there's no formatter drift between what we validate and what we post. A split signature (\`assertPublishSize(manifest)\` + separate \`JSON.stringify\` in the caller) would leave room for the cap to silently rise.

## Test coverage (7 new, 564/564 total)

| Test | What it proves |
|---|---|
| Constant value | \`MAX_PUBLISH_MANIFEST_BYTES = 8192\` |
| Postel invariant | \`< MAX_MANIFEST_BYTES\` (8 KB publish < 40 KB read) |
| Normal manifest | Passes, returns parseable JSON |
| Near-cap binary search | Cap is inclusive on the pass side |
| One byte over | Rejects with \`/Publish size/\` |
| Oversize tools[] | Message names actual bytes + cap + the fields to shrink |
| Multi-byte emoji padding | Cap measured in UTF-8 bytes, not UTF-16 units |

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 564/564 pass
- [x] \`bun test -t "assertPublishSizeAndSerialize"\` — 7/7 pass

Closes bead \`ccsc-0qk.2\`.

Jeremy made me do it
-claude