### PR TITLE
refactor(journal): reverse-chunk tail read + single file handle (ccsc-otd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`JournalWriter.open()` — reverse-chunk tail read + single file handle** (`ccsc-otd`). Replaces the full `readFileSync` of the audit log (used only to recover `lastHash` and `nextSeq` from the last line) with a 64 KiB reverse-chunk scan from EOF backwards until the last newline boundary is found. Drops startup memory from O(file size) to O(last line size). Also unifies the previous read-then-fsOpen pair into one `fsOpen('a+', 0o600)` handle: reads use explicit `position` so they don't disturb the append pointer, and writes still go through O_APPEND (atomic EOF writes preserved). The single-handle design incidentally closes the stat-then-use TOCTOU window that triggered the earlier CodeQL `js/file-system-race` pattern on this path. Four new tests in `server.test.ts` exercise the reverse-scan edge cases (pre-existing empty file, trailing-newlines-only, last line straddling a chunk boundary, last line larger than one chunk).
+
 ### Fixed
 
 - **Server-side duplicate-policy-rule-id rejection** (`ccsc-kx8`). `ACCESS.md` §"Safety checks the loader runs" documented duplicate-id rejection as fatal at boot, but `server.ts loadPolicy()` never wired the check — only the validator script shipped with the `/slack-channel:policy` skill caught it. A policy with two rules sharing an `id` would load cleanly and the second rule would be silently unreachable (evaluator uses first-applicable). Adds `assertUniqueRuleIds()` to `policy.ts` (sibling to `detectShadowing` / `detectBroadAutoApprove`; throws rather than returning warnings, matching the documented fatal contract). `server.ts loadPolicy()` now runs it after `parsePolicyRules()` and fails boot with a descriptive error naming every duplicated id. `scripts/policy-validate.ts` swapped its local `findDuplicateIds` helper for the shared primitive so the skill and the server use one code path. Four new tests in `server.test.ts` lock the behavior.

--- a/journal.ts
+++ b/journal.ts
@@ -36,7 +36,6 @@
  */
 
 import { createHash, randomBytes } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
 import { type FileHandle, open as fsOpen, readFile } from 'node:fs/promises'
 import { z } from 'zod'
 import type { SessionKey } from './lib'
@@ -296,6 +295,66 @@ export interface WriterOptions {
  *  than allowing two writers to interleave their hash chains silently. */
 const ACTIVE_PATHS = new Set<string>()
 
+/** Chunk size for the reverse-chunk tail read in `readLastLine`. 64 KiB is
+ *  large enough that realistic audit lines (~300-2000 bytes) fit in a
+ *  single chunk, small enough that the buffer cost stays negligible even
+ *  if recovery runs on a tiny-memory machine. Lines larger than the chunk
+ *  are handled correctly by the loop — it just reads another chunk. */
+const READ_LAST_LINE_CHUNK_SIZE = 64 * 1024
+
+/** Read the last non-empty newline-delimited line from an open file
+ *  handle without loading the whole file into memory. Returns null if
+ *  the file is empty (or contains only trailing newlines). Used by
+ *  `JournalWriter.open` to recover chain state in O(last-line-size)
+ *  memory instead of O(file-size) — the original full-`readFileSync`
+ *  path stopped scaling past the low-MB range per ccsc-otd.
+ *
+ *  Reads with explicit `position` so it doesn't disturb the append
+ *  pointer of an `a+`-opened handle (writes still land at EOF via
+ *  O_APPEND).
+ */
+async function readLastLine(fh: FileHandle): Promise<string | null> {
+  const { size } = await fh.stat()
+  if (size === 0) return null
+
+  // Walk backwards from EOF in chunks, accumulating into `tail`. Stop
+  // when we find a newline that precedes non-empty content (i.e., the
+  // newline before the last line) or when we reach the start of file.
+  let tail = Buffer.alloc(0)
+  let pos = size
+  while (pos > 0) {
+    const readSize = Math.min(READ_LAST_LINE_CHUNK_SIZE, pos)
+    pos -= readSize
+    const buf = Buffer.alloc(readSize)
+    const { bytesRead } = await fh.read(buf, 0, readSize, pos)
+    if (bytesRead === 0) break // unexpected but defensive
+    tail = Buffer.concat([buf.subarray(0, bytesRead), tail])
+
+    // Trim trailing newlines (one or more) before scanning for the
+    // boundary newline so an empty last line (file ends with "\n\n")
+    // is treated as "no content on that line".
+    let end = tail.length
+    while (end > 0 && tail[end - 1] === 0x0a /* '\n' */) end--
+    if (end === 0) {
+      // Chunk(s) so far are all newlines. Keep reading earlier bytes.
+      continue
+    }
+    // Look for the nearest newline strictly before `end`. If found,
+    // the last line is the slice after it (up to `end`).
+    const nl = tail.subarray(0, end).lastIndexOf(0x0a)
+    if (nl !== -1) {
+      return tail.subarray(nl + 1, end).toString('utf8')
+    }
+    // No newline yet and we've reached start-of-file — whole file is
+    // one line. Return it (minus any trailing newlines).
+    if (pos === 0) return tail.subarray(0, end).toString('utf8')
+    // Else: line is longer than what we've read; loop and pull another
+    // chunk.
+  }
+  // Got here only if the whole file was newlines.
+  return null
+}
+
 /** Tamper-evident append-only writer. See audit-journal-architecture.md
  *  §76-161 for the full contract. One writer per process per path.
  *
@@ -369,25 +428,31 @@ export class JournalWriter {
       )
     }
 
+    // Mode 0o600 on creation; 'a+' flag sets O_RDWR|O_APPEND|O_CREAT.
+    // One FileHandle for both the tail read (to recover chain state) and
+    // every subsequent append — closes the stat-then-open TOCTOU window
+    // that a separate read-then-open pair exposes (per CodeQL
+    // js/file-system-race). O_APPEND still guarantees writes land
+    // atomically at EOF per audit-journal-architecture.md §155-160;
+    // reads use explicit `position` and don't move the append pointer.
+    //
+    // FileHandle (fs.open) rather than fs.createWriteStream because
+    // we need explicit `fh.sync()` after every write for durability;
+    // streams buffer and make that awkward. One event = one write =
+    // one fsync for this bead (ccsc-5pi.7). A higher-volume operator
+    // can relax to batch fsync in a future bead.
+    const fh = await fsOpen(opts.path, 'a+', 0o600)
+
     let lastHash: string
     let nextSeq: number
-
-    if (existsSync(opts.path)) {
-      // ccsc-otd: this reads the whole file into memory to recover the
-      // last line. Fine for a per-developer install whose journal is
-      // MB-scale; not fine at GB-scale. Follow-up replaces this with a
-      // reverse-chunked scan (64 KiB windows from EOF until the last
-      // newline). Rotation (Epic 30-B) bounds file size further; this
-      // fallback just stops being the bottleneck once files grow.
-      const content = readFileSync(opts.path, 'utf8')
-      const lines = content.split('\n').filter((line) => line.length > 0)
-      if (lines.length === 0) {
-        // File exists but is empty — treat as fresh chain. Not an error;
-        // happens when an operator pre-created the file with `touch`.
+    try {
+      const lastLine = await readLastLine(fh)
+      if (lastLine === null) {
+        // File is empty (fresh or operator-created with `touch`) —
+        // start a new chain. Not an error.
         lastHash = opts.initialPrevHash ?? sha256Hex(randomBytes(32))
         nextSeq = 1
       } else {
-        const lastLine = lines[lines.length - 1]!
         let parsed: JournalEvent
         try {
           parsed = JournalEvent.parse(JSON.parse(lastLine))
@@ -401,26 +466,14 @@ export class JournalWriter {
         lastHash = parsed.hash
         nextSeq = parsed.seq + 1
       }
-    } else {
-      lastHash = opts.initialPrevHash ?? sha256Hex(randomBytes(32))
-      nextSeq = 1
+    } catch (err) {
+      // Don't leak the file descriptor if anything in the recovery path
+      // throws. ACTIVE_PATHS hasn't been registered yet so we just close.
+      await fh.close().catch(() => {})
+      throw err
     }
 
-    // Mode 0o600 on creation; 'a' flag sets O_APPEND|O_WRONLY|O_CREAT
-    // per audit-journal-architecture.md §155-160. POSIX guarantees
-    // O_APPEND writes land atomically at EOF even with concurrent
-    // writers — the kernel seeks to EOF and writes in one step. We
-    // still serialize via the queue for the hash chain, not for
-    // write-safety.
-    //
-    // FileHandle (fs.open) rather than fs.createWriteStream because
-    // we need explicit `fh.sync()` after every write for durability;
-    // streams buffer and make that awkward. One event = one write =
-    // one fsync for this bead (ccsc-5pi.7). A higher-volume operator
-    // can relax to batch fsync in a future bead.
-    const fh = await fsOpen(opts.path, 'a', 0o600)
     ACTIVE_PATHS.add(opts.path)
-
     return new JournalWriter(fh, lastHash, nextSeq, opts.now ?? ((): Date => new Date()), opts.path)
   }
 

--- a/journal.ts
+++ b/journal.ts
@@ -469,7 +469,16 @@ export class JournalWriter {
     } catch (err) {
       // Don't leak the file descriptor if anything in the recovery path
       // throws. ACTIVE_PATHS hasn't been registered yet so we just close.
-      await fh.close().catch(() => {})
+      // If close itself fails, surface it to stderr (it may indicate a
+      // deeper fs problem) but still throw the original recovery error —
+      // that's the one the operator needs to fix.
+      try {
+        await fh.close()
+      } catch (closeErr) {
+        console.error(
+          `[journal] fh.close failed during open() recovery cleanup for ${opts.path}: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`,
+        )
+      }
       throw err
     }
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -5646,6 +5646,116 @@ describe('JournalWriter', () => {
     ).rejects.toThrow(/valid JournalEvent/)
   })
 
+  // ── Reverse-chunk tail read (ccsc-otd) ───────────────────────────────
+  // readLastLine walks the file backwards in 64 KiB windows. These tests
+  // exercise the paths the original full-readFileSync hid: empty files,
+  // trailing-newline-only files, and multi-chunk straddle lines.
+
+  test('reopen on a pre-existing empty file starts a fresh chain', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    // Operator-typed `touch audit.log` — file exists, size 0.
+    writeFileSync(logPath, '', { mode: 0o600 })
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    try {
+      expect(w.headHash).toBe(stableAnchor)
+      expect(w.nextSequenceNumber).toBe(1)
+      const ev = await w.writeEvent(sysBoot)
+      expect(ev.seq).toBe(1)
+      expect(ev.prevHash).toBe(stableAnchor)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('reopen on a file that is only trailing newlines starts a fresh chain', async () => {
+    const { JournalWriter } = await import('./journal.ts')
+    writeFileSync(logPath, '\n\n\n', { mode: 0o600 })
+    const w = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+    })
+    try {
+      expect(w.headHash).toBe(stableAnchor)
+      expect(w.nextSequenceNumber).toBe(1)
+    } finally {
+      await w.close()
+    }
+  })
+
+  test('reopen recovers correctly when the last line straddles 64 KiB chunk boundaries', async () => {
+    // Write a chain whose body is large enough that the tail scan has to
+    // pull multiple 64 KiB chunks to find the boundary newline. We do
+    // this by writing many events until the file is comfortably over
+    // 192 KiB (three chunks). Exercises the loop in readLastLine.
+    const { JournalWriter } = await import('./journal.ts')
+    const w1 = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    let lastWritten!: Awaited<ReturnType<typeof w1.writeEvent>>
+    try {
+      // Each session.activate event is ~250-350 bytes framed. 1,000
+      // events ⇒ ~300 KiB file, well past a single 64 KiB chunk.
+      for (let i = 0; i < 1_000; i++) {
+        lastWritten = await w1.writeEvent({
+          kind: 'session.activate',
+          correlationId: `chunk-straddle-${i.toString().padStart(6, '0')}`,
+        })
+      }
+    } finally {
+      await w1.close()
+    }
+    expect(lastWritten.seq).toBe(1_000)
+
+    // Reopen and verify the recovered head is the last-written event,
+    // not something the tail scanner misattributed from an earlier chunk.
+    const w2 = await JournalWriter.open({ path: logPath })
+    try {
+      expect(w2.headHash).toBe(lastWritten.hash)
+      expect(w2.nextSequenceNumber).toBe(1_001)
+    } finally {
+      await w2.close()
+    }
+  })
+
+  test('reopen recovers when the last line itself is larger than one 64 KiB chunk', async () => {
+    // Write a single event whose framed JSON exceeds 64 KiB so the tail
+    // scanner has to read multiple chunks just to assemble the last line
+    // before finding its preceding newline. A large `correlationId`
+    // padding produces a line >64 KiB without needing new event shapes.
+    const { JournalWriter } = await import('./journal.ts')
+    const huge = 'x'.repeat(80 * 1024) // 80 KiB of body, > one chunk
+    const w1 = await JournalWriter.open({
+      path: logPath,
+      initialPrevHash: stableAnchor,
+      now: () => fixedNow,
+    })
+    let ev1!: Awaited<ReturnType<typeof w1.writeEvent>>
+    let ev2!: Awaited<ReturnType<typeof w1.writeEvent>>
+    try {
+      ev1 = await w1.writeEvent({ kind: 'session.activate', correlationId: 'small' })
+      ev2 = await w1.writeEvent({ kind: 'session.activate', correlationId: huge })
+    } finally {
+      await w1.close()
+    }
+
+    const w2 = await JournalWriter.open({ path: logPath })
+    try {
+      expect(w2.headHash).toBe(ev2.hash)
+      expect(w2.nextSequenceNumber).toBe(3)
+      // And the first event is still reachable through the chain — the
+      // writer didn't accidentally re-root.
+      expect(ev2.prevHash).toBe(ev1.hash)
+    } finally {
+      await w2.close()
+    }
+  })
+
   test('concurrent writeEvent calls serialize in call order', async () => {
     const { JournalWriter } = await import('./journal.ts')
     const w = await JournalWriter.open({


### PR DESCRIPTION
## Summary

Closes **ccsc-otd**. Originally flagged in Gemini review on PR #69.

\`JournalWriter.open()\` previously \`readFileSync\`'d the entire audit log just to pull \`lastHash\` and \`nextSeq\` off the last line — **O(file size)** in both memory and startup time. Fine at MB-scale, stops scaling past that.

## Changes

- **Reverse-chunk tail scan.** New module-private \`readLastLine(fh)\` helper reads 64 KiB windows from EOF backwards until it finds the newline preceding the last non-empty line. Memory drops to **O(last line size)**. Chunk size is a named constant (\`READ_LAST_LINE_CHUNK_SIZE\`).
- **Single file handle.** Unifies the old pattern (\`readFileSync\` → separate \`fsOpen('a')\`) into **one** \`fsOpen('a+', 0o600)\` throughout. Reads use explicit \`position\` so they don't disturb the O_APPEND pointer; writes still land atomically at EOF. **Incidentally closes the stat-then-use TOCTOU window** that triggered the earlier CodeQL \`js/file-system-race\` pattern (alert #22, dismissed as out-of-threat-model yesterday but now structurally gone).
- **FD safety.** If recovery throws (invalid JSON last line, etc.), the handle is \`.close()\`d before the throw propagates — \`ACTIVE_PATHS\` is registered only on the happy path, so no leak and no orphaned registration.
- **Dropped \`existsSync\` + \`readFileSync\` imports** — both are gone from \`journal.ts\`.

## Edge cases — 4 new tests

| Case | What it exercises |
|---|---|
| Pre-existing empty file (\`touch audit.log\`) | Fresh chain starts cleanly from \`initialPrevHash\` |
| File of only trailing newlines (\`\\\\n\\\\n\\\\n\`) | Scanner loops and terminates at pos=0 with \`return null\` |
| 1,000-event file (~300 KiB) | Tail straddles multiple 64 KiB chunks |
| Single event with 80 KiB \`correlationId\` body | Last line itself exceeds one chunk — scanner must aggregate |

Existing tests still covering the happy paths:
- First write on empty file seeds from \`initialPrevHash\`
- Reopen recovers \`headHash\` + \`nextSequenceNumber\` from disk
- Reopen rejects on invalid-JSON last line
- Single-writer invariant still enforced

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bunx @biomejs/biome check .\` — clean
- [x] \`bun test --timeout 15000\` — **690 pass / 0 fail / 4,021 expects** (was 686 / 4,009)
- [x] \`bash scripts/coverage-floor.sh 95\` — 98.46% line / 98.20% func (floor 95%)
- [x] \`bunx depcruise --config .dependency-cruiser.js .\` — no violations
- [x] \`bash scripts/harness-hash.sh --verify\` — OK
- [x] \`bun scripts/crap-score.ts --threshold 30\` — max 28, 0 over
- [x] \`bash scripts/gherkin-lint.sh --path features/ --strict\` — 0 warnings
- [x] \`bun audit --audit-level=high --ignore=GHSA-j3q9-mxjg-w52f\` — clean

Jeremy made me do it
-claude