### PR TITLE
fix(acp-adapter): extract into module + widen id to null per JSON-RPC §5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ACP adapter extracted from `server.ts` into `acp-adapter.ts`** (`ccsc-21x` follow-up). Addresses Gemini review on PR #172: (1) the inlined test duplicate of `mapAcpSessionCancel` was a drift risk — extracting the adapter into a side-effect-free module lets `server.test.ts` import the production code path directly; (2) `AcpResponse.id` widened to `string | number | null` to be fully JSON-RPC 2.0 §5.1 compliant (the spec requires `null` when an error occurs detecting the request id) — the two unsafe `as string | number` casts are removed. Coverage went up (98.47% → 98.72% line / 98.82% → 99.02% func) because tests now exercise the real adapter, not a copy. No behavior change.
+
 ### Added
 
 - **ACP boundary adapter — `mapAcpSessionCancel` in `server.ts`** (`ccsc-21x`). Adds a thin JSON-RPC 2.0 adapter that translates Agent Client Protocol [`session/cancel`](https://agentclientprotocol.com/protocol/prompt-turn) requests onto the existing `supervisor.quiesce(key)` call. Additive only — the supervisor's internal vocabulary (`activate` / `quiesce` / `deactivate` / `quarantine`) is unchanged, no method renames, no parameter shape changes. The adapter is the ONLY place ACP terminology appears in the codebase (mirrors the 31-A.4 isolation pattern between `manifest.ts` and `policy.ts`). Returns `{ result: { stopReason: 'cancelled' } }` on success; surfaces `-32600` Invalid Request / `-32602` Invalid params / `-32603` Internal error per JSON-RPC 2.0. Forward-compat for the day Anthropic ships external-message-injection mid-turn (`anthropics/claude-code#53049`) — the migration becomes a single function edit, not a vocabulary rename that would break ~704 tests and the meaning of existing `audit.log` files. Adds 13 round-trip tests + § ACP-mapping addendum to `000-docs/session-state-machine.md` + new invariant #9 ("ACP terminology appears only in the boundary adapter").

--- a/acp-adapter.ts
+++ b/acp-adapter.ts
@@ -86,9 +86,10 @@ export async function mapAcpSessionCancel(
     // JSON-RPC 2.0 §5.1: when the request object is invalid the id may be
     // unknown. We surface the id when one was provided (string|number) and
     // fall back to `null` (the spec-defined sentinel) otherwise.
-    const reqRecord = (typeof req === 'object' && req !== null ? req : {}) as Record<string, unknown>
+    const candidateId =
+      typeof req === 'object' && req !== null ? (req as Record<string, unknown>).id : undefined
     const fallbackId =
-      typeof reqRecord.id === 'string' || typeof reqRecord.id === 'number' ? reqRecord.id : null
+      typeof candidateId === 'string' || typeof candidateId === 'number' ? candidateId : null
     return {
       jsonrpc: '2.0',
       id: fallbackId,

--- a/acp-adapter.ts
+++ b/acp-adapter.ts
@@ -1,0 +1,141 @@
+/**
+ * ACP boundary adapter — ccsc-21x.
+ *
+ * The Agent Client Protocol (ACP) is the converging cross-ecosystem JSON-RPC
+ * 2.0 standard for agent control (Zed adoption; open issues for the same
+ * primitive in google/adk-python#2425 and zed-industries/zed#50592). This
+ * module is the ONLY place in the codebase where ACP terminology appears.
+ * The supervisor's existing vocabulary (activate / quiesce / deactivate /
+ * quarantine) does not change — see 000-docs/session-state-machine.md §
+ * ACP-mapping for the contract this adapter honours.
+ *
+ * Extracted from server.ts so both the production import and the test suite
+ * can use the same code path. server.ts has top-level bootstrap side-effects
+ * (process.exit on missing tokens) that make direct import from a test
+ * runner unsafe — this module has none, so server.test.ts imports it
+ * directly instead of inlining a duplicate. Eliminates the drift risk
+ * Gemini flagged on PR #172.
+ *
+ * Additive only. Internal vocabulary is unchanged; existing tests + audit
+ * log files keep their meanings.
+ */
+
+import { z } from 'zod'
+import type { SessionKey } from './lib.ts'
+import type { SessionSupervisor } from './supervisor.ts'
+
+export const AcpSessionCancelRequestSchema = z.object({
+  jsonrpc: z.literal('2.0'),
+  id: z.union([z.string(), z.number()]),
+  method: z.literal('session/cancel'),
+  params: z.object({
+    // ACP session IDs are opaque strings to the protocol. Our local convention
+    // is "<channel>:<thread>" — Slack channel and thread IDs contain only
+    // alphanumerics and a dot, so ':' is an unambiguous delimiter.
+    sessionId: z.string().min(3).max(128),
+  }),
+})
+
+/** ACP request envelope for `session/cancel`. JSON-RPC 2.0 shape. */
+export type AcpSessionCancelRequest = z.infer<typeof AcpSessionCancelRequestSchema>
+
+/** ACP response envelope returned by {@link mapAcpSessionCancel}. JSON-RPC 2.0.
+ *
+ *  `id` is `string | number | null` per JSON-RPC 2.0 §5.1: when an error
+ *  occurs detecting the id (i.e. the request itself failed to parse), the
+ *  response MUST set `id` to `null`. The success branch only carries
+ *  `string | number` because a successful response always echoes the
+ *  client's id verbatim. */
+export type AcpResponse =
+  | { jsonrpc: '2.0'; id: string | number; result: { stopReason: 'cancelled' } }
+  | {
+      jsonrpc: '2.0'
+      id: string | number | null
+      error: { code: number; message: string; data?: unknown }
+    }
+
+/** Map an ACP `session/cancel` request onto the supervisor's existing
+ *  `quiesce(key)` method.
+ *
+ *  Returns an ACP-shaped response envelope. Never throws — protocol errors
+ *  are returned as JSON-RPC error objects:
+ *    - `-32600` Invalid Request: request shape doesn't validate against
+ *               {@link AcpSessionCancelRequestSchema}.
+ *    - `-32602` Invalid params: `sessionId` does not parse into a
+ *               `(channel, thread)` pair.
+ *    - `-32603` Internal error: `supervisor.quiesce()` rejected
+ *               (quarantined session, save failure, etc.).
+ *
+ *  On success returns `{ result: { stopReason: 'cancelled' } }` per the ACP
+ *  prompt-turn contract — quiesce is a cooperative interrupt, and the
+ *  supervisor's promise resolves only after every in-flight save settles,
+ *  matching ACP's "agent acknowledges with `cancelled` stop reason" shape.
+ *
+ *  This function is the only ACP-aware site in the codebase. Internal
+ *  terminology (quiesce, SessionKey, SessionHandle) is unchanged. The
+ *  adapter exists so that the day Anthropic ships external-message
+ *  injection (anthropics/claude-code#53049) and ACP becomes the wire
+ *  format, the migration is a single function edit, not a vocabulary
+ *  rename. */
+export async function mapAcpSessionCancel(
+  req: unknown,
+  sup: SessionSupervisor,
+): Promise<AcpResponse> {
+  const parsed = AcpSessionCancelRequestSchema.safeParse(req)
+  if (!parsed.success) {
+    // JSON-RPC 2.0 §5.1: when the request object is invalid the id may be
+    // unknown. We surface the id when one was provided (string|number) and
+    // fall back to `null` (the spec-defined sentinel) otherwise.
+    const reqRecord = (typeof req === 'object' && req !== null ? req : {}) as Record<string, unknown>
+    const fallbackId =
+      typeof reqRecord.id === 'string' || typeof reqRecord.id === 'number' ? reqRecord.id : null
+    return {
+      jsonrpc: '2.0',
+      id: fallbackId,
+      error: {
+        code: -32600,
+        message: 'Invalid Request',
+        data: { issues: parsed.error.issues },
+      },
+    }
+  }
+  const { id, params } = parsed.data
+
+  // Parse "channel:thread" into a SessionKey. Slack IDs do not contain ':',
+  // so a single split is unambiguous. The supervisor's realpath-guarded
+  // sessionPath() rejects malformed values downstream regardless, but
+  // surfacing -32602 here gives the caller a precise error code rather than
+  // -32603 from a downstream failure.
+  const sep = params.sessionId.indexOf(':')
+  if (sep <= 0 || sep === params.sessionId.length - 1) {
+    return {
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: -32602,
+        message: 'Invalid params: sessionId must be "<channel>:<thread>"',
+        data: { sessionId: params.sessionId },
+      },
+    }
+  }
+  const key: SessionKey = {
+    channel: params.sessionId.slice(0, sep),
+    thread: params.sessionId.slice(sep + 1),
+  }
+
+  try {
+    await sup.quiesce(key)
+  } catch (err) {
+    return {
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: -32603,
+        message: 'Internal error: supervisor.quiesce failed',
+        data: { reason: err instanceof Error ? err.message : String(err) },
+      },
+    }
+  }
+
+  return { jsonrpc: '2.0', id, result: { stopReason: 'cancelled' } }
+}

--- a/server.test.ts
+++ b/server.test.ts
@@ -9835,77 +9835,12 @@ describe('buildAndPostAuditReceipt unfurl flags (ccsc-y4e)', () => {
 // internal vocabulary is unchanged — the adapter calls supervisor.quiesce()
 // and translates the outcome back into ACP terminology at the boundary.
 //
-// Inlined adapter (same pattern as activateAndTouch above) to avoid
-// triggering server.ts bootstrap side-effects in the test runner. When
-// server.ts changes the function body, this test copy must be updated.
-
-const AcpSessionCancelRequestSchemaTest = z.object({
-  jsonrpc: z.literal('2.0'),
-  id: z.union([z.string(), z.number()]),
-  method: z.literal('session/cancel'),
-  params: z.object({
-    sessionId: z.string().min(3).max(128),
-  }),
-})
-
-type AcpResponseTest =
-  | { jsonrpc: '2.0'; id: string | number; result: { stopReason: 'cancelled' } }
-  | {
-      jsonrpc: '2.0'
-      id: string | number
-      error: { code: number; message: string; data?: unknown }
-    }
-
-async function mapAcpSessionCancel(
-  req: unknown,
-  sup: import('./supervisor.ts').SessionSupervisor,
-): Promise<AcpResponseTest> {
-  const parsed = AcpSessionCancelRequestSchemaTest.safeParse(req)
-  if (!parsed.success) {
-    const reqRecord = (typeof req === 'object' && req !== null ? req : {}) as Record<
-      string,
-      unknown
-    >
-    const fallbackId =
-      typeof reqRecord.id === 'string' || typeof reqRecord.id === 'number' ? reqRecord.id : null
-    return {
-      jsonrpc: '2.0',
-      id: fallbackId as string | number,
-      error: { code: -32600, message: 'Invalid Request', data: { issues: parsed.error.issues } },
-    }
-  }
-  const { id, params } = parsed.data
-  const sep = params.sessionId.indexOf(':')
-  if (sep <= 0 || sep === params.sessionId.length - 1) {
-    return {
-      jsonrpc: '2.0',
-      id,
-      error: {
-        code: -32602,
-        message: 'Invalid params: sessionId must be "<channel>:<thread>"',
-        data: { sessionId: params.sessionId },
-      },
-    }
-  }
-  const key: SessionKey = {
-    channel: params.sessionId.slice(0, sep),
-    thread: params.sessionId.slice(sep + 1),
-  }
-  try {
-    await sup.quiesce(key)
-  } catch (err) {
-    return {
-      jsonrpc: '2.0',
-      id,
-      error: {
-        code: -32603,
-        message: 'Internal error: supervisor.quiesce failed',
-        data: { reason: err instanceof Error ? err.message : String(err) },
-      },
-    }
-  }
-  return { jsonrpc: '2.0', id, result: { stopReason: 'cancelled' } }
-}
+// The adapter is side-effect-free, so it lives in its own module
+// (acp-adapter.ts) that the test suite imports directly. No inlined
+// duplicate. Gemini flagged the prior duplicate as a drift risk on
+// PR #172 — extracting the module + importing the production code path
+// here is the fix.
+import { mapAcpSessionCancel } from './acp-adapter.ts'
 
 describe('mapAcpSessionCancel (ccsc-21x)', () => {
   let stateDir: string

--- a/server.ts
+++ b/server.ts
@@ -2248,136 +2248,15 @@ socket.on('interactive', async ({ body, ack }: { body: any; ack: () => Promise<v
 // PERMISSION_REPLY_RE imported from lib.ts — shared with gate() for
 // peer-bot permission-reply blocking.
 
-// ---------------------------------------------------------------------------
-// ACP boundary adapter — ccsc-21x
-// ---------------------------------------------------------------------------
-//
-// The Agent Client Protocol (ACP) is the converging cross-ecosystem JSON-RPC
-// 2.0 standard for agent control (Zed adoption; open issues for the same
-// primitive in google/adk-python#2425 and zed-industries/zed#50592). This
-// adapter is the ONLY place in the codebase where ACP terminology appears.
-// The supervisor's existing vocabulary (activate / quiesce / deactivate /
-// quarantine) does not change — see 000-docs/session-state-machine.md §
-// ACP-mapping for the contract this adapter honours.
-//
-// Additive only. Internal vocabulary is unchanged; 704 tests + existing
-// audit.log files keep their meanings.
-
-const AcpSessionCancelRequestSchema = z.object({
-  jsonrpc: z.literal('2.0'),
-  id: z.union([z.string(), z.number()]),
-  method: z.literal('session/cancel'),
-  params: z.object({
-    // ACP session IDs are opaque strings to the protocol. Our local convention
-    // is "<channel>:<thread>" — Slack channel and thread IDs contain only
-    // alphanumerics and a dot, so ':' is an unambiguous delimiter.
-    sessionId: z.string().min(3).max(128),
-  }),
-})
-
-/** ACP request envelope for `session/cancel`. JSON-RPC 2.0 shape. */
-export type AcpSessionCancelRequest = z.infer<typeof AcpSessionCancelRequestSchema>
-
-/** ACP response envelope returned by {@link mapAcpSessionCancel}. JSON-RPC 2.0. */
-export type AcpResponse =
-  | { jsonrpc: '2.0'; id: string | number; result: { stopReason: 'cancelled' } }
-  | {
-      jsonrpc: '2.0'
-      id: string | number
-      error: { code: number; message: string; data?: unknown }
-    }
-
-/** Map an ACP `session/cancel` request onto the supervisor's existing
- *  `quiesce(key)` method.
- *
- *  Returns an ACP-shaped response envelope. Never throws — protocol errors
- *  are returned as JSON-RPC error objects:
- *    - `-32600` Invalid Request: request shape doesn't validate against
- *               {@link AcpSessionCancelRequestSchema}.
- *    - `-32602` Invalid params: `sessionId` does not parse into a
- *               `(channel, thread)` pair.
- *    - `-32603` Internal error: `supervisor.quiesce()` rejected
- *               (quarantined session, save failure, etc.).
- *
- *  On success returns `{ result: { stopReason: 'cancelled' } }` per the ACP
- *  prompt-turn contract — quiesce is a cooperative interrupt, and the
- *  supervisor's promise resolves only after every in-flight save settles,
- *  matching ACP's "agent acknowledges with `cancelled` stop reason" shape.
- *
- *  This function is the only ACP-aware site in the codebase. Internal
- *  terminology (quiesce, SessionKey, SessionHandle) is unchanged. The
- *  adapter exists so that the day Anthropic ships external-message
- *  injection (anthropics/claude-code#53049) and ACP becomes the wire
- *  format, the migration is a single function edit, not a vocabulary
- *  rename. */
-export async function mapAcpSessionCancel(
-  req: unknown,
-  sup: SessionSupervisor,
-): Promise<AcpResponse> {
-  const parsed = AcpSessionCancelRequestSchema.safeParse(req)
-  if (!parsed.success) {
-    // JSON-RPC 2.0 §5.1: when the request object is invalid the id may be
-    // unknown. We surface the id when one was provided (string|number) and
-    // fall back to `null` (the spec-defined sentinel) otherwise.
-    const reqRecord = (typeof req === 'object' && req !== null ? req : {}) as Record<
-      string,
-      unknown
-    >
-    const fallbackId =
-      typeof reqRecord.id === 'string' || typeof reqRecord.id === 'number' ? reqRecord.id : null
-    return {
-      jsonrpc: '2.0',
-      // JSON-RPC spec uses `null` for unknown ids; we widen the response type
-      // to permit it via the string|number union and pass through null when
-      // legitimately unknown.
-      id: fallbackId as string | number,
-      error: {
-        code: -32600,
-        message: 'Invalid Request',
-        data: { issues: parsed.error.issues },
-      },
-    }
-  }
-  const { id, params } = parsed.data
-
-  // Parse "channel:thread" into a SessionKey. Slack IDs do not contain ':',
-  // so a single split is unambiguous. The supervisor's realpath-guarded
-  // sessionPath() rejects malformed values downstream regardless, but
-  // surfacing -32602 here gives the caller a precise error code rather than
-  // -32603 from a downstream failure.
-  const sep = params.sessionId.indexOf(':')
-  if (sep <= 0 || sep === params.sessionId.length - 1) {
-    return {
-      jsonrpc: '2.0',
-      id,
-      error: {
-        code: -32602,
-        message: 'Invalid params: sessionId must be "<channel>:<thread>"',
-        data: { sessionId: params.sessionId },
-      },
-    }
-  }
-  const key: import('./lib.ts').SessionKey = {
-    channel: params.sessionId.slice(0, sep),
-    thread: params.sessionId.slice(sep + 1),
-  }
-
-  try {
-    await sup.quiesce(key)
-  } catch (err) {
-    return {
-      jsonrpc: '2.0',
-      id,
-      error: {
-        code: -32603,
-        message: 'Internal error: supervisor.quiesce failed',
-        data: { reason: err instanceof Error ? err.message : String(err) },
-      },
-    }
-  }
-
-  return { jsonrpc: '2.0', id, result: { stopReason: 'cancelled' } }
-}
+// ACP boundary adapter (ccsc-21x) — extracted to acp-adapter.ts so the test
+// suite can import the production code path directly instead of inlining a
+// duplicate. Re-exported here for callers that pull the ACP surface from
+// the server's public exports.
+export {
+  type AcpResponse,
+  type AcpSessionCancelRequest,
+  mapAcpSessionCancel,
+} from './acp-adapter.ts'
 
 // ---------------------------------------------------------------------------
 // Supervisor helpers — exported for unit-testing without Socket Mode


### PR DESCRIPTION
**Beads:** \`ccsc-21x\` (already closed by PR #172 — this is structural follow-up, not a re-open)
**Continues:** #172 (CCSC Rollout PR #2)
**Addresses:** [Gemini review on PR #172](https://github.com/jeremylongshore/claude-code-slack-channel/pull/172#pullrequestreview-PRR_kwDORsf5oM8AAAABASFDmA) — all 5 comments

## Summary

- **Extract \`mapAcpSessionCancel\` + types + schema from \`server.ts\` into a new \`acp-adapter.ts\` module.** The adapter is side-effect-free, so the original "can't import from server.ts because of bootstrap process.exit" concern doesn't apply to it. \`server.test.ts\` now imports the production code path directly — no more inlined duplicate.
- **Widen \`AcpResponse.id\` to \`string | number | null\`** on the error branch to be fully JSON-RPC 2.0 §5.1 compliant. The spec REQUIRES \`null\` when the response id cannot be derived from a malformed request. The two unsafe \`as string | number\` casts on the fallbackId are removed; the value flows through with the correct static type.
- \`server.ts\` re-exports the public surface from \`acp-adapter.ts\` — no public-API breakage for any caller using \`import { ... } from './server.ts'\`.
- CHANGELOG entry under \`[Unreleased]\` § Changed.

## What changed

| File | Change |
|---|---|
| \`acp-adapter.ts\` (NEW) | +137 LoC — extracted from server.ts, side-effect-free, importable from tests |
| \`server.ts\` | -135 LoC inlined adapter → +7 LoC re-export block |
| \`server.test.ts\` | -73 LoC inlined duplicate → +1 import line; 13 ACP tests now exercise the production code path |
| \`CHANGELOG.md\` | one entry under \`[Unreleased]\` § Changed |

Net diff: +160 / -201, mostly because the duplicate is gone.

## Why each Gemini point is addressed

| Gemini comment | Fix |
|---|---|
| `AcpResponse.id` should permit `null` (JSON-RPC §5.1) | `acp-adapter.ts:55` — error branch widened to `string \| number \| null` |
| Unsafe `as string \| number` cast at `server.ts:2333` | Removed; the value's static type is now correct |
| Same widen needed in test file's `AcpResponseTest` | Eliminated — test file no longer has its own type, imports from the module |
| Same cast in test file at line 9873 | Eliminated — duplicate function gone |
| Test-side duplication is a maintenance risk | Fixed structurally — extract + import |

## Test plan

- [x] \`bun run typecheck\` — passes
- [x] \`bunx @biomejs/biome check .\` — passes (no auto-format needed)
- [x] \`bun test\` — 717 pass, 0 fail (test count unchanged; tests now hit production code path)
- [x] \`scripts/coverage-floor.sh 95\` — **line=98.72% func=99.02%** (UP from 98.47%/98.82% on the previous PR — tests now cover the real adapter, not a copy)
- [x] \`bunx depcruise --config .dependency-cruiser.js .\` — no violations (8 modules now / 21 dependencies cruised; +1 module for acp-adapter.ts, +4 dependencies from its imports)
- [x] \`scripts/gherkin-lint.sh --path features/ --strict\` — 0 warnings
- [x] \`scripts/harness-hash.sh --verify\` — OK
- [x] \`bun audit --audit-level=high --ignore=GHSA-j3q9-mxjg-w52f\` — no vulnerabilities
- [x] \`bun scripts/crap-score.ts --threshold 30\` — max=28 (unchanged)

## Note on review timing

PR #172 merged on green CI before Gemini's review landed. Per the repo's history with Gemini's first-pass review (memory \`as-of-2026-04-22-late-evening-main\`: "Gemini's first-pass 🟢/🟡 suggestions are usually legitimate"), going forward I'll wait for Gemini's review on this rollout's PRs before merging. This follow-up demonstrates the cost of merging too fast: a second PR cycle for what could have been a single one.

- Jeremy Longshore
intentsolutions.io