### PR TITLE
docs(readme): fix Policy Engine intro to reflect tier-aware evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Full troubleshooting matrix (10 failure modes): [`skills/install/references/trou
 
 ## Policy Engine (v0.6.0+)
 
-Author rules in `access.json.policy` to automate permission decisions for Claude Code tool calls. Three rule effects, first-applicable ordering:
+Author rules in `access.json.policy` to automate permission decisions for Claude Code tool calls. Three rule effects, evaluated strictest-tier-first then first-applicable within a tier (detailed below):
 
 ```json
 {


### PR DESCRIPTION
## What

One-line consistency fix. The Policy Engine section's intro still read "first-applicable ordering" while the paragraph below it (added in the v0.10 README refresh) documents the tier-aware model. Aligns the lead sentence to **strictest-tier-first then first-applicable within a tier**.

Verified against `policy.ts` `evaluate()` — walks tiers `admin → user → workspace → default`, first-applicable within each (confirmed at policy.ts:412-445). CHANGELOG `ccsc-8pw`.

Docs-only, one line.