### PR TITLE
feat(journal): wire pairing.expired events via pruneExpired return [bz-ccsc-rc1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`pairing.expired` journal events** (`ccsc-rc1`). `lib.ts pruneExpired()` now returns the `[code, entry]` tuples it removed (previously `void`); `server.ts getAccess()` iterates that return and emits one `pairing.expired` event per expiry (minimal-disclosure payload: `{ channel: entry.chatId }`, matching the `pairing.issued` shape). Static-mode boot-time pruning remains silent because the journal isn't open at module-load time — static mode downgrades `dmPolicy` to `allowlist`, so no new pending entries are created after boot and residue is cleared once without an audit trace (documented inline). Audit EventKind coverage moves from 17/19 to 18/19 of the v0.5.0-declared kinds — `pairing.accepted` remains unwired (tracked in `ccsc-scv`, which needs an IPC design decision since the skill runs outside the server process). Four new unit tests in `server.test.ts` cover the new return value (empty pending, nothing-expired, mixed expired/live, multiple expiries).
+
 ### Changed
 
 - **`JournalWriter.open()` — reverse-chunk tail read + single file handle** (`ccsc-otd`). Replaces the full `readFileSync` of the audit log (used only to recover `lastHash` and `nextSeq` from the last line) with a 64 KiB reverse-chunk scan from EOF backwards until the last newline boundary is found. Drops startup memory from O(file size) to O(last line size). Also unifies the previous read-then-fsOpen pair into one `fsOpen('a+', 0o600)` handle: reads use explicit `position` so they don't disturb the append pointer, and writes still go through O_APPEND (atomic EOF writes preserved). The single-handle design incidentally closes the stat-then-use TOCTOU window that triggered the earlier CodeQL `js/file-system-race` pattern on this path. Four new tests in `server.test.ts` exercise the reverse-scan edge cases (pre-existing empty file, trailing-newlines-only, last line straddling a chunk boundary, last line larger than one chunk).

--- a/lib.ts
+++ b/lib.ts
@@ -659,12 +659,9 @@ export function defaultAccess(): Access {
  *  only need the side-effect can ignore it. */
 export function pruneExpired(access: Access): Array<[string, PendingEntry]> {
   const now = Date.now()
-  const pruned: Array<[string, PendingEntry]> = []
-  for (const [code, entry] of Object.entries(access.pending)) {
-    if (entry.expiresAt <= now) {
-      pruned.push([code, entry])
-      delete access.pending[code]
-    }
+  const pruned = Object.entries(access.pending).filter(([, entry]) => entry.expiresAt <= now)
+  for (const [code] of pruned) {
+    delete access.pending[code]
   }
   return pruned
 }

--- a/lib.ts
+++ b/lib.ts
@@ -650,13 +650,23 @@ export function defaultAccess(): Access {
   }
 }
 
-export function pruneExpired(access: Access): void {
+/** Prune expired pending pairings and return what was removed.
+ *
+ *  Mutates `access.pending` in place by deleting entries whose
+ *  `expiresAt <= Date.now()`. Returns the `[code, entry]` tuples that
+ *  were removed so callers can journal a `pairing.expired` event per
+ *  expiry (ccsc-rc1). The return value is advisory — callers that
+ *  only need the side-effect can ignore it. */
+export function pruneExpired(access: Access): Array<[string, PendingEntry]> {
   const now = Date.now()
+  const pruned: Array<[string, PendingEntry]> = []
   for (const [code, entry] of Object.entries(access.pending)) {
     if (entry.expiresAt <= now) {
+      pruned.push([code, entry])
       delete access.pending[code]
     }
   }
+  return pruned
 }
 
 export function generateCode(): string {

--- a/server.test.ts
+++ b/server.test.ts
@@ -1381,9 +1381,7 @@ describe('pruneExpired', () => {
       },
     })
     const pruned = pruneExpired(access)
-    expect(pruned).toHaveLength(1)
-    expect(pruned[0]![0]).toBe('OLD')
-    expect(pruned[0]![1]).toEqual(oldEntry)
+    expect(pruned).toEqual([['OLD', oldEntry]])
   })
 
   test('returned entries carry chatId for journaling (ccsc-rc1)', () => {

--- a/server.test.ts
+++ b/server.test.ts
@@ -1343,6 +1343,77 @@ describe('pruneExpired', () => {
     pruneExpired(access)
     expect(Object.keys(access.pending)).toHaveLength(0)
   })
+
+  test('returns empty array when nothing expired (ccsc-rc1)', () => {
+    const access = makeAccess({
+      pending: {
+        LIVE: {
+          senderId: 'U1',
+          chatId: 'D1',
+          createdAt: Date.now(),
+          expiresAt: Date.now() + 999999,
+          replies: 1,
+        },
+      },
+    })
+    const pruned = pruneExpired(access)
+    expect(pruned).toEqual([])
+  })
+
+  test('returns [code, entry] pairs for expired entries (ccsc-rc1)', () => {
+    const oldEntry = {
+      senderId: 'U_OLD',
+      chatId: 'D_OLD',
+      createdAt: 0,
+      expiresAt: 1,
+      replies: 3,
+    }
+    const access = makeAccess({
+      pending: {
+        OLD: oldEntry,
+        FRESH: {
+          senderId: 'U_FRESH',
+          chatId: 'D_FRESH',
+          createdAt: Date.now(),
+          expiresAt: Date.now() + 999999,
+          replies: 1,
+        },
+      },
+    })
+    const pruned = pruneExpired(access)
+    expect(pruned).toHaveLength(1)
+    expect(pruned[0]![0]).toBe('OLD')
+    expect(pruned[0]![1]).toEqual(oldEntry)
+  })
+
+  test('returned entries carry chatId for journaling (ccsc-rc1)', () => {
+    const access = makeAccess({
+      pending: {
+        A: {
+          senderId: 'U_A',
+          chatId: 'D_A',
+          createdAt: 0,
+          expiresAt: 1,
+          replies: 1,
+        },
+        B: {
+          senderId: 'U_B',
+          chatId: 'D_B',
+          createdAt: 0,
+          expiresAt: 1,
+          replies: 1,
+        },
+      },
+    })
+    const pruned = pruneExpired(access)
+    const chatIds = pruned.map(([, entry]) => entry.chatId).sort()
+    expect(chatIds).toEqual(['D_A', 'D_B'])
+  })
+
+  test('returns empty array when pending is empty (ccsc-rc1)', () => {
+    const access = makeAccess()
+    expect(pruneExpired(access)).toEqual([])
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/server.ts
+++ b/server.ts
@@ -250,6 +250,11 @@ let staticAccess: Access | null = null
 
 if (STATIC_MODE) {
   staticAccess = loadAccess()
+  // Boot-time prune: journal is not open yet at module-load time, so
+  // expiries detected here cannot emit pairing.expired. Static mode
+  // downgrades dmPolicy from 'pairing' to 'allowlist' below, so no new
+  // pending entries are created after boot — leftover entries are
+  // pre-boot residue and are cleared silently.
   pruneExpired(staticAccess)
   // Downgrade pairing to allowlist in static mode
   if (staticAccess.dmPolicy === 'pairing') {
@@ -260,7 +265,18 @@ if (STATIC_MODE) {
 function getAccess(): Access {
   if (STATIC_MODE && staticAccess) return staticAccess
   const access = loadAccess()
-  pruneExpired(access)
+  // Journal every expiry surfaced by this prune so the audit log
+  // records pairing lifecycle closure (ccsc-rc1). Matches the payload
+  // shape used by `pairing.issued` at the pair-handling site —
+  // minimal disclosure, just the originating channel.
+  for (const [, entry] of pruneExpired(access)) {
+    journalWrite({
+      kind: 'pairing.expired',
+      outcome: 'n/a',
+      actor: 'system',
+      input: { channel: entry.chatId },
+    })
+  }
   return access
 }
 


### PR DESCRIPTION
## Summary

Closes **ccsc-rc1** (scoped down from "pairing.accepted + pairing.expired" to just `pairing.expired`; `pairing.accepted` split to new bead **ccsc-scv** which needs an IPC design decision — the access skill runs outside the server process).

Moves audit EventKind coverage from **17/19 → 18/19** of the kinds declared in v0.5.0.

## The change

- **`lib.ts pruneExpired()`** — return type changed from `void` to `Array<[string, PendingEntry]>`. Callers that only need the mutation (existing tests, static-mode boot) can keep ignoring the return; callers that want to journal per-expiry use it.
- **`server.ts getAccess()`** — iterates the return and emits one `pairing.expired` event per expiry. Payload matches `pairing.issued`: `{ channel: entry.chatId }` (minimal disclosure — no code, no senderId). `actor: 'system'`, `outcome: 'n/a'` mirror the issuance-side precedent.
- **`server.ts` static-mode boot-time prune (line 253)** — left silent. The journal is not opened until `main()` runs, so events emitted at module-load would be dropped. Static mode downgrades `dmPolicy` from `'pairing'` to `'allowlist'` on the next line, so no new pending entries are created after boot — any leftover entries are pre-boot residue. Documented inline.

## What's NOT in this PR

- `pairing.accepted` — deferred to `ccsc-scv`. The `/slack-channel:access pair <code>` skill runs in Claude Code's process, not the MCP server's. Three design options (file-watcher on access.json, skill writes a drain-me journal file, or move pairing acceptance into server.ts with SIGUSR1/named-pipe signalling). Each has different tradeoffs on raciness, IPC surface area, and skill-semantics disruption. That design decision is its own PR.
- `correlationId` wiring to match issued↔expired 1:1. Today neither event carries one — auditors can reconstruct by channel + time window. Out of scope; future bead if needed.

## Test plan

- [x] 4 new unit tests in `server.test.ts` covering the new return value:
  - Empty array when nothing expired
  - `[code, entry]` pair for each expired entry
  - Returned entries carry `chatId` (what the journaler needs)
  - Empty array when `pending` is empty
- [x] All 5 pre-existing `pruneExpired` tests still pass (discard the return value — backward compatible)
- [x] `bun run typecheck` — clean
- [x] `bun test --timeout 15000` — **694/694 pass** (up from 690), 4,027 expect() calls
- [x] `bunx @biomejs/biome check .` — clean
- [x] `bash scripts/coverage-floor.sh 95` — line 98.46% / func 98.82% (floor 95%)
- [x] `bunx depcruise --config .dependency-cruiser.js .` — no violations
- [x] `bash scripts/gherkin-lint.sh --path features/ --strict` — 0 errors
- [x] `bash scripts/harness-hash.sh --verify` — OK
- [x] `bun scripts/crap-score.ts --threshold 30` — max 28, 0 over threshold

Jeremy made me do it
-claude