### PR TITLE
Always reply in a thread, anchored on the inbound's ts

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -2496,9 +2496,9 @@ async function deliverEvent(ev: Record<string, unknown>, access: Access): Promis
     ts: ev.ts as string,
   }
 
-  if (ev.thread_ts) {
-    meta.thread_ts = ev.thread_ts as string
-  }
+  // Always reply in a thread: existing anchor if any, else the
+  // inbound message's own ts so the bot starts a new thread.
+  meta.thread_ts = (ev.thread_ts as string | undefined) ?? (ev.ts as string)
 
   const evFiles = ev.files as any[] | undefined
   if (evFiles?.length) {


### PR DESCRIPTION
## Problem

When a user @-mentions the bot at channel-main level (not inside an existing thread), the bot's reply currently lands top-level. When they @-mention inside a thread, the reply lands in-thread. This inconsistency clutters the channel feed in busy operations channels — some replies live in the main feed, some in threads.

## Fix

In `handleMessage`'s inbound meta builder, set `meta.thread_ts` unconditionally:

```diff
-  if (ev.thread_ts) {
-    meta.thread_ts = ev.thread_ts as string
-  }
+  // Always reply in a thread: existing anchor if any, else the
+  // inbound message's own ts so the bot starts a new thread.
+  meta.thread_ts = (ev.thread_ts as string | undefined) ?? (ev.ts as string)
```

- Existing-thread mentions: `ev.thread_ts` is already non-empty → unchanged.
- Channel-main mentions: `ev.thread_ts` is undefined → fall back to `ev.ts` (the inbound message's own timestamp), which the Slack API treats as the anchor for a new thread.

The reply tool's `executeReply` already forwards `thread_ts` correctly when claude provides it — no change needed there.

## Tested in production

Running as a local patch in our Hearth deployment for ~2 days. Behavior is consistent:

- `@Hearth ping` at channel-main level: new thread starts under the user's message; pong lives inside.
- `@Hearth ping` inside an existing thread: reply continues in that thread (unchanged behavior).

No regressions observed across ~50 bot turns across 4 channels.

## Notes

- One-line behavior change; ~6-line diff including the explanatory comment.
- No new tests added — the change is small and the existing thread-handling tests in `executeReply` still pass since the only difference is what gets passed into the meta builder, not what `executeReply` does with `thread_ts`.

Happy to add tests if you'd like — would naturally go in a `handleMessage` test for the meta builder. Let me know.