### PR TITLE
feat(test): expand Stryker scope to policy + manifest + journal (ccsc-l5z)

### DIFF
--- a/000-docs/MUTATION_REPORT.md
+++ b/000-docs/MUTATION_REPORT.md
@@ -34,19 +34,25 @@ mutation-testing gap so severe that the baseline should be treated as a draft.
 
 `server.ts` and `supervisor.ts` remain out of scope: `server.ts` has boot-time side effects and module-load globals that confuse the mutator; `supervisor.ts` mutants routinely time out under the command runner's cold-spawn overhead.
 
-### Per-file baselines (expanded scope)
+### Per-file baselines (expanded scope — 2026-04-21)
 
-A full re-run against the expanded config is captured separately as the run completes. Header numbers land here; per-file breakdowns land after:
+Full 42-minute run against the four-file scope after `ccsc-y4e`'s survivor-kill tests landed. Final numbers:
 
-| File | Mutants | Killed | Survived | Timed out | Score |
+| File | Mutants | Killed | Timed out | Survived | Score |
 |---|---|---|---|---|---|
-| `lib.ts` | (run in progress) | — | — | — | — |
-| `policy.ts` | (run in progress) | — | — | — | — |
-| `manifest.ts` | (run in progress) | — | — | — | — |
-| `journal.ts` | (run in progress) | — | — | — | — |
-| **All files** | **1 860** | — | — | — | — |
+| `journal.ts` | 433 | 378 | 2 | 53 | **87.76%** |
+| `lib.ts` | 913 | 770 | 4 | 139 | **84.78%** |
+| `manifest.ts` | 214 | 197 | 0 | 17 | **92.06%** |
+| `policy.ts` | 300 | 233 | 1 | 66 | **78.00%** |
+| **All files** | **1 860** | **1 578** | **7** | **275** | **85.22%** |
 
-**Update trailer:** A follow-up commit to this same PR will replace the "in progress" rows with the final per-file numbers once the run completes. The intermediate y4e-only re-run on `lib.ts` landed at **84.45%** (up from 79.85% baseline) after the top-5 survivor-kill tests.
+Overall **85.22%** — above the `high: 80` threshold in `stryker.conf.mjs`.
+
+`manifest.ts` leads at 92.06% — Epic 31-B's Zod schema + strict subset validation produces easily-killable mutants. `journal.ts` second at 87.76%. `lib.ts` at 84.78% matches the post-y4e intermediate run within noise. `policy.ts` is the outlier at 78.00% — below `high` but above `low: 60`. The surviving mutants cluster on error-string literals inside `detectShadowing` / `detectBroadAutoApprove` warnings — the behavior (warn on shadow / footgun) is fully exercised, but the exact warning text isn't asserted bit-for-bit.
+
+**Follow-up:** strengthening `policy.ts` warning-message assertions is a reasonable P3 follow-up — the primitive is exercised, the text isn't. Not urgent; the mutation score is above the `low` threshold and the behavior coverage is strong.
+
+Runtime: **42 minutes 43 seconds** at `concurrency: 4` on this workstation. HTML report written to `reports/mutation/mutation.html` (gitignored).
 
 ## Reproduce
 

--- a/000-docs/MUTATION_REPORT.md
+++ b/000-docs/MUTATION_REPORT.md
@@ -28,16 +28,25 @@ mutation-testing gap so severe that the baseline should be treated as a draft.
 
 ## Scope (and why it's narrow)
 
-Baseline run covered **`lib.ts` only** (1,770 lines, 913 mutants generated).
-`policy.ts` and `manifest.ts` are out of scope for this first run. The initial
-attempt over all three files (1,427 mutants) projected ~24 min on this hardware
-— over the 20-min budget set for the PR — so the config was narrowed. Opening
-the scope to `policy.ts` and `manifest.ts` is a reasonable follow-up once
-either (a) CI-free hardware is faster or (b) Stryker is wired to run the tests
-via a warm `bun test` runner rather than cold-spawning `bun test` per mutant.
+**Original baseline** (ccsc-ao9) covered **`lib.ts` only** (1,770 lines, 913 mutants) because the full-scope run projected ~24 min on this hardware — over the 20-min budget the PR had set.
 
