### PR TITLE
feat(policy): bind the no-gaps journal invariant to production dispatch (ccsc-175)

### DIFF
--- a/policy-dispatch.ts
+++ b/policy-dispatch.ts
@@ -14,6 +14,17 @@
  *     MCP notification sent to Claude on policy.deny
  *   - recordPolicyDenyToJournal() — two-event journal sequence:
  *     full-detail policy.deny + sanitised policy.deny.context_stripped
+ *   - buildPolicyAllowEvent / buildPolicyRequireEvent /
+ *     buildPolicyApprovedEvent — pure builders for the remaining policy
+ *     journal events the dispatcher writes (ccsc-175). server.ts calls
+ *     these to construct what it journals, so a test can import the
+ *     production event source directly instead of asserting the inline
+ *     server.ts object literals structurally.
+ *   - permissionRouteJournalEvents() — the exhaustive route→events
+ *     contract (ccsc-175). A `never`-guard makes a new PermissionRoute
+ *     variant fail to COMPILE, binding the "every policy decision is
+ *     journaled, no silent gaps" invariant (ccsc-1iw.2) to production
+ *     code rather than a test-local route→kind map.
  *
  * What this module does NOT do:
  *   - Send the actual MCP notification. server.ts owns the MCP
@@ -30,7 +41,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JournalWriter } from './journal.ts'
+import type { EventKind, JournalWriter, WriteInput } from './journal.ts'
+import type { PermissionRoute } from './lib.ts'
 
 // ---------------------------------------------------------------------------
 // Wire-format invariant — buildDenyNotificationParams (ccsc-06s)
@@ -141,4 +153,216 @@ export async function recordPolicyDenyToJournal(
       error: err instanceof Error ? err.message : String(err),
     })
   }
