### PR TITLE
feat: admin commands (!clear/!restart) and thinking indicator

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "slack": {
-      "command": "bun",
-      "args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--shell=bun", "--silent", "start"]
+      "command": "${CLAUDE_PLUGIN_ROOT}/node_modules/.bin/tsx",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server.ts"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "@slack/socket-mode": "2.0.6",
     "@slack/web-api": "7.15.0",
+    "tsx": "^4.21.0",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/server.ts
+++ b/server.ts
@@ -7,7 +7,6 @@
  *
  * SPDX-License-Identifier: MIT
  */
-
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
@@ -860,7 +859,6 @@ async function handleMessage(event: unknown): Promise<void> {
   if (isDuplicateEvent(ev, seenEvents, Date.now(), EVENT_DEDUP_TTL_MS)) return
 
   const result = await gate(event)
-
   switch (result.action) {
     case 'drop':
       return

--- a/server.ts
+++ b/server.ts
@@ -16,6 +16,7 @@ import {
 import { z } from 'zod'
 import { SocketModeClient } from '@slack/socket-mode'
 import { WebClient } from '@slack/web-api'
+import { execSync } from 'child_process'
 import { homedir } from 'os'
 import { join, resolve } from 'path'
 import {
@@ -935,6 +936,29 @@ async function handleMessage(event: unknown): Promise<void> {
         return // Don't forward as chat
       }
 
+      // Admin commands from allowlisted users — intercept before normal delivery
+      if (result.access!.allowFrom.includes(ev['user'] as string)) {
+        const cmd = msgText.toLowerCase()
+        if (cmd === '!clear' || cmd === '!restart') {
+          const tmuxSession = process.env.SLACK_TMUX_SESSION || 'slack'
+          try {
+            if (cmd === '!clear') {
+              execSync(`tmux send-keys -t ${tmuxSession} '/clear' Enter`)
+            } else {
+              execSync(`tmux send-keys -t ${tmuxSession} '/exit' Enter`)
+            }
+            await web.reactions.add({
+              channel: channelId,
+              timestamp: ev['ts'] as string,
+              name: cmd === '!clear' ? 'recycle' : 'arrows_counterclockwise',
+            })
+          } catch (err) {
+            console.error(`[slack] admin command ${cmd} failed:`, err)
+          }
+          return
+        }
+      }
+
       const access = result.access!
       const userName = await resolveUserName(ev['user'] as string)
 
@@ -985,6 +1009,14 @@ async function handleMessage(event: unknown): Promise<void> {
       if (botUserId) {
         text = text.replace(new RegExp(`<@${botUserId}>\\s*`, 'g'), '').trim()
       }
+
+      // Send thinking indicator to Slack before forwarding to Claude
+      const thinkingThreadTs = (ev['thread_ts'] as string | undefined) || (ev['ts'] as string)
+      web.chat.postMessage({
+        channel: ev['channel'] as string,
+        text: '💭 Thinking...',
+        thread_ts: thinkingThreadTs,
+      }).catch(() => {})
 
       // Push into Claude Code session via MCP notification
       mcp.notification({


### PR DESCRIPTION
## Summary

- **Admin commands**: allowlisted Slack users can send `!clear` (reset conversation) or `!restart` (exit session) — executed via tmux send-keys, confirmed with emoji reaction
- **Thinking indicator**: posts "💭 Thinking..." to the thread immediately on message receipt, before forwarding to Claude
- **tsx runtime**: switched `.mcp.json` to use `tsx` as default command for Node.js compatibility on environments where Bun has issues

Closes #156

## Test plan

- [ ] Send `!clear` from an allowlisted user — verify ♻️ reaction and `/clear` fires in tmux
- [ ] Send `!restart` — verify 🔄 reaction and `/exit` fires
- [ ] Send `!clear` from a non-allowlisted user — verify it's treated as a normal message
- [ ] Send a normal message — verify "💭 Thinking..." appears in thread before Claude responds
- [ ] Verify `npx tsx server.ts` starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)