### PR TITLE
feat(skill): /slack-channel:policy — author policy rules without hand-editing access.json

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -284,6 +284,10 @@ A missing or empty `policy` field means "no authored rules" and is **not** an er
 
 Epic 29-B wired the loader and the `evaluate()` call into the permission-relay handler. The wiring lives in `server.ts` at the `PermissionRequestSchema` handler — see the `decidePermissionRoute()` helper in `lib.ts` for the pure decision-routing logic.
 
+### Authoring rules without hand-editing
+
+The `/slack-channel:policy` skill (`skills/policy/SKILL.md`) is the ergonomic front door to authoring rules. It wraps atomic `access.json` writes with pre-write validation via `scripts/policy-validate.ts`, which runs the same `parsePolicyRules()` + `detectShadowing()` + `detectBroadAutoApprove()` functions the server uses at boot. Subcommands: `list`, `lint`, `add <id> <effect> <json-match> [opts]`, `remove <id>`. The skill complements the hand-edit path; it does not replace it. Hot reload remains unsupported — every successful mutation ends with a "restart the server" notice.
+
 ## File attachments — sendable roots
 
 The `reply` tool can attach files to Slack messages, but only files whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/slack-channel:policy` skill — author policy rules without hand-editing `access.json`** (`ccsc-0ss`). New operator-facing skill at `skills/policy/SKILL.md` with four subcommands: `list` (tabular view of current rules), `lint` (shadow + broad-auto-approve warnings), `add <id> <effect> <json-match> [opts]`, and `remove <id>`. All writes are atomic (`access.json.tmp` → rename) with mode `0o600`. Pre-write validation runs through a new `scripts/policy-validate.ts` wrapper that imports the real `parsePolicyRules()` / `detectShadowing()` / `detectBroadAutoApprove()` from `policy.ts` — the same functions the server uses at boot — so a rule that validates clean here will load clean. Adds a duplicate-id check in the validator to match what ACCESS.md §"Safety checks" documents — server.ts `loadPolicy()` currently does not enforce this; server-side fix tracked as `ccsc-kx8`. Hot reload remains intentionally unsupported; every success message tells the operator to restart the server.
+
 ### Changed
 
 - **Tighten `crap-score` CI threshold from 85 → 30** (`ccsc-510`). Wall 5 ideal now enforced in CI. Prior threshold 85 was a regression-only gate tuned to the previous ceiling; all four outliers (`gate` 32, `handleMessage` 35, interactive-handler anon 39, MCP-dispatch anon 84) are now refactored under ccsc-53g. Current ceiling is 28 (`server.ts`) — ~2 points of headroom. Every future PR must justify any function landing above the Wall 5 ideal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,10 +127,12 @@ echo '{"strict":true, "contexts":["Typecheck"]}' | gh api -X PATCH repos/jeremyl
 - `scripts/gherkin-lint.sh` — Wall 1 Gherkin style check (mirrored from `/audit-tests` skill)
 - `scripts/harness-hash.sh` — tamper-detect pinned artifacts (mirrored from skill)
 - `scripts/bias-count.sh` — test-bias pattern scanner (mirrored from skill with pipefail fix)
+- `scripts/policy-validate.ts` — CLI wrapper around `parsePolicyRules` + `detectShadowing` + `detectBroadAutoApprove` used by `/slack-channel:policy`
 
 ### Skills & docs
 - `skills/configure/SKILL.md` — `/slack-channel:configure` token setup skill
 - `skills/access/SKILL.md` — `/slack-channel:access` pairing/allowlist management skill
+- `skills/policy/SKILL.md` — `/slack-channel:policy` policy-rule authoring skill (validates via `scripts/policy-validate.ts`)
 - `ACCESS.md` — access control schema documentation
 - `CHANGELOG.md` — Keep a Changelog format; every user-visible change lands with a PR entry
 

--- a/scripts/policy-validate.ts
+++ b/scripts/policy-validate.ts
@@ -32,9 +32,10 @@ function die(msg: string): never {
 
 function readInput(): { source: string; raw: unknown } {
   const args = process.argv.slice(2)
-  if (args.length === 0) die('usage: policy-validate.ts <access.json> | --rules <file> | --stdin')
+  const firstArg = args[0]
+  if (!firstArg) die('usage: policy-validate.ts <access.json> | --rules <file> | --stdin')
 
-  if (args[0] === '--stdin') {
+  if (firstArg === '--stdin') {
     const body = readFileSync(0, 'utf8')
     try {
       return { source: '<stdin>', raw: JSON.parse(body) }
@@ -43,21 +44,22 @@ function readInput(): { source: string; raw: unknown } {
     }
   }
 
-  if (args[0] === '--rules') {
-    if (!args[1]) die('--rules requires a path argument')
+  if (firstArg === '--rules') {
+    const rulesPath = args[1]
+    if (!rulesPath) die('--rules requires a path argument')
     try {
-      return { source: args[1]!, raw: JSON.parse(readFileSync(args[1]!, 'utf8')) }
+      return { source: rulesPath, raw: JSON.parse(readFileSync(rulesPath, 'utf8')) }
     } catch (err) {
-      die(`cannot read ${args[1]}: ${err instanceof Error ? err.message : String(err)}`)
+      die(`cannot read ${rulesPath}: ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 
   // Default: treat arg as access.json and pull its `policy` field.
   try {
-    const body = JSON.parse(readFileSync(args[0]!, 'utf8')) as Record<string, unknown>
-    return { source: args[0]!, raw: body.policy ?? [] }
+    const body = JSON.parse(readFileSync(firstArg, 'utf8')) as Record<string, unknown>
+    return { source: firstArg, raw: body.policy ?? [] }
   } catch (err) {
-    die(`cannot read ${args[0]}: ${err instanceof Error ? err.message : String(err)}`)
+    die(`cannot read ${firstArg}: ${err instanceof Error ? err.message : String(err)}`)
   }
 }
 

