### PR TITLE
docs(readme): align audit claim with AGP marketing discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Each layer's limit, and an explicit **"what this does NOT protect against"** sec
 
 ## Audit Signing
 
-Every decision the gate makes is journaled to `~/.claude/channels/slack/audit.log` — hash-chained (tamper-evident) and, as of v0.10, **Ed25519-signed** so a third party can verify the log against a public key without trusting the host.
+Every decision the gate makes is journaled to `~/.claude/channels/slack/audit.log` — hash-chained and, as of v0.10, **Ed25519-signed** — so a third party can verify the log against a public key without trusting the host.
 
 ```bash
 # Verify a journal end-to-end (hash chain + signatures):


### PR DESCRIPTION
Drops `tamper-evident` from the Audit Signing section and describes the journal by its shipped mechanism (hash-chained, Ed25519-signed, verifiable offline). Resolves the internal CCSC↔AGP claim contradiction — AGP's `MARKETING_CLAIMS.md` bans `tamper-evident` as over-promising at v0, while CCSC's README used it. Now consistent and primitive-backed. Docs-only; no code change.