### PR TITLE
docs(readme): reframe tagline as enterprise multi-agent governance substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-code-slack-channel v0.9.1
 
-Two-way Slack ↔ Claude Code bridge. Chat with Claude from Slack DMs and channels, just like you'd chat in the terminal. Per-thread session isolation, hash-chained tamper-evident audit journal with optional per-channel Slack projection, policy-gated tools, five-layer prompt-injection defense.
+Enterprise Slack-native governance substrate where humans, Claude Code sessions, and peer agents converse safely in shared channels. Every tool call passes through a declarative policy engine; every gate decision lands in a hash-chained tamper-evident audit journal — per-thread session isolation, identity-aware permission gates, five-layer prompt-injection defense, built for workspaces where multiple agents share space with humans.
 
 [![CI](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml/badge.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-code-slack-channel v0.9.1
 
-Enterprise Slack-native governance substrate where humans, Claude Code sessions, and peer agents converse safely in shared channels. Every tool call passes through a declarative policy engine; every gate decision lands in a hash-chained tamper-evident audit journal — per-thread session isolation, identity-aware permission gates, five-layer prompt-injection defense, built for workspaces where multiple agents share space with humans.
+Enterprise Slack-native governance substrate where humans, Claude Code sessions, and peer agents converse safely in shared channels. Every tool call passes through a declarative policy engine; every gate decision lands in a hash-chained tamper-evident audit journal — per-thread session isolation, identity-aware permission gates, five-layer prompt-injection defense.
 
 [![CI](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml/badge.svg)](https://github.com/jeremylongshore/claude-code-slack-channel/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
## Summary

Reframes the README tagline (and same text on 3 other surfaces — GitHub repo description, gist description, gist in-file tagline) from \"two-way bridge\" to \"enterprise Slack-native governance substrate.\"

The two-way framing undersold what CCSC actually is. With the rollout in flight (signed audit journal, tiered policy, peer-bot manifests, admin verbs, ACP boundary adapter), CCSC is a governance substrate where humans, Claude Code sessions, and peer agents share channels through one policy engine + one audit journal + one identity-aware permission gate. \"Bridge\" implies one-to-one; the real shape is many-to-many under policy.

## Surfaces synced (all 4 now match)

| Surface | Form | Status |
|---|---|---|
| GitHub repo description | Short (~190 chars) | ✅ updated via API |
| Gist description | Short (same text) | ✅ updated via API |
| Gist file in-line tagline | Long form | ✅ pushed to gist |
| README.md tagline | Long form | ⏳ this PR |

## Test plan

- [x] No code change — docs-only
- [x] CI gates will run (Typecheck, gitleaks, CodeQL) — all expected pass
- [x] Tagline now matches gist file tagline per readme-template.md \"Tagline must match gist tagline\"

- Jeremy Longshore
intentsolutions.io