### PR TITLE
docs(mutation): fix dangling bead id ccsc-mut1 -> ccsc-2et

### DIFF
--- a/000-docs/MUTATION_REPORT.md
+++ b/000-docs/MUTATION_REPORT.md
@@ -67,7 +67,7 @@ box now OOM-kills a full run). **Result: PASS** — overall **83.46%**, above th
 the gate was designed to absorb). `policy.ts` dropped 4.09pp to 73.91% — the
 v0.10 tier-aware `evaluate()` + cross-tier shadow logic (`ccsc-8pw`, `ccsc-4g8`)
 added branches without matching mutation-killing tests. Survivor-kill follow-up
-tracked in **`ccsc-mut1`** (policy.ts mutation drift). Not a gate failure;
+tracked in **`ccsc-2et`** (policy.ts mutation drift). Not a gate failure;
 flagged so the trend doesn't silently erode toward the 80 floor.
 
 `manifest.ts` leads at 92.06% — Epic 31-B's Zod schema + strict subset validation produces easily-killable mutants. `journal.ts` second at 87.76%. `lib.ts` at 84.78% matches the post-y4e intermediate run within noise. `policy.ts` is the outlier at 78.00% — below `high` but above `low: 60`. The surviving mutants cluster on error-string literals inside `detectShadowing` / `detectBroadAutoApprove` warnings — the behavior (warn on shadow / footgun) is fully exercised, but the exact warning text isn't asserted bit-for-bit.


### PR DESCRIPTION
MUTATION_REPORT.md cited a placeholder bead id `ccsc-mut1` that was never created — the policy.ts mutation-drift follow-up was actually filed as `ccsc-2et`. One-word fix so the doc points at the real bead. Docs-only.