### PR TITLE
docs(policy-validate): correct stale exit-code + stdout-shape header

### DIFF
--- a/scripts/policy-validate.ts
+++ b/scripts/policy-validate.ts
@@ -10,11 +10,12 @@
 //   bun scripts/policy-validate.ts --stdin                         (bare array on stdin)
 //
 // Exit codes:
-//   0 — parse OK (warnings printed to stderr; --json output on stdout)
-//   1 — parse failure (Zod error or duplicate id) or bad CLI args
+//   0 — parse + uniqueness OK (shadow / broad-auto-approve warnings, if any,
+//       are carried inside the stdout JSON — see shape below)
+//   1 — parse failure (Zod error), duplicate rule id, or bad CLI args
 //
-// stdout shape (always valid JSON):
-//   { "ok": true,  "count": N, "shadows": [...], "broads": [...], "duplicates": [] }
+// stdout shape (always a single line of valid JSON):
+//   { "ok": true,  "source": "...", "count": N, "shadows": [...], "broads": [...] }
 //   { "ok": false, "error": "<message>" }
 
 import { readFileSync } from 'node:fs'


### PR DESCRIPTION
## Summary

Addresses an unhandled round-2 Gemini review comment from PR #144 (\`scripts/policy-validate.ts:13\`) that I merged past.

**What was wrong:**
1. Header said \"warnings printed to stderr; --json output on stdout\" — but shadow / broad-auto-approve warnings are actually **inside** the stdout JSON (\`shadows: [...]\`, \`broads: [...]\`).
2. Documented shape showed a \`duplicates: []\` field — removed when ccsc-kx8 (PR #146) moved duplicate-id handling to a throw via \`assertUniqueRuleIds\`. Leftover.
3. Missing \`source\` field in the documented shape, despite the script always emitting it.

**Fix:** three-line doc edit. No behavior change.

## Test plan
- [x] \`bun run typecheck\` — clean
- [x] \`bunx @biomejs/biome check scripts/policy-validate.ts\` — clean
- [x] Runtime smoke — \`echo '[]' | bun scripts/policy-validate.ts --stdin\` returns the exact shape now documented (\`{\"ok\":true,\"source\":\"<stdin>\",\"count\":0,\"shadows\":[],\"broads\":[]}\`).

Jeremy made me do it
-claude