+}
+
+// ---------------------------------------------------------------------------
+// Policy journal-event builders — allow / require / approved (ccsc-175)
+//
+// server.ts used to write these three events as inline object literals at
+// the dispatch site. Because server.ts runs main() and constructs Slack
+// clients at module top level, a test cannot import it to drive the real
+// write — the no-gaps invariant (ccsc-1iw.2) therefore bound a test-local
+// route→kind map, not production code. Extracting the builders here (the
+// same shape as recordPolicyDenyToJournal above) makes the production
+// event source importable: a test drives the builder and asserts the exact
+// EventKind written. The deny pair stays in recordPolicyDenyToJournal — it
+// carries the awaited-before-notify + resilient-write semantics the deny
+// branch needs and must not regress.
+// ---------------------------------------------------------------------------
+
+/** Fields recorded on a `policy.allow` event (auto_approve match). */
+export interface PolicyAllowDetail {
+  sessionKey?: { channel: string; thread: string }
+  toolName: string
+  input: Record<string, unknown>
+  ruleId: string
+  /** Audit-receipt correlation id, when a receipt was posted. */
+  correlationId?: string
+}
+
+/** Build the `policy.allow` journal event for an auto-approved call. */
+export function buildPolicyAllowEvent(detail: PolicyAllowDetail): WriteInput {
+  return {
+    kind: 'policy.allow',
+    outcome: 'allow',
+    actor: 'claude_process',
+    sessionKey: detail.sessionKey,
+    toolName: detail.toolName,
+    input: detail.input,
+    ruleId: detail.ruleId,
+    correlationId: detail.correlationId,
+  }
+}
+
+/** Fields recorded on a `policy.require` event (require_approval match). */
+export interface PolicyRequireDetail {
+  sessionKey?: { channel: string; thread: string }
+  toolName: string
+  /** Base input echo (tool, channel, thread_ts). `approversNeeded` is
+   *  merged on by the builder so the trace records the quorum size. */
+  input: Record<string, unknown>
+  ruleId: string
+  approversNeeded: number
+}
+
+/** Build the `policy.require` trace event for a human-approval dispatch. */
+export function buildPolicyRequireEvent(detail: PolicyRequireDetail): WriteInput {
+  return {
+    kind: 'policy.require',
+    outcome: 'require',
+    actor: 'claude_process',
+    sessionKey: detail.sessionKey,
+    toolName: detail.toolName,
+    input: { ...detail.input, approversNeeded: detail.approversNeeded },
+    ruleId: detail.ruleId,
+  }
+}
+
+/** Fields recorded on a `policy.approved` event (quorum reached). Unlike
+ *  the other three, this is NOT a `decidePermissionRoute` outcome — it is
+ *  emitted later, when a human-approver quorum votes Allow on a pending
+ *  require_approval request (server.ts processApprovalVote). */
+export interface PolicyApprovedDetail {
+  sessionKey: { channel: string; thread: string }
+  toolName: string
+  ruleId: string
+  approversNeeded: number
+  /** Verified Slack user_ids that voted Allow (NEVER display names). */
+  approvers: readonly string[]
+}
+
+/** Build the `policy.approved` journal event for a quorum grant. */
+export function buildPolicyApprovedEvent(detail: PolicyApprovedDetail): WriteInput {
+  return {
+    kind: 'policy.approved',
+    outcome: 'allow',
+    actor: 'human_approver',
+    sessionKey: detail.sessionKey,
+    toolName: detail.toolName,
+    input: {
+      tool: detail.toolName,
+      approversNeeded: detail.approversNeeded,
+      approvers: [...detail.approvers],
+    },
+    ruleId: detail.ruleId,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exhaustive route→events contract — permissionRouteJournalEvents (ccsc-175)
+// ---------------------------------------------------------------------------
+
+/** Context the exhaustive route→events mapping needs to build each event.
+ *  Every field is optional except the always-present ones, because a
+ *  single ctx serves all four routes; the relevant subset is consumed per
+ *  route. `reason` is deny-only, `correlationId` allow-only,
+ *  `approversNeeded` require-only. */
+export interface PermissionRouteJournalContext {
+  sessionKey?: { channel: string; thread: string }
+  toolName: string
+  /** Base input echo: { tool, channel, thread_ts }. */
+  input: Record<string, unknown>
+  /** Audit-receipt correlation id — attached to `policy.allow`. */
+  correlationId?: string
+  /** Quorum size — attached to `policy.require`. */
+  approversNeeded?: number
+  /** Denial reason — attached to the first `policy.deny` event. */
+  reason?: string
+}
+
+/** The ordered journal events a resolved permission route must produce.
+ *
+ *  This is the single production source of the "no silent gaps" invariant
+ *  (ccsc-1iw.2): every `PermissionRoute` variant maps here to the exact
+ *  EventKind(s) journaled for it, or to `[]` for the deliberately-silent
+ *  `default_human` route. The `never`-guard in the `default` arm makes a
+ *  newly-added route variant fail to COMPILE until its audit record is
+ *  declared — and because server.ts calls this function, that compile
+ *  error surfaces in the production build, not only in a test.
+ *
+ *  Execution split (intentional): server.ts writes the returned events
+ *  directly for `auto_allow` / `require_human` / `default_human`. For
+ *  `deny` it routes through `recordPolicyDenyToJournal` instead — that
+ *  helper awaits each write before the MCP deny notification and attempts
+ *  the second event even if the first throws (ccsc-06s resilience). The
+ *  `deny` arm here returns the identical two-event pair so the contract is
+ *  complete and exhaustive; a consistency test pins the two paths together
+ *  (server.test.ts §"permissionRouteJournalEvents deny matches helper"). */
+export function permissionRouteJournalEvents(
+  route: PermissionRoute,
+  ctx: PermissionRouteJournalContext,
+): readonly WriteInput[] {
+  switch (route.type) {
+    case 'auto_allow':
+      return [
+        buildPolicyAllowEvent({
+          sessionKey: ctx.sessionKey,
+          toolName: ctx.toolName,
+          input: ctx.input,
+          ruleId: route.ruleId,
+          correlationId: ctx.correlationId,
+        }),
+      ]
+    case 'require_human':
+      return [
+        buildPolicyRequireEvent({
+          sessionKey: ctx.sessionKey,
+          toolName: ctx.toolName,
+          input: ctx.input,
+          ruleId: route.ruleId,
+          approversNeeded: ctx.approversNeeded ?? 0,
+        }),
+      ]
+    case 'deny':
+      return [
+        {
+          kind: 'policy.deny',
+          outcome: 'deny',
+          actor: 'claude_process',
+          sessionKey: ctx.sessionKey,
+          toolName: ctx.toolName,
+          input: ctx.input,
+          ruleId: route.ruleId,
+          reason: route.reason,
+        },
+        {
+          kind: 'policy.deny.context_stripped',
+          outcome: 'n/a',
+          actor: 'system',
+          sessionKey: ctx.sessionKey,
+          toolName: ctx.toolName,
+        },
+      ]
+    case 'default_human':
+      // Deliberately silent — the evaluator has no opinion. Tracing the
+      // no-rule-match case would 10x the journal on a busy channel.
+      return []
+    default: {
+      // Exhaustiveness guard: a new PermissionRoute variant that forgets
+      // to declare its journal record fails to compile here (ccsc-175).
+      const _exhaustive: never = route
+      return _exhaustive
+    }
+  }
+}
+
+/** The EventKind(s) a route journals, derived from the contract above.
+ *  Convenience surface for the no-gaps test and any caller that wants the
+ *  kinds without building full events. Kept in lock-step with
+ *  permissionRouteJournalEvents by construction (it maps over the same
+ *  output), so there is no second switch to drift. */
+export function permissionRouteJournalKinds(
+  routeType: PermissionRoute['type'],
+): readonly EventKind[] {
+  // Build with a minimal ctx; only `.kind` is read. `route` is
+  // reconstructed with placeholder fields the kind-mapping ignores.
+  const route: PermissionRoute =
+    routeType === 'auto_allow'
+      ? { type: 'auto_allow', ruleId: '' }
+      : routeType === 'require_human'
+        ? { type: 'require_human', ruleId: '' }
+        : routeType === 'deny'
+          ? { type: 'deny', ruleId: '', reason: '' }
+          : { type: 'default_human' }
+  return permissionRouteJournalEvents(route, { toolName: '', input: {} }).map((e) => e.kind)
 }

--- a/server.test.ts
+++ b/server.test.ts
@@ -9411,69 +9411,57 @@ describe('decidePermissionRoute', () => {
 // recordPolicyDenyToJournal two-event tests below, and the audit_chain_verifier
 // acceptance primitive.
 //
-// KNOWN CONSTRAINT (ccsc-175): server.ts writes the policy.allow / .require /
-// .approved events INLINE and runs main() on import, so a test cannot import it
-// to assert those exact write calls. This test therefore anchors the mapping to
-// the REAL journal EventKind enum and drives the real deny helper; the stronger
-// "execute the production dispatch" assertion is filed as ccsc-175.
+// CONSTRAINT RESOLVED (ccsc-175, PR for bz-ccsc-175): server.ts now builds the
+// policy.allow / .require / .approved events via the importable, side-effect-free
+// builders in policy-dispatch.ts, and dispatches the route→events mapping through
+// the exhaustive `permissionRouteJournalEvents` (a `never`-guard that fails to
+// COMPILE on a new un-journaled route). This block now anchors to that PRODUCTION
+// contract — `permissionRouteJournalKinds` — instead of a test-local switch, so
+// the no-gaps guarantee binds the code server.ts actually runs. The dedicated
+// ccsc-175 block below drives each builder + the deny-path consistency.
 // ---------------------------------------------------------------------------
 describe('every policy decision is journaled — no silent gaps (ccsc-1iw.2)', () => {
   type RouteType = import('./lib.ts').PermissionRoute['type']
   type PolicyDecisionShape = import('./lib.ts').PolicyDecisionShape
 
-  // Single source of truth for "what each route must journal". default_human is
-  // deliberately silent — server.ts does not trace the no-opinion case (tracing
-  // it would 10x the journal on a busy channel). Encoded as an explicit `null`,
-  // NOT an omission. The `never` arm makes a new route.type a compile error
-  // until its journal decision is declared here.
-  const journalKindForRoute = (type: RouteType): string | null => {
-    switch (type) {
-      case 'auto_allow':
-        return 'policy.allow'
-      case 'deny':
-        return 'policy.deny' // two-event sequence; .context_stripped asserted below
-      case 'require_human':
-        return 'policy.require'
-      case 'default_human':
-        return null
-      default: {
-        const _exhaustive: never = type
-        return _exhaustive
-      }
-    }
-  }
-
   test('each decision branch routes to a real EventKind (or the one deliberately-silent route)', async () => {
     const { decidePermissionRoute } = await import('./lib.ts')
     const { EventKind } = await import('./journal.ts')
+    // PRODUCTION contract (ccsc-175): the same function server.ts calls to
+    // decide what to journal for a route. No test-local re-implementation.
+    const { permissionRouteJournalKinds } = await import('./policy-dispatch.ts')
 
     const decisions: PolicyDecisionShape[] = [
       { kind: 'allow', rule: 'safe-reads' }, // → auto_allow → policy.allow
       { kind: 'allow' }, // → default_human → (deliberately none)
-      { kind: 'deny', rule: 'no-shell', reason: 'blocked' }, // → deny → policy.deny
+      { kind: 'deny', rule: 'no-shell', reason: 'blocked' }, // → deny → policy.deny[+stripped]
       { kind: 'require', rule: 'dangerous', approver: 'human_approver', ttlMs: 1000, approvers: 1 },
     ]
 
+    const eventKinds = EventKind.options as readonly string[]
     for (const decision of decisions) {
       const route = decidePermissionRoute(decision)
-      const kind = journalKindForRoute(route.type)
-      if (kind === null) {
+      const kinds = permissionRouteJournalKinds(route.type)
+      if (kinds.length === 0) {
         // Only the no-opinion default_human route is deliberately un-journaled.
         expect(route.type).toBe('default_human')
       } else {
-        // Widen the readonly literal tuple to string[] — the mapping returns a
-        // plain string, and we are asserting membership, not narrowing.
-        expect((EventKind.options as readonly string[]).includes(kind)).toBe(true)
+        // Every kind the production contract emits must be a real EventKind.
+        for (const kind of kinds) {
+          expect(eventKinds.includes(kind)).toBe(true)
+        }
       }
     }
   })
 
-  test('exactly one route — the no-opinion default_human — is deliberately not journaled', () => {
+  test('exactly one route — the no-opinion default_human — is deliberately not journaled', async () => {
+    const { permissionRouteJournalKinds } = await import('./policy-dispatch.ts')
     const all: RouteType[] = ['auto_allow', 'deny', 'require_human', 'default_human']
-    const silent = all.filter((t) => journalKindForRoute(t) === null)
+    const silent = all.filter((t) => permissionRouteJournalKinds(t).length === 0)
     // If a future change drops the journal write on a real decision branch
     // (e.g. makes auto_allow silent), this fails loudly — that is the "no
-    // silent gap" guarantee at runtime, paired with the compile-time `never`.
+    // silent gap" guarantee at runtime, paired with the compile-time `never`
+    // inside permissionRouteJournalEvents.
     expect(silent).toEqual(['default_human'])
   })
 
@@ -9508,6 +9496,202 @@ describe('every policy decision is journaled — no silent gaps (ccsc-1iw.2)', (
       },
     )
     expect(kinds).toEqual(['policy.deny', 'policy.deny.context_stripped'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Permission-route journal builders bind production code (ccsc-175)
+//
+// Before ccsc-175, server.ts wrote policy.allow / .require / .approved as inline
+// object literals at the dispatch site, and ran main() (plus top-level Slack
+// client construction) on import — so a test could not import the module to
+// drive those exact writes. ccsc-1iw.2's no-gaps guarantee therefore bound a
+// test-local route→kind switch, not production code.
+//
+// ccsc-175 extracts the event source into policy-dispatch.ts (side-effect-free,
+// importable): three pure builders + the exhaustive `permissionRouteJournalEvents`
+// dispatcher (a `never`-guard). server.ts now CALLS these, so the tests below
+// drive the REAL production event source and assert the exact EventKind written
+// for each decision branch — the assertion ccsc-1iw.2 could not make directly.
+// The deny pair stays on recordPolicyDenyToJournal (awaited + resilient before
+// the MCP deny notification, ccsc-06s); the final test pins the dispatcher's deny
+// arm to that helper so the two execution paths cannot drift.
+// ---------------------------------------------------------------------------
+describe('permission-route journal builders bind production code (ccsc-175)', () => {
+  test('buildPolicyAllowEvent emits a policy.allow with the auto-approve detail', async () => {
+    const { buildPolicyAllowEvent } = await import('./policy-dispatch.ts')
+    const ev = buildPolicyAllowEvent({
+      sessionKey: { channel: 'C1', thread: 'T1' },
+      toolName: 'Read',
+      input: { tool: 'Read', channel: 'C1', thread_ts: 'T1' },
+      ruleId: 'safe-reads',
+      correlationId: 'corr-123',
+    })
+    expect(ev.kind).toBe('policy.allow')
+    expect(ev.outcome).toBe('allow')
+    expect(ev.actor).toBe('claude_process')
+    expect(ev.ruleId).toBe('safe-reads')
+    expect(ev.correlationId).toBe('corr-123')
+    expect(ev.toolName).toBe('Read')
+  })
+
+  test('buildPolicyAllowEvent omits correlationId when no receipt was posted', async () => {
+    const { buildPolicyAllowEvent } = await import('./policy-dispatch.ts')
+    const ev = buildPolicyAllowEvent({
+      toolName: 'Read',
+      input: {},
+      ruleId: 'safe-reads',
+    })
+    expect(ev.kind).toBe('policy.allow')
+    expect(ev.correlationId).toBeUndefined()
+  })
+
+  test('buildPolicyRequireEvent emits a policy.require and merges approversNeeded into input', async () => {
+    const { buildPolicyRequireEvent } = await import('./policy-dispatch.ts')
+    const ev = buildPolicyRequireEvent({
+      sessionKey: { channel: 'C1', thread: 'T1' },
+      toolName: 'Bash',
+      input: { tool: 'Bash', channel: 'C1', thread_ts: 'T1' },
+      ruleId: 'dangerous',
+      approversNeeded: 2,
+    })
+    expect(ev.kind).toBe('policy.require')
+    expect(ev.outcome).toBe('require')
+    expect(ev.actor).toBe('claude_process')
+    expect(ev.ruleId).toBe('dangerous')
+    // The quorum size is recorded in the trace input, not a top-level field.
+    expect((ev.input as Record<string, unknown>).approversNeeded).toBe(2)
+    expect((ev.input as Record<string, unknown>).tool).toBe('Bash')
+  })
+
+  test('buildPolicyApprovedEvent emits a policy.approved attributed to human_approver', async () => {
+    const { buildPolicyApprovedEvent } = await import('./policy-dispatch.ts')
+    const approvers = ['U1', 'U2']
+    const ev = buildPolicyApprovedEvent({
+      sessionKey: { channel: 'C1', thread: 'T1' },
+      toolName: 'Bash',
+      ruleId: 'dangerous',
+      approversNeeded: 2,
+      approvers,
+    })
+    expect(ev.kind).toBe('policy.approved')
+    expect(ev.outcome).toBe('allow')
+    expect(ev.actor).toBe('human_approver')
+    expect(ev.ruleId).toBe('dangerous')
+    const input = ev.input as Record<string, unknown>
+    expect(input.approversNeeded).toBe(2)
+    expect(input.approvers).toEqual(['U1', 'U2'])
+    // The builder copies the approver list — mutating the source must not leak.
+    approvers.push('U3')
+    expect((ev.input as Record<string, unknown>).approvers).toEqual(['U1', 'U2'])
+  })
+
+  test('permissionRouteJournalEvents maps every route to its exact ordered EventKinds', async () => {
+    const { permissionRouteJournalEvents } = await import('./policy-dispatch.ts')
+    type PermissionRoute = import('./lib.ts').PermissionRoute
+    const ctx = {
+      sessionKey: { channel: 'C1', thread: 'T1' },
+      toolName: 'Bash',
+      input: { tool: 'Bash', channel: 'C1', thread_ts: 'T1' },
+      correlationId: 'corr-9',
+      approversNeeded: 3,
+      reason: 'blocked',
+    }
+    const cases: { route: PermissionRoute; kinds: string[] }[] = [
+      { route: { type: 'auto_allow', ruleId: 'r' }, kinds: ['policy.allow'] },
+      {
+        route: { type: 'deny', ruleId: 'r', reason: 'blocked' },
+        kinds: ['policy.deny', 'policy.deny.context_stripped'],
+      },
+      { route: { type: 'require_human', ruleId: 'r' }, kinds: ['policy.require'] },
+      { route: { type: 'default_human' }, kinds: [] },
+    ]
+    for (const { route, kinds } of cases) {
+      const events = permissionRouteJournalEvents(route, ctx)
+      expect(events.map((e) => e.kind as string)).toEqual(kinds)
+    }
+  })
+
+  test('auto_allow events carry the route ruleId and the ctx correlationId', async () => {
+    const { permissionRouteJournalEvents } = await import('./policy-dispatch.ts')
+    const [ev] = permissionRouteJournalEvents(
+      { type: 'auto_allow', ruleId: 'safe-reads' },
+      {
+        sessionKey: { channel: 'C1', thread: 'T1' },
+        toolName: 'Read',
+        input: { tool: 'Read' },
+        correlationId: 'corr-7',
+      },
+    )
+    expect(ev.kind).toBe('policy.allow')
+    expect(ev.ruleId).toBe('safe-reads')
+    expect(ev.correlationId).toBe('corr-7')
+  })
+
+  test('every decidePermissionRoute outcome maps to real EventKinds (no-gaps, driven through production)', async () => {
+    const { decidePermissionRoute } = await import('./lib.ts')
+    const { permissionRouteJournalEvents } = await import('./policy-dispatch.ts')
+    const { EventKind } = await import('./journal.ts')
+    type PolicyDecisionShape = import('./lib.ts').PolicyDecisionShape
+    const eventKinds = EventKind.options as readonly string[]
+    const ctx = { toolName: 'Bash', input: {}, approversNeeded: 1, reason: 'x' }
+
+    const decisions: PolicyDecisionShape[] = [
+      { kind: 'allow', rule: 'safe-reads' },
+      { kind: 'allow' },
+      { kind: 'deny', rule: 'no-shell', reason: 'blocked' },
+      { kind: 'require', rule: 'dangerous', approver: 'human_approver', ttlMs: 1000, approvers: 1 },
+    ]
+    for (const decision of decisions) {
+      const route = decidePermissionRoute(decision)
+      for (const ev of permissionRouteJournalEvents(route, ctx)) {
+        expect(eventKinds.includes(ev.kind)).toBe(true)
+      }
+    }
+  })
+
+  test('the dispatcher deny arm matches what recordPolicyDenyToJournal actually writes', async () => {
+    // Pins the two deny execution paths together: server.ts routes deny through
+    // recordPolicyDenyToJournal (awaited + resilient), while the exhaustive
+    // dispatcher declares the same pair for contract completeness. If either
+    // drifts, this fails.
+    const { permissionRouteJournalEvents, recordPolicyDenyToJournal } = await import(
+      './policy-dispatch.ts'
+    )
+    const ctx = {
+      sessionKey: { channel: 'C1', thread: 'T1' },
+      toolName: 'Bash',
+      input: { tool: 'Bash', channel: 'C1', thread_ts: 'T1' },
+      reason: 'blocked',
+    }
+    const dispatched = permissionRouteJournalEvents(
+      { type: 'deny', ruleId: 'no-shell', reason: 'blocked' },
+      ctx,
+    )
+
+    const written: Record<string, unknown>[] = []
+    await recordPolicyDenyToJournal(
+      async (input: Record<string, unknown>) => {
+        written.push(input)
+        return { ok: true } as unknown
+      },
+      {
+        sessionKey: ctx.sessionKey,
+        toolName: ctx.toolName,
+        input: ctx.input,
+        ruleId: 'no-shell',
+        reason: 'blocked',
+      },
+    )
+
+    // Same ordered kinds.
+    expect(dispatched.map((e) => e.kind as string)).toEqual(written.map((e) => e.kind as string))
+    // The forensic policy.deny event carries identical ruleId + reason on both paths.
+    expect(dispatched[0].ruleId).toBe(written[0].ruleId as string | undefined)
+    expect(dispatched[0].reason).toBe(written[0].reason as string | undefined)
+    // The stripped second event omits ruleId/reason on both paths.
+    expect(dispatched[1].ruleId).toBeUndefined()
+    expect(written[1].ruleId).toBeUndefined()
   })
 })
 

--- a/server.ts
+++ b/server.ts
@@ -456,19 +456,15 @@ function processApprovalVote(
   entry.policy = vote.state
   if (vote.kind === 'approved') {
     grantPolicyApproval(vote.state, now)
-    journalWrite({
-      kind: 'policy.approved',
-      outcome: 'allow',
-      actor: 'human_approver',
-      sessionKey: vote.state.sessionKey,
-      toolName: entry.tool_name,
-      input: {
-        tool: entry.tool_name,
+    journalWrite(
+      buildPolicyApprovedEvent({
+        sessionKey: vote.state.sessionKey,
+        toolName: entry.tool_name,
+        ruleId: vote.state.ruleId,
         approversNeeded: vote.state.approversNeeded,
         approvers: Array.from(vote.state.approvedBy),
-      },
-      ruleId: vote.state.ruleId,
-    })
+      }),
+    )
     return { kind: 'approved', state: vote.state }
   }
   return { kind: 'pending', state: vote.state }
@@ -636,15 +632,23 @@ function journalWrite(
 // resolve. Mirrors the acp-adapter.ts pattern (PR #173).
 import {
   buildDenyNotificationParams,
+  buildPolicyAllowEvent,
+  buildPolicyApprovedEvent,
+  buildPolicyRequireEvent,
   type DenyNotificationParams,
   type PolicyDenyDetail,
+  permissionRouteJournalEvents,
   recordPolicyDenyToJournal,
 } from './policy-dispatch.ts'
 
 export {
   buildDenyNotificationParams,
+  buildPolicyAllowEvent,
+  buildPolicyApprovedEvent,
+  buildPolicyRequireEvent,
   type DenyNotificationParams,
   type PolicyDenyDetail,
+  permissionRouteJournalEvents,
   recordPolicyDenyToJournal,
 }
 
@@ -2194,16 +2198,17 @@ mcp.setNotificationHandler(
         lastActiveThread,
         params.tool_name,
       )
-      journalWrite({
-        kind: 'policy.allow',
-        outcome: 'allow',
-        actor: 'claude_process',
+      // Build + write via the exhaustive route→events contract so the
+      // no-gaps invariant (ccsc-1iw.2) binds this production path, not a
+      // test-local map (ccsc-175). auto_allow → exactly [policy.allow].
+      for (const ev of permissionRouteJournalEvents(route, {
         sessionKey: policySessionKey,
         toolName: params.tool_name,
         input: policyInput,
-        ruleId: route.ruleId,
         correlationId,
-      })
+      })) {
+        journalWrite(ev)
+      }
       await mcp.notification({
         method: 'notifications/claude/channel/permission',
         params: { request_id: params.request_id, behavior: 'allow' },
@@ -2286,15 +2291,17 @@ mcp.setNotificationHandler(
     // for the no-opinion case — see release-plan R2).
     let pendingPolicy: PendingPolicyApproval | undefined
     if (route.type === 'require_human' && decision.kind === 'require') {
-      journalWrite({
-        kind: 'policy.require',
-        outcome: 'require',
-        actor: 'claude_process',
+      // Same exhaustive contract as auto_allow above (ccsc-175):
+      // require_human → exactly [policy.require], approversNeeded merged
+      // into the trace input by the builder.
+      for (const ev of permissionRouteJournalEvents(route, {
         sessionKey: policySessionKey,
         toolName: params.tool_name,
-        input: { ...policyInput, approversNeeded: decision.approvers },
-        ruleId: route.ruleId,
-      })
+        input: policyInput,
+        approversNeeded: decision.approvers,
+      })) {
+        journalWrite(ev)
+      }
       pendingPolicy = {
         ruleId: decision.rule,
         ttlMs: decision.ttlMs,


### PR DESCRIPTION
## What

Makes the **"every policy decision is journaled — no silent gaps"** invariant (`ccsc-1iw.2`) bind the code `server.ts` actually runs, instead of a test-local route→kind switch.

## Why

`server.ts` wrote `policy.allow` / `policy.require` / `policy.approved` as **inline object literals** at the dispatch site, and runs `main()` (plus top-level Slack client construction) on import — so a test could not import the module to drive those exact writes. `ccsc-1iw.2`'s no-gaps guarantee therefore had to reconstruct the route→kind mapping locally in the test. If `server.ts` and that test-local map drifted, the audit gap would be invisible. (Discovered while shipping `ccsc-1iw.2`; scoped on the bead.)

## How

Extract the event source into `policy-dispatch.ts` — already the side-effect-free home of the `ccsc-06s` deny helpers:

- **`buildPolicyAllowEvent` / `buildPolicyRequireEvent` / `buildPolicyApprovedEvent`** — pure builders for the three previously-inline events. `server.ts` now calls them, so they are the real production event source a test can drive.
- **`permissionRouteJournalEvents(route, ctx)`** — the exhaustive route→events dispatcher with a `never`-guard. A new `PermissionRoute` variant that forgets its audit record **fails to compile**, and because `server.ts` calls it, that surfaces in the production build — not only a test.
- **`permissionRouteJournalKinds()`** — kind-only convenience over the same dispatcher; the `ccsc-1iw.2` block now anchors to it.

### Deny stays untouched
The `deny` pair keeps flowing through `recordPolicyDenyToJournal` (awaited + resilient *before* the MCP deny notification, `ccsc-06s`) — the most-tested path, zero changes. A new consistency test pins the dispatcher's `deny` arm to that helper so the two paths cannot drift.

### Isolation
Type-only import of `PermissionRoute` from `lib.ts` (the vendored kernel is **not** mutated). `depcruise` clean.

## Verification

- `bun run typecheck` clean · `bun test` **1164 pass / 0 fail** (+8)
- All nine CI gates green locally: biome, coverage (96.57%, `policy-dispatch.ts` 100% func), depcruise, gherkin-lint, harness-hash, `bun audit`, crap-score
- New tests drive each builder + the exhaustive contract + the deny-path consistency through **production code**

Closes `ccsc-175`.

- Jeremy Longshore
intentsolutions.io