--- a/scripts/policy-validate.ts
+++ b/scripts/policy-validate.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+// Policy-rule validator used by the `/slack-channel:policy` skill. Thin wrapper
+// around the real loaders in policy.ts so the skill can surface parse errors,
+// shadow warnings, and broad-auto-approve warnings BEFORE the operator writes
+// access.json and restarts the server.
+//
+// Usage:
+//   bun scripts/policy-validate.ts <path-to-access.json>
+//   bun scripts/policy-validate.ts --rules <path-to-rules.json>   (bare array)
+//   bun scripts/policy-validate.ts --stdin                         (bare array on stdin)
+//
+// Exit codes:
+//   0 — parse OK (warnings printed to stderr; --json output on stdout)
+//   1 — parse failure (Zod error or duplicate id) or bad CLI args
+//
+// stdout shape (always valid JSON):
+//   { "ok": true,  "count": N, "shadows": [...], "broads": [...], "duplicates": [] }
+//   { "ok": false, "error": "<message>" }
+
+import { readFileSync } from 'node:fs'
+import {
+  detectBroadAutoApprove,
+  detectShadowing,
+  type PolicyRule,
+  parsePolicyRules,
+} from '../policy.ts'
+
+function die(msg: string): never {
+  process.stdout.write(`${JSON.stringify({ ok: false, error: msg })}\n`)
+  process.exit(1)
+}
+
+function readInput(): { source: string; raw: unknown } {
+  const args = process.argv.slice(2)
+  if (args.length === 0) die('usage: policy-validate.ts <access.json> | --rules <file> | --stdin')
+
+  if (args[0] === '--stdin') {
+    const body = readFileSync(0, 'utf8')
+    try {
+      return { source: '<stdin>', raw: JSON.parse(body) }
+    } catch (err) {
+      die(`invalid JSON on stdin: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  if (args[0] === '--rules') {
+    if (!args[1]) die('--rules requires a path argument')
+    try {
+      return { source: args[1]!, raw: JSON.parse(readFileSync(args[1]!, 'utf8')) }
+    } catch (err) {
+      die(`cannot read ${args[1]}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  // Default: treat arg as access.json and pull its `policy` field.
+  try {
+    const body = JSON.parse(readFileSync(args[0]!, 'utf8')) as Record<string, unknown>
+    return { source: args[0]!, raw: body.policy ?? [] }
+  } catch (err) {
+    die(`cannot read ${args[0]}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+// Duplicate-id check — ACCESS.md §"Safety checks" promises this is fatal at
+// boot but server.ts doesn't actually enforce it today (ccsc-kx8). Do it here
+// so the skill catches the mismatch before the operator writes.
+function findDuplicateIds(rules: readonly PolicyRule[]): string[] {
+  const seen = new Set<string>()
+  const dupes = new Set<string>()
+  for (const rule of rules) {
+    if (seen.has(rule.id)) dupes.add(rule.id)
+    seen.add(rule.id)
+  }
+  return [...dupes]
+}
+
+const { source, raw } = readInput()
+
+let parsed: PolicyRule[]
+try {
+  parsed = parsePolicyRules(raw)
+} catch (err) {
+  die(`parse failed for ${source}: ${err instanceof Error ? err.message : String(err)}`)
+}
+
+const duplicates = findDuplicateIds(parsed)
+if (duplicates.length > 0) {
+  die(`duplicate rule id(s) in ${source}: ${duplicates.join(', ')}`)
+}
+
+const shadows = detectShadowing(parsed)
+const broads = detectBroadAutoApprove(parsed)
+
+process.stdout.write(
+  `${JSON.stringify({
+    ok: true,
+    source,
+    count: parsed.length,
+    shadows: shadows.map((w) => ({ later: w.later, earlier: w.earlier, message: w.message })),
+    broads: broads.map((w) => ({ ruleId: w.ruleId, message: w.message })),
+  })}\n`,
+)

--- a/scripts/policy-validate.ts
+++ b/scripts/policy-validate.ts
@@ -56,8 +56,12 @@ function readInput(): { source: string; raw: unknown } {
 
   // Default: treat arg as access.json and pull its `policy` field.
   try {
-    const body = JSON.parse(readFileSync(firstArg, 'utf8')) as Record<string, unknown>
-    return { source: firstArg, raw: body.policy ?? [] }
+    const body: unknown = JSON.parse(readFileSync(firstArg, 'utf8'))
+    const policy =
+      typeof body === 'object' && body !== null && 'policy' in body
+        ? (body as { policy?: unknown }).policy
+        : undefined
+    return { source: firstArg, raw: policy ?? [] }
   } catch (err) {
     die(`cannot read ${firstArg}: ${err instanceof Error ? err.message : String(err)}`)
   }

--- a/skills/policy/SKILL.md
+++ b/skills/policy/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: policy
+description: Author MCP tool-call policy rules without hand-editing access.json
+version: 1.0.0
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+user-invocable: true
+argument-hint: "list | lint | add <id> <effect> <json-match> [opts] | remove <id>"
+allowed-tools: [Read, Write, Edit, "Bash(cmd:bun)", "Bash(cmd:chmod)"]
+---
+
+# /slack-channel:policy
+
+Author, lint, and remove policy rules under `access.json`'s top-level `policy` field.
+The evaluator (`evaluate()` in `policy.ts`) is the veto layer for every MCP tool
+call — this skill is the ergonomic front door to authoring rules without opening
+`access.json` in a text editor.
+
+See [`ACCESS.md` §Policy schema](../../ACCESS.md#policy-schema-v050) for the full
+rule shape and semantics. This skill does not replace the hand-edit path; it
+complements it.
+
+## Usage
+
+```
+/slack-channel:policy list
+/slack-channel:policy lint
+/slack-channel:policy add <id> <effect> <json-match> [--reason "..."] [--ttl-ms N] [--approvers N] [--priority N]
+/slack-channel:policy remove <id>
+```
+
+**Effect** is one of `auto_approve`, `deny`, `require_approval`.
+**json-match** is a JSON object literal for the `match` field — e.g.
+`'{"tool":"read_file","pathPrefix":"/workspace/docs"}'`. At least one field
+must be populated; the validator rejects empty matches.
+
+### Options by effect
+
+| Effect             | Required               | Optional                                   |
+|--------------------|------------------------|--------------------------------------------|
+| `auto_approve`     | —                      | `--priority`                               |
+| `deny`             | `--reason "…"` (1-200) | `--priority`                               |
+| `require_approval` | —                      | `--ttl-ms`, `--approvers`, `--priority`    |
+
+Defaults: `priority=100`, `ttl-ms=300000` (5 min), `approvers=1`.
+
+## State file
+
+`~/.claude/channels/slack/access.json` — the `policy` field is a JSON array.
+A missing or empty array means "no authored rules" and is valid.
+
+## Instructions
+
+Parse `$ARGUMENTS` and execute the matching subcommand. Before every write, run
+the validator script. Exit cleanly without writing if validation fails.
+
+### `list`
+
+1. Read `~/.claude/channels/slack/access.json`
+2. If the `policy` field is missing or empty, print `No policy rules authored. Evaluator applies defaults — see ACCESS.md §Default-branch behavior.` and return.
+3. Otherwise, print a table: `id | effect | match summary | extras`.
+   - **match summary** — join populated fields: `tool=read_file pathPrefix=/workspace` (omit undefined fields).
+   - **extras** — for `deny` show `reason=…`; for `require_approval` show `ttlMs=… approvers=…`.
+
+### `lint`
+
+1. Run: `bun scripts/policy-validate.ts ~/.claude/channels/slack/access.json`
+2. Parse the JSON output on stdout.
+3. If `ok: false`, show the error message verbatim.
+4. If `ok: true`:
+   - Report `count` rules loaded.
+   - Print each shadow warning as `SHADOW: rule '<later>' is shadowed by '<earlier>'`.
+   - Print each broad warning as `FOOTGUN: <message>`.
+   - If both arrays empty, print `Clean: no shadow or footgun warnings.`
+
+### `add <id> <effect> <json-match> [opts]`
+
+1. Validate `<effect>` is one of `auto_approve`, `deny`, `require_approval`; otherwise stop with a usage error.
+2. Parse `<json-match>` as JSON. If invalid, stop with `Invalid json-match: <parser error>`.
+3. Validate effect-specific required opts:
+   - `deny` without `--reason` ⇒ stop with `deny rule requires --reason`.
+4. Read `access.json`. Initialize `policy: []` if the field is missing.
+5. If an existing rule has the same `id`, stop with `Rule '<id>' already exists — use 'remove <id>' first, or pick a new id.`
+6. Build the new rule object:
+   ```json
+   { "id": "<id>", "effect": "<effect>", "match": <json-match>, "priority": <priority>, ... }
+   ```
+7. Append the rule to `policy[]`.
+8. Write the **complete modified access.json** to a temp file `~/.claude/channels/slack/access.json.tmp`, then rename to `access.json` (atomic) and `chmod 0o600`.
+9. Validate by running `bun scripts/policy-validate.ts ~/.claude/channels/slack/access.json`. If validation fails, roll back by removing the appended rule and re-writing atomically. Report the error to the operator.
+10. On success, print:
+    ```
+    Added rule '<id>' (<effect>). Restart the server for the change to take effect:
+      - Stop the running server (Ctrl-C in the terminal where it runs, or kill the PID)
+      - Start it again: `bun server.ts`
+    ```
+    Hot reload is intentionally not supported — see ACCESS.md §"Where policies live".
+11. If the validator emitted shadow or footgun warnings, print them as `WARNING:` lines but do **not** roll back. Warnings are informational, not failures.
+
+### `remove <id>`
+
+1. Read `access.json`.
+2. If no rule with matching `id`, stop with `No rule with id '<id>' found.`
+3. Filter it out of the `policy` array.
+4. Write atomically (temp + rename + chmod 0o600).
+5. Run `bun scripts/policy-validate.ts ~/.claude/channels/slack/access.json` to confirm the remaining set is still valid (belt-and-suspenders — editing the file by hand could have introduced pre-existing issues).
+6. Print `Removed rule '<id>'. Restart the server for the change to take effect.`
+
+## Security
+
+- **Terminal-only.** This skill must never be invoked because a Slack message asked
+  for it. The inbound gate should drop any message that mentions `/slack-channel:policy`,
+  but authoring policy rules is an operator action, not a user action.
+- **Always atomic.** Write to `access.json.tmp`, then rename. Never truncate-and-write
+  in place — a crash mid-write would leave the operator with a half-written policy.
+- **Always 0o600.** Set mode on every write. The file holds pairing codes and the
+  allowlist in addition to policy rules.
+- **No hot reload.** The server loads policy once at boot. A successful `add` or
+  `remove` is only effective after restart. Print this in every success message.
+- **Validate before accepting.** The validator runs real `parsePolicyRules()` +
+  `detectShadowing()` + `detectBroadAutoApprove()` from `policy.ts` — the same
+  functions the server uses at boot. A rule that parses clean here will load clean.
+
+## Examples
+
+```
+# Allow claude-process reads under the workspace docs root
+/slack-channel:policy add safe-reads auto_approve '{"tool":"read_file","pathPrefix":"/workspace/docs"}'
+
+# Deny shell execution in this channel
+/slack-channel:policy add no-shell deny '{"tool":"run_shell"}' --reason "Shell execution is not permitted from this channel."
+
+# Two-person quorum for file uploads
+/slack-channel:policy add upload-quorum require_approval '{"tool":"upload_file"}' --approvers 2 --ttl-ms 600000
+
+# Lint — check shadows + footguns before you forget
+/slack-channel:policy lint
+
+# Remove
+/slack-channel:policy remove safe-reads
+```

--- a/skills/policy/SKILL.md
+++ b/skills/policy/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 user-invocable: true
-argument-hint: "list | lint | add <id> <effect> <json-match> [opts] | remove <id>"
+argument-hint: "list | lint | add <id> <effect> <json-match> [--reason \"...\"] [--ttl-ms N] [--approvers N] [--priority N] | remove <id>"
 allowed-tools: [Read, Write, Edit, "Bash(cmd:bun)", "Bash(cmd:chmod)"]
 ---
 


### PR DESCRIPTION
## Summary

- Adds new operator skill `skills/policy/SKILL.md` with four subcommands: `list`, `lint`, `add <id> <effect> <json-match> [opts]`, `remove <id>`.
- Adds `scripts/policy-validate.ts` — thin CLI wrapper around the real `parsePolicyRules()` + `detectShadowing()` + `detectBroadAutoApprove()` from `policy.ts`, so skill-authored rules go through the same validation the server uses at boot.
- Validator also implements the **duplicate-id check** that `ACCESS.md §"Safety checks"` promises but `server.ts loadPolicy()` does not enforce today. Drift tracked in **ccsc-kx8**.
- All writes atomic (`access.json.tmp` → rename) with `chmod 0o600`.
- No server-side changes; no hot reload (intentionally). Every success message tells the operator to restart.

Closes **ccsc-0ss**.

## Design notes

- **Validator as a script, not a server flag.** Keeps `server.ts` unchanged (no new boot-time surface) while giving the skill a deterministic pre-write check. Script exit code is the contract: `0` = parse OK (with optional warnings), `1` = refuse to write.
- **Validator output is always valid JSON on stdout.** The skill parses it rather than scraping stderr, so messages can move without breaking the skill.
- **Duplicate-id check lives in the validator, not the server.** Philosophically it should be in `policy.ts` so server and validator share one code path; that's ccsc-kx8. Shipping the check here first means the skill can't silently land dupes today.
- **Roll-back on post-write validation failure.** The skill's `add` path writes, re-validates, and rolls back if the re-validation fails. This covers the "my rule was valid individually but shadows something existing" edge case.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx @biomejs/biome check .` — clean (Biome reformatted the new script's imports on first pass; committed)
- [x] `bun test --timeout 15000` — 682 pass, 0 fail
- [x] `bash scripts/coverage-floor.sh 95` — 98.39% / 98.75%
- [x] `bunx depcruise --config .dependency-cruiser.js .` — no violations (scripts/ is excluded)
- [x] `bash scripts/gherkin-lint.sh --path features/ --strict` — 0 warnings
- [x] `bash scripts/harness-hash.sh --verify` — OK (no pinned files touched)
- [x] `bun audit --audit-level=high --ignore=GHSA-j3q9-mxjg-w52f` — clean
- [x] `bun scripts/crap-score.ts --threshold 30` — 0 over (max 28)
- [x] Smoke tests of `scripts/policy-validate.ts` (empty, valid, malformed, duplicate-id, broad-auto-approve) all return the expected exit codes + JSON shapes.
- [x] Smoke test against a realistic `access.json` with 3 mixed-effect rules — count 3, no warnings.

Jeremy made me do it
-claude