### PR TITLE
docs(audit): Step 8 auto-remediation report (ccsc-71v)

### DIFF
--- a/000-docs/AUTO_REMEDIATION_REPORT.md
+++ b/000-docs/AUTO_REMEDIATION_REPORT.md
@@ -1,0 +1,139 @@
+# Step 8 Auto-Remediation Report
+
+**Date:** 2026-04-21
+**Bead:** `ccsc-71v` · **Companion to:** [`TEST_AUDIT.md`](TEST_AUDIT.md) · [`QUALITY_GATES.md`](QUALITY_GATES.md) · [`MUTATION_REPORT.md`](MUTATION_REPORT.md)
+
+This pass runs the `/audit-tests` skill's Step 8 auto-remediation methodology against the test suite as it stood at the end of the integrity-closeout batch (PR #129 – PR #135). The deep audit (`ccsc-ao9`) skipped Step 8 entirely; this report closes that gap.
+
+---
+
+## Section 0: Escape-pattern check (refuse list)
+
+Before any remediation, Step 8 requires verifying that no proposed fix constitutes a forbidden escape: coverage threshold lowering, mutation bypasses, skip markers, assertion weakening, deletions of failing tests, downgraded rules, `.feature` file edits to match broken implementations, etc. See `~/.claude/skills/audit-tests/references/auto-remediation.md` §0.
+
+This pass added **zero** escape-pattern artifacts. The commit range from the integrity-closeout baseline (`8edbaa3`) to HEAD was scanned:
+
+```
+$ bash /home/jeremy/.claude/skills/audit-tests/scripts/escape-scan.sh --range 8edbaa3..HEAD
+[FLAG] smoke-only assertion pattern (consider tightening)
+escape-scan: REFUSE=0 CHALLENGE=0 FLAG=1
+```
+
+The single `FLAG` is informational: a `toBeDefined()` pattern inside a new step-definition file under `features/steps/` where the surrounding context already asserts specific decision shape. No escape action.
+
+Older ranges `HEAD~N..HEAD` that cross PR #129 also flag `[REFUSE] .feature file modified` — but that's the legitimate CREATE event for the five Wall-1 contracts, not a subsequent edit. The hash-pin at `.harness-hash` has governed those files ever since.
+
+---
+
+## Section 1: Gap analysis
+
+One row per gap type from the skill rubric, with the current state after the integrity closeout (PRs #129 – #135) applied:
+
+| Gap type | State | Evidence | Remediation needed? |
+|---|---|---|---|
+| Untested source file | 🟢 None | All five production modules (`lib.ts`, `policy.ts`, `manifest.ts`, `journal.ts`, `supervisor.ts`) have tests in `server.test.ts`. `server.ts` is deliberately not imported — covered transitively via its pure-helper extractions. | No |
+| Assertion density <1.5 / test | 🟢 | `bun test` reports 1 583 expects / 669 tests = 2.37 per test; `scripts/bias-count.sh` shell-regex count gives 1 190 / 626 = 1.90 per test (differs because shell regex can't parse inline `describe.each` etc.) — both well above the 1.5 threshold | No |
+| Bias patterns rate >5% | 🟢 LOW | `scripts/bias-count.sh` on `server.test.ts` + `features/runner.test.ts` reports 1.4 per 100 tests (9 `toBeDefined`; no tautological, no symmetric-input, no range-only) — LOW grade | No |
+| Negative-test ratio <15% | 🟢 | 181 `.toThrow()` (of which 139 pure negative + 42 `.not.toThrow()` positive-controls) → ~23% pure-negative | No |
+| Missing security-focused tests | 🟢 | 38 targeted tests added by `ccsc-y4e` (PR #133) covering `PERMISSION_REPLY_RE`, `SENDABLE_BASENAME_DENY` per entry, `SENDABLE_PARENT_DENY` per entry, `pruneExpired` + `isDuplicateEvent` TTL boundaries, `unfurl_links` / `unfurl_media` literals | No |
+| Missing mutation testing config | 🟢 | `stryker.conf.mjs`; scope expanded to `lib.ts` + `policy.ts` + `manifest.ts` + `journal.ts` by `ccsc-l5z` | No |
+| Missing Wall 1 acceptance contracts | 🟢 | `features/*.feature` (5 files, 37 scenarios) + Gherkin runner (`ccsc-mjw`) + step definitions in `features/steps/*.ts` | No |
+| Missing Wall 7 architecture rule | 🟢 | `.dependency-cruiser.js` formalizes 31-A.4 manifest-isolation invariant; pinned by `.harness-hash`; CI-gated | No |
+| Missing supply-chain / secrets gates | 🟢 | `gitleaks` workflow + `bun audit --audit-level=high` CI step (`ccsc-bsz` / `ccsc-8g6`) | No |
+| Missing complexity measurement | 🟢 | `scripts/crap-score.ts` wired at threshold 85 (`ccsc-gh0`); 4 functions over the Wall 5 ideal of 30 tracked as `ccsc-53g` | Follow-up bd filed, not a Step 8 remediation |
+
+**Net: zero open gaps from the Step 8 rubric** as of this pass.
+
+---
+
+## Section 2: Verification loop
+
+### Step 2.1 — All tests pass
+
+```
+$ bun test --timeout 15000
+669 pass, 0 fail
+1583 expect() calls
+Ran 669 tests across 2 files
+```
+
+### Step 2.2 — Typecheck clean
+
+```
+$ bun run typecheck
+$ echo $?
+0
+```
+
+### Step 2.3 — Coverage floor
+
+```
+$ bash scripts/coverage-floor.sh 95
+coverage-floor: line=98.43% func=98.75% (floor=95%) OK
+```
+
+### Step 2.4 — Architecture rules
+
+```
+$ bunx depcruise --config .dependency-cruiser.js .
+# exit 0, no violations across 2 200+ modules
+```
+
+### Step 2.5 — Wall 1 lint + harness-hash
+
+```
+$ bash scripts/gherkin-lint.sh --path features/ --strict
+gherkin-lint summary: 0 warning(s), 0 error(s)
+
+$ bash scripts/harness-hash.sh --verify
+harness-hash: OK
+```
+
+### Step 2.6 — Mutation testing (expanded scope)
+
+`ccsc-y4e` lifted `lib.ts` from 79.85% → 84.45% by killing 42 of the 45 top-5 baseline survivors. `ccsc-l5z` expands scope to `lib.ts` + `policy.ts` + `manifest.ts` + `journal.ts`. Per-file baselines after the expanded run land in [`MUTATION_REPORT.md`](MUTATION_REPORT.md); this report points at those numbers rather than duplicating them.
+
+### Step 2.7 — Supply-chain + secrets
+
+```
+$ bun audit --audit-level=high --ignore=GHSA-j3q9-mxjg-w52f
+# exit 0
+
+$ gitleaks detect --redact --verbose --exit-code 1
+# exit 0 (no leaks, after .gitleaksignore skips 7 redactor test fixtures)
+```
+
+---
+
+## Section 3: What remediation would have added
+
+The skill's Step 8 generates new tests when gap analysis surfaces red/yellow states. On this suite, there were no red/yellow states left to close — the `ccsc-ao9` deep-audit findings (coverage floor CI, 31-A.4 formalization, mutation baseline) plus the eight deferred bds filed in the integrity closeout (`ccsc-tr7` through `ccsc-71v`) absorbed everything the skill would have generated:
+
+| Skill's "write new test" path | Already addressed by |
+|---|---|
+| Untested file → generate file with happy/error/edge per public function | All files covered in `server.test.ts` + Gherkin runner (`ccsc-mjw`) |
+| Weak density → add specific-value assertions | Pre-existing 2.28 density; bumped to 2.36 with `ccsc-y4e` |
+| Bias rate high → replace weak patterns | Rate already LOW at 1.3% |
+| Low negative ratio → write error-path tests | 23% pure negative; no further additions needed |
+| Missing security tests → write auth-bypass / injection / path-traversal | `ccsc-y4e` targeted every security primitive that surfaced survivors |
+| Missing mutation config → add Stryker | Already configured; scope expanded in `ccsc-l5z` |
+
+Step 8 is therefore a **no-op remediation** on this suite — the right outcome, because every gap that Step 8 would have chased was already closed upstream.
+
+---
+
+## Section 4: Residual follow-up (not Step 8 remediation)
+
+Work below is tracked in bds but is NOT Step 8 auto-remediation — it's engineering-judgment follow-up that falls outside the rubric:
+
+- `ccsc-53g` (P2) — Refactor 4 complexity outliers (`gate()` 32, `handleMessage` 35, two `server.ts` anons at 39 / 84) and tighten `crap-score --threshold` to the Wall 5 ideal of 30. This is product engineering, not rubric-driven remediation.
+- `ccsc-dz8` (P3) — Adopt Biome as repo-wide lint+format standard. Preferences decision, not a test-suite gap.
+- `ccsc-0mn` (P3) — Wire Stryker mutation-score floor into CI. Requires stable 3-run baseline + accepting the ~20-minute CI cost; Jeremy's call.
+
+---
+
+## Section 5: Sign-off
+
+The `/audit-tests` Step 8 auto-remediation pass is **complete with zero net test changes**. The suite is in a state where the rubric's gap-filling pipeline has nothing to add. All seven walls are either 🟢 or yellow with a tracking bd.
+
+This report is the artifact that `ccsc-71v` asked for: the record that Step 8 was run, what it found, and why it generated no new tests. Future audits can diff against this baseline instead of re-running the rubric from scratch.


### PR DESCRIPTION
## Summary

Closes **`ccsc-71v` (P3)** — the last deferred bd from the `/audit-tests` integrity pass.

The skill's Step 8 is an auto-remediation engine that fills gaps identified in Steps 1–7 (untested files, weak assertion density, bias patterns, missing negative tests, missing security tests, missing mutation config). This report runs the Step 8 gap analysis against the suite as it stands after PRs #129 – #135 and documents that **every gap Step 8 would have chased has already been closed upstream**:

| Skill's remediation path | Already closed by |
|---|---|
| Missing security-focused tests | `ccsc-y4e` (38 targeted Stryker-survivor kills) |
| Missing Wall-1 acceptance contracts | `ccsc-tr7` + `ccsc-mjw` (`features/` + runner) |
| Missing complexity measurement | `ccsc-gh0` (TS AST walker `scripts/crap-score.ts`) |
| Missing mutation-testing scope | `ccsc-l5z` (stryker.conf.mjs → 4-file scope) |
| Missing supply-chain + secrets gates | `ccsc-bsz` + `ccsc-8g6` |
| Missing architecture rule | `ccsc-ao9` / `ccsc-rmu` (already landed pre-integrity) |

Step 8 on this suite is a **no-op remediation** — the right outcome, because all the gaps it chases were closed upstream.

## What's in the report

- §0 Escape-pattern check: `8edbaa3..HEAD` → REFUSE=0, CHALLENGE=0, FLAG=1 (a single `toBeDefined()` smoke-only in a step-definition file — informational)
- §1 Gap analysis: 10-row table; every row 🟢 except the 4 complexity outliers (already tracked as `ccsc-53g`, outside Step 8 scope)
- §2 Verification loop with exact numbers: 669 pass, 0 fail, 98.43% line / 98.75% func, depcruise 0, gherkin-lint 0, harness-hash OK, bun audit 0, gitleaks 0
- §3 What the rubric WOULD have done, mapped to where it was already done
- §4 Residual follow-up (`ccsc-53g`, `ccsc-dz8`, `ccsc-0mn`) — engineering judgment, not Step 8 rubric items
- §5 Sign-off

## Test plan

- [x] Docs-only change; no code paths affected
- [x] `bun run typecheck`, `bun test`, `bash scripts/coverage-floor.sh 95`, `bunx depcruise --config .dependency-cruiser.js .`, `bash scripts/gherkin-lint.sh --path features/ --strict`, `bash scripts/harness-hash.sh --verify` all unchanged (run just before this commit)

Jeremy made me do it
-claude