### PR TITLE
ci(mutation): wire Stryker mutation-score floor as a scheduled gate (ccsc-0mn)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,62 @@
+name: Mutation
+
+# Stryker mutation testing — the deferred CI gate from ccsc-0mn.
+#
+# A full run mutates lib.ts + policy.ts + manifest.ts + journal.ts (~1,860
+# mutants, ~42 min). That is far too slow for the per-PR `ci.yml` job — the
+# original blocker that kept this manual since v0.x. So it runs here instead:
+#
+#   - weekly on a schedule (catches mutation-score drift on main), and
+#   - on demand via workflow_dispatch (run before a release, or to re-baseline).
+#
+# The gate itself lives in stryker.conf.mjs: `thresholds.break = 80`. Stryker
+# exits non-zero when the overall mutation score drops below 80% (~5pp below
+# the documented 85.22% baseline), which fails this job. Update the baseline in
+# 000-docs/MUTATION_REPORT.md whenever the break threshold is intentionally moved.
+
+on:
+  schedule:
+    # 06:10 UTC every Monday — staggered off the Scorecard cron (06:32 Mon).
+    - cron: '10 6 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    name: Stryker mutation score
+    runs-on: ubuntu-latest
+    # Generous ceiling over the observed ~42 min so a cold runner doesn't
+    # false-fail; the break threshold is the real gate, not wall-clock.
+    timeout-minutes: 75
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Stryker mutation run (break < 80%)
+        # Non-zero exit when overall score < thresholds.break (80) in
+        # stryker.conf.mjs fails the job. Baseline: 85.22% (MUTATION_REPORT.md).
+        run: bunx stryker run
+
+      - name: Upload mutation HTML report
+        # Always upload so a threshold failure still ships the survivor list.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-report
+          path: reports/mutation/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -2,15 +2,19 @@
 /**
  * Stryker mutation testing configuration.
  *
- * One-time baseline, manual-run only (not wired into CI).
- * Targets pure-logic modules with dedicated test coverage in server.test.ts.
+ * Gated in CI via the scheduled/dispatch `Mutation` workflow
+ * (.github/workflows/mutation.yml) — NOT the per-PR `ci.yml` job, since a full
+ * run is ~42 min. `thresholds.break = 80` makes Stryker exit non-zero (failing
+ * that workflow) if the overall mutation score drops below 80%, ~5pp under the
+ * documented 85.22% baseline (000-docs/MUTATION_REPORT.md). Wired by ccsc-0mn.
  *
- * server.ts and supervisor.ts are excluded — they have boot-time side effects
- * and module-load globals that confuse the mutator. journal.ts is excluded
- * from this baseline run to keep the first pass fast (can expand later).
+ * Targets the four security-critical pure-logic modules. server.ts and
+ * supervisor.ts are excluded — they have boot-time side effects and module-load
+ * globals that confuse the mutator (supervisor mutants also time out under the
+ * command runner's cold-spawn overhead).
  *
- * Run: bunx stryker run
- * Bead: ccsc-ao9
+ * Run locally: bunx stryker run
+ * Beads: ccsc-ao9 (baseline), ccsc-l5z (expanded scope), ccsc-0mn (CI gate)
  */
 
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
@@ -36,7 +40,14 @@ export default {
   checkers: [],
   coverageAnalysis: 'off',
   reporters: ['html', 'clear-text', 'progress'],
-  thresholds: { high: 80, low: 60, break: null },
+  // break: 80 — fail the run if overall mutation score drops below 80%.
+  // Documented baseline is 85.22% (000-docs/MUTATION_REPORT.md, ccsc-y4e);
+  // 80 sits ~5pp below baseline, the regression margin called for in ccsc-0mn.
+  // Enforced by the scheduled/dispatch `Mutation` workflow
+  // (.github/workflows/mutation.yml), NOT the per-PR `ci.yml` job — a full run
+  // is ~42 min and would triple PR CI cost (the original ccsc-0mn blocker).
+  // Lower this only alongside a documented baseline re-measure.
+  thresholds: { high: 80, low: 60, break: 80 },
   timeoutMS: 60000,
   concurrency: 4,
   tempDirName: '.stryker-tmp',


### PR DESCRIPTION
## What

Closes **ccsc-0mn** — the deferred mutation-testing CI gate.

Stryker stays **off the per-PR path** (a full run mutates 4 modules / ~1,860 mutants / ~42 min — the original reason it was never wired) and instead runs in a dedicated workflow:

- **`.github/workflows/mutation.yml`** — weekly cron (Mon 06:10 UTC, staggered off Scorecard) + `workflow_dispatch`. SHA-pinned actions matching repo convention, 75-min timeout, uploads the HTML survivor report as an artifact (even on failure).
- **`stryker.conf.mjs`** — `thresholds.break` `null` → **80**. Stryker exits non-zero (failing the workflow) if the overall mutation score drops below 80% — ~5pp under the documented **85.22%** baseline, the regression margin ccsc-0mn called for.

Docs synced: `MUTATION_REPORT.md` (gating note), `QUALITY_GATES.md` (partial → gated), README Testing & Quality section, `stryker.conf.mjs` header.

## Verification

- `mutation.yml` valid YAML; Biome clean on `stryker.conf.mjs`.
- Baseline unchanged (85.22%, four security-critical pure modules).
- No production code touched — config + workflow + docs only.

Note: a local full Stryker run was attempted to re-confirm the score but the dev box OOM-killed it (known memory constraint); moving the run onto GitHub's runners is precisely the point of this bead. The workflow can be smoke-tested post-merge via `gh workflow run mutation.yml`.