-`server.ts`, `supervisor.ts`, and `journal.ts` were excluded by design:
-boot-time side effects and module-load globals confuse the mutator.
+**Expanded scope** (ccsc-l5z, this change): `stryker.conf.mjs` now mutates `lib.ts` + `policy.ts` + `manifest.ts` + `journal.ts` — the four security-critical pure modules. Observed mutant count on the expanded scope: **1 860** (up from 913), with an expected ~45-minute runtime on this workstation at `concurrency: 4`.
+
+`server.ts` and `supervisor.ts` remain out of scope: `server.ts` has boot-time side effects and module-load globals that confuse the mutator; `supervisor.ts` mutants routinely time out under the command runner's cold-spawn overhead.
+
+### Per-file baselines (expanded scope)
+
+A full re-run against the expanded config is captured separately as the run completes. Header numbers land here; per-file breakdowns land after:
+
+| File | Mutants | Killed | Survived | Timed out | Score |
+|---|---|---|---|---|---|
+| `lib.ts` | (run in progress) | — | — | — | — |
+| `policy.ts` | (run in progress) | — | — | — | — |
+| `manifest.ts` | (run in progress) | — | — | — | — |
+| `journal.ts` | (run in progress) | — | — | — | — |
+| **All files** | **1 860** | — | — | — | — |
+
+**Update trailer:** A follow-up commit to this same PR will replace the "in progress" rows with the final per-file numbers once the run completes. The intermediate y4e-only re-run on `lib.ts` landed at **84.45%** (up from 79.85% baseline) after the top-5 survivor-kill tests.
 
 ## Reproduce
 

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -15,12 +15,14 @@
 
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 export default {
-  // Baseline scope: lib.ts only. A full-scope run over lib.ts + policy.ts +
-  // manifest.ts (1427 mutants) projected ~24 min on this hardware — over the
-  // 20-min budget this PR's stop-if rule sets. Narrowing to lib.ts gives a
-  // meaningful first baseline of the security-critical gate/outbound/sendable
-  // guards. policy.ts and manifest.ts can be added in follow-up PRs.
-  mutate: ['lib.ts'],
+  // Expanded scope (ccsc-l5z): lib.ts + policy.ts + manifest.ts + journal.ts.
+  // Baseline runs now cover the four security-critical modules. server.ts and
+  // supervisor.ts remain out of scope — server.ts has boot-time side effects
+  // and module-load globals; supervisor.ts is well-covered by integration-
+  // style tests but its mutants regularly time out under the command runner's
+  // cold-spawn overhead. Per-file mutation scores are captured in
+  // 000-docs/MUTATION_REPORT.md after each run.
+  mutate: ['lib.ts', 'policy.ts', 'manifest.ts', 'journal.ts'],
   testRunner: 'command',
   commandRunner: {
     command: 'bun test --timeout 15000',


### PR DESCRIPTION
## Summary

Closes **`ccsc-l5z` (P3)** — expands the Stryker mutation-testing config from `lib.ts` alone to four security-critical pure modules:

- `lib.ts`
- `policy.ts`
- `manifest.ts`
- `journal.ts`

`server.ts` and `supervisor.ts` remain excluded — `server.ts` has boot-time side effects that confuse the mutator, and `supervisor.ts` mutants routinely time out under the command runner's cold-spawn overhead.

Expanded-scope mutant count: **1 860** (up from 913).

## Two-phase ship

1. **This commit** — config change + `MUTATION_REPORT.md` scope rewrite with in-progress rows. The bd's primary acceptance ("`stryker.conf.mjs` mutate glob covers lib.ts + policy.ts + manifest.ts + journal.ts") is met here.
2. **Follow-up commit on this same branch** — replaces the in-progress rows with final per-file kill/survivor numbers once the ~45-minute local run completes. Background run is in flight as of this PR open; will land before merge.

## Test plan

- [x] `bun run typecheck` → clean (config change only; no TS surface moved)
- [x] `bun test --timeout 15000` → 669 pass, 0 fail (unchanged)
- [x] `bunx stryker run` — verified the expanded config parses and begins mutating all four files (1 860 mutants generated). Full run in flight.
- [ ] Final per-file table committed to `MUTATION_REPORT.md` before merge

Jeremy made me do it
-claude