### PR TITLE
feat(manifest): 1-publish-per-channel-per-hour rate limiter

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -337,6 +337,103 @@ export function createManifestCache(
  * output, liberal on input). See `MAX_PUBLISH_MANIFEST_BYTES` for the
  * reasoning.
  */
+// ---------------------------------------------------------------------------
+// Publish rate limiter (Epic 31-B.4, bead ccsc-0qk.4)
+// ---------------------------------------------------------------------------
+
+/**
+ * One publish per channel per hour. Prevents pin-spam if an operator
+ * (or a misbehaving automation) triggers repeated publishes. Not
+ * persisted — a process restart clears the window, which is the
+ * accepted tradeoff for keeping this purely in-memory (doc §166 has
+ * the same "restart clears" posture for the read cache).
+ */
+export const PUBLISH_RATE_LIMIT_MS = 60 * 60 * 1000
+
+export interface PublishRateLimiter {
+  /**
+   * Check whether `channelId` is currently in a cooldown window and,
+   * if not, record `now()` as the most-recent publish timestamp. The
+   * record happens BEFORE the caller's actual publish — reserving the
+   * slot — so a concurrent or retried call sees the cooldown even if
+   * the first call's publish is mid-flight or later fails. A rate
+   * limiter that rolls back on downstream failure is trivially
+   * bypassable (retry until success), which is not what we want here.
+   *
+   * Throws on a hit with an ID-bearing, time-bearing message naming
+   * both the channel and the approximate minutes remaining until the
+   * next publish is allowed.
+   */
+  checkAndRecord(channelId: string): void
+  /** Drop every entry. For tests and future operator commands. */
+  clear(): void
+  /** Current entry count. For tests and operator inspection. */
+  size(): number
+}
+
+export interface PublishRateLimiterOptions {
+  /** Time source. Defaults to `Date.now`. */
+  now?: () => number
+  /** Window length in ms. Defaults to `PUBLISH_RATE_LIMIT_MS`. */
+  windowMs?: number
+  /** Soft cap on distinct-channel entries. Default 256 — same bound
+   *  as the read cache; larger than any realistic workspace channel
+   *  count, small enough to cap memory. */
+  maxEntries?: number
+}
+
+/**
+ * Create an in-memory per-channel publish rate limiter. Symmetric to
+ * `createManifestCache` on the read side: plain-object factory, no
+ * `this` binding concerns, injected time source for testability,
+ * soft-LRU eviction when the entry cap would be breached.
+ */
+export function createPublishRateLimiter(
+  opts: PublishRateLimiterOptions = {},
+): PublishRateLimiter {
+  const now = opts.now ?? Date.now
+  const windowMs = opts.windowMs ?? PUBLISH_RATE_LIMIT_MS
+  const maxEntries = opts.maxEntries ?? 256
+  const store = new Map<string, number>()
+
+  return {
+    checkAndRecord(channelId) {
+      const currentMs = now()
+      const lastMs = store.get(channelId)
+      if (lastMs !== undefined && currentMs - lastMs < windowMs) {
+        const remainingMs = windowMs - (currentMs - lastMs)
+        const remainingMins = Math.max(1, Math.ceil(remainingMs / 60_000))
+        throw new Error(
+          `Publish rate limit: channel '${channelId}' was last published ` +
+            `${Math.floor((currentMs - lastMs) / 60_000)}m ago; 1-per-hour window. ` +
+            `Try again in ~${remainingMins}m.`,
+        )
+      }
+      // Soft-LRU eviction matches the read cache pattern — drop the
+      // entry with the smallest timestamp when we'd otherwise breach
+      // maxEntries on an insertion for a new channel.
+      if (store.size >= maxEntries && !store.has(channelId)) {
+        let oldestKey: string | undefined
+        let oldestAt = Infinity
+        for (const [k, v] of store) {
+          if (v < oldestAt) {
+            oldestAt = v
+            oldestKey = k
+          }
+        }
+        if (oldestKey !== undefined) store.delete(oldestKey)
+      }
+      store.set(channelId, currentMs)
+    },
+    clear() {
+      store.clear()
+    },
+    size() {
+      return store.size
+    },
+  }
+}
+
 export function assertPublishSizeAndSerialize(manifest: ManifestV1): string {
   const body = JSON.stringify(manifest, null, 2)
   const bytes = utf8ByteLength(body)

--- a/server.test.ts
+++ b/server.test.ts
@@ -4079,6 +4079,143 @@ describe('createManifestCache (31-A.5)', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// createPublishRateLimiter — 1-publish-per-channel-per-hour (Epic 31-B.4)
+//
+// In-memory Map<channelId, lastPublishAt> with injected time source so
+// the one-hour window can be exercised without wall-clock waits. Design
+// symmetric to the read-side cache (ccsc-s53.5): factory function, soft
+// LRU eviction at 256 entries, non-persisted (restart clears).
+// ---------------------------------------------------------------------------
+
+describe('createPublishRateLimiter (31-B.4)', () => {
+  test('exports PUBLISH_RATE_LIMIT_MS = 1 hour', async () => {
+    const { PUBLISH_RATE_LIMIT_MS } = await import('./manifest.ts')
+    expect(PUBLISH_RATE_LIMIT_MS).toBe(60 * 60 * 1000)
+  })
+
+  test('first publish for a channel passes without throwing', async () => {
+    const { createPublishRateLimiter } = await import('./manifest.ts')
+    const limiter = createPublishRateLimiter({ now: () => 1_000 })
+    expect(() => limiter.checkAndRecord('C_A')).not.toThrow()
+    expect(limiter.size()).toBe(1)
+  })
+
+  test('second publish within the window throws with an ID- and time-bearing error', async () => {
+    const { createPublishRateLimiter } = await import('./manifest.ts')
+    let nowValue = 0
+    const limiter = createPublishRateLimiter({ now: () => nowValue, windowMs: 1000 })
+    nowValue = 100
+    limiter.checkAndRecord('C_A')
+    nowValue = 500 // 400 ms later; still within the 1000 ms window
+    expect(() => limiter.checkAndRecord('C_A')).toThrow(/Publish rate limit/)
+    expect(() => limiter.checkAndRecord('C_A')).toThrow('C_A')
+    expect(() => limiter.checkAndRecord('C_A')).toThrow(/1-per-hour window/)
+    // Still just the one entry — a failed check must not add another.
+    expect(limiter.size()).toBe(1)
+  })
+
+  test('publish at exactly windowMs from the last is allowed (boundary exclusive)', async () => {
+    const { createPublishRateLimiter } = await import('./manifest.ts')
+    let nowValue = 0
+    const limiter = createPublishRateLimiter({ now: () => nowValue, windowMs: 1000 })
+    nowValue = 100
+    limiter.checkAndRecord('C_A')
+    nowValue = 100 + 999
+    // 999 ms after the first publish — still inside the window.
+    expect(() => limiter.checkAndRecord('C_A')).toThrow(/Publish rate limit/)
+    nowValue = 100 + 1000
+    // Exactly windowMs elapsed — window is [0, windowMs) so this is out.
+    expect(() => limiter.checkAndRecord('C_A')).not.toThrow()
+  })
+
+  test('publish after the window succeeds and refreshes the stamp', async () => {
+    const { createPublishRateLimiter } = await import('./manifest.ts')
+    let nowValue = 0
+    const limiter = createPublishRateLimiter({ now: () => nowValue, windowMs: 1000 })
+    nowValue = 100
+    limiter.checkAndRecord('C_A')
+    nowValue = 100 + 5000 // well past the window
+    expect(() => limiter.checkAndRecord('C_A')).not.toThrow()
+    // A subsequent call within windowMs of the new stamp is rejected
+    // against the refreshed timestamp, proving the set() updated.
+    nowValue = 100 + 5000 + 500
+    expect(() => limiter.checkAndRecord('C_A')).toThrow(/Publish rate limit/)
+  })
+
+  test('channelId isolation — a cooldown on one channel does not affect another', async () => {
+    const { createPublishRateLimiter } = await import('./manifest.ts')
+    let nowValue = 0
+    const limiter = createPublishRateLimiter({ now: () => nowValue, windowMs: 1000 })
+    nowValue = 100
+    limiter.checkAndRecord('C_ALICE')
+    // Concurrent publish in a different channel is fine.
+    expect(() => limiter.checkAndRecord('C_BOB')).not.toThrow()
+    // But repeating C_ALICE within the window still rejects.
+    expect(() => limiter.checkAndRecord('C_ALICE')).toThrow(/C_ALICE/)
+    expect(limiter.size()).toBe(2)
+  })
+
+  test('clear drops every entry', async () => {
+    const { createPublishRateLimiter } = await import('./manifest.ts')
+    const limiter = createPublishRateLimiter({ now: () => 0 })
+    limiter.checkAndRecord('C_A')
+    limiter.checkAndRecord('C_B')
+    expect(limiter.size()).toBe(2)
+    limiter.clear()
+    expect(limiter.size()).toBe(0)
+    // After clear, the previously-cooling-down channel can publish again.
+    expect(() => limiter.checkAndRecord('C_A')).not.toThrow()
+  })
+
+  test('soft-LRU eviction: inserting at the cap drops the oldest stamp', async () => {
+    const { createPublishRateLimiter } = await import('./manifest.ts')
+    let nowValue = 0
+    const limiter = createPublishRateLimiter({ now: () => nowValue, maxEntries: 2 })
+    nowValue = 10
+    limiter.checkAndRecord('C_A')
+    nowValue = 20
+    limiter.checkAndRecord('C_B')
+    nowValue = 30
+    limiter.checkAndRecord('C_C') // should evict C_A
+    expect(limiter.size()).toBe(2)
+    // C_A was evicted, so a fresh publish for C_A is allowed (it looks
+    // unknown to the limiter now). That IS the semantic: at the cap we
+    // accept some imprecision on long-tail channels to bound memory.
+    nowValue = 31
+    expect(() => limiter.checkAndRecord('C_A')).not.toThrow()
+  })
+
+  test('default window is 1 hour when opts.windowMs is omitted', async () => {
+    const { createPublishRateLimiter, PUBLISH_RATE_LIMIT_MS } = await import(
+      './manifest.ts'
+    )
+    let nowValue = 0
+    const limiter = createPublishRateLimiter({ now: () => nowValue })
+    nowValue = 100
+    limiter.checkAndRecord('C_A')
+    nowValue = 100 + PUBLISH_RATE_LIMIT_MS - 1
+    expect(() => limiter.checkAndRecord('C_A')).toThrow(/Publish rate limit/)
+    nowValue = 100 + PUBLISH_RATE_LIMIT_MS
+    expect(() => limiter.checkAndRecord('C_A')).not.toThrow()
+  })
+
+  test('rejection message includes remaining-time estimate in minutes', async () => {
+    const { createPublishRateLimiter } = await import('./manifest.ts')
+    let nowValue = 0
+    const limiter = createPublishRateLimiter({
+      now: () => nowValue,
+      windowMs: 60 * 60 * 1000, // 1 hour
+    })
+    nowValue = 0
+    limiter.checkAndRecord('C_A')
+    // 10 minutes after the publish — 50 minutes remain.
+    nowValue = 10 * 60 * 1000
+    expect(() => limiter.checkAndRecord('C_A')).toThrow(/10m ago/)
+    expect(() => limiter.checkAndRecord('C_A')).toThrow(/~50m/)
+  })
+})
+
 describe('createSessionSupervisor.activate', () => {
   let rawRoot: string
   let tmpRoot: string

--- a/server.ts
+++ b/server.ts
@@ -65,6 +65,7 @@ import { JournalWriter, createBootAnchor, verifyJournal } from './journal.ts'
 import {
   extractManifests,
   createManifestCache,
+  createPublishRateLimiter,
   ManifestV1,
   MANIFEST_V1_MAGIC_KEY,
   assertPublishSizeAndSerialize,
@@ -474,6 +475,12 @@ const seenEvents = new Map<string, number>()
 // instead of re-hitting Slack. A process restart clears the cache by design
 // (000-docs/bot-manifest-protocol.md §166).
 const manifestCache = createManifestCache()
+
+// Per-channel publish rate limiter for `publish_manifest` (Epic 31-B.4).
+// One publish per channel per hour; prevents pin-spam. In-memory only, reset
+// on process restart (same posture as the read cache). Reservation happens
+// BEFORE the Slack round-trip so retries on failure don't bypass the limit.
+const publishRateLimiter = createPublishRateLimiter()
 
 // ---------------------------------------------------------------------------
 // Session supervisor — lifecycle authority for per-thread sessions
@@ -1393,6 +1400,25 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
           reason: sizeErr instanceof Error ? sizeErr.message : String(sizeErr),
         })
         throw sizeErr
+      }
+
+      // Gate 4 (ccsc-0qk.4): per-channel 1-per-hour rate limit. Last
+      // gate before any Slack round-trip, so an in-cooldown caller gets
+      // the rate-limit error without consuming any Slack API budget.
+      // The reservation is recorded here; if a downstream step fails,
+      // the slot is still taken — a retry-on-failure path would make
+      // the limiter trivially bypassable.
+      try {
+        publishRateLimiter.checkAndRecord(channel)
+      } catch (rateErr) {
+        journalWrite({
+          kind: 'gate.outbound.deny',
+          outcome: 'deny',
+          toolName: 'publish_manifest',
+          input: { channel, caller_user_id: callerUserId },
+          reason: rateErr instanceof Error ? rateErr.message : String(rateErr),
+        })
+        throw rateErr
       }
 
       // Replace semantics: unpin any prior manifest this bot posted in


### PR DESCRIPTION
## Summary

Epic 31-B.4 (bead \`ccsc-0qk.4\`). Caps publish frequency to prevent pin-spam. In-memory only, reset on process restart — same posture as the 31-A.5 read cache.

## Changes

- **\`manifest.ts\`** — \`PUBLISH_RATE_LIMIT_MS = 60 * 60 * 1000\` + \`createPublishRateLimiter({now, windowMs, maxEntries})\` factory returning \`{checkAndRecord, clear, size}\`. Design symmetric to \`createManifestCache\`: factory, injected time source, soft LRU at 256 entries. Rejection error names the channel, how long ago the last publish was, and approximate minutes-remaining.

- **\`server.ts\`** — module-level \`publishRateLimiter\`, wired into \`publish_manifest\` handler **after auth gates + size cap, before replace sweep**. Slot reservation happens at the check, so a downstream Slack failure does NOT roll back the stamp — a retry-on-failure limiter would be trivially bypassable.

## Gate order (publish_manifest)

1. \`assertPublishAllowed\` — only \`access.allowFrom\` users
2. \`assertOutboundAllowed\` — channel opt-in
3. \`assertPublishSizeAndSerialize\` — 8 KB serialized cap
4. **\`publishRateLimiter.checkAndRecord\`** — ← this PR
5. replace sweep + post + pin + journal

## Test coverage (10 new, 574/574 total)

| Test | What it proves |
|---|---|
| Constant value | \`PUBLISH_RATE_LIMIT_MS = 3 600 000 ms\` |
| First publish | Passes, size() = 1 |
| Second within window | Throws \`/Publish rate limit/\` + channel ID + \`1-per-hour\` |
| Boundary at exactly windowMs | Window is \`[0, windowMs)\` — allowed at the boundary |
| Post-window refresh | Second publish updates stamp (next check rejects against refreshed) |
| Channel isolation | Cooldown on one channel doesn't affect another |
| \`clear()\` | Drops everything |
| Soft-LRU at cap | Oldest evicted on insert |
| Default window | 1 hour when \`opts.windowMs\` omitted |
| Rejection message | Includes \`10m ago\` + \`~50m\` remaining |

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 574/574 pass
- [x] \`bun test -t "createPublishRateLimiter"\` — 10/10 pass

Closes bead \`ccsc-0qk.4\`.

Jeremy made me do it
-claude