### PR TITLE
docs(claude-md): correct architecture drift (LoC, file/test counts, AGENTS.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,16 +6,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Slack channel for the Claude Code — two-way chat bridge via Socket Mode + MCP stdio.
 
+> **`AGENTS.md` is the cross-tool sibling of this file.** Top-level `AGENTS.md` follows the open [agents.md](https://agents.md) spec and is the instruction surface read by non-Claude assistants (Codex CLI, Cursor, Cline, Gemini CLI, Copilot, etc.). This `CLAUDE.md` is the Claude-Code-specific layer. When a fact in one (architecture, security model, gates) changes, update both — they must not drift.
+
 ## Architecture
 
-Bun/TypeScript, strict mode. ~16 production source files (LoC drifts every commit — run `wc -l *.ts` for current). The load-bearing core:
+Bun/TypeScript, strict mode. ~17 production source files (LoC drifts every commit — run `wc -l *.ts` for current). The load-bearing core:
 
 | File | ~LoC | Purpose |
 |---|---|---|
-| `server.ts` | 3250 | Stateful runtime — Slack client bootstrap, MCP server, event handlers, file I/O |
-| `lib.ts` | 1894 | Pure functions — `gate()`, `assertSendable()`, `assertOutboundAllowed()`, session types, audit-receipt helpers |
-| `journal.ts` | 1450 | Hash-chained audit log — `JournalWriter`, `verifyJournal`, redactor (Epic 30-A) |
-| `supervisor.ts` | 980 | `SessionSupervisor` — activate / deactivate / quiesce, idle reaper, quarantine (Epic 32) |
+| `server.ts` | 3518 | Stateful runtime — Slack client bootstrap, MCP server, event handlers, file I/O |
+| `lib.ts` | 2369 | Pure functions — `gate()`, `assertSendable()`, `assertOutboundAllowed()`, session types, audit-receipt + idempotent-send helpers |
+| `supervisor.ts` | 1721 | `SessionSupervisor` — activate / deactivate / quiesce, idle reaper, quarantine (Epic 32), outbox drain (`drainOutbox`, ccsc-o7x) |
+| `journal.ts` | 1458 | Hash-chained audit log — `JournalWriter`, `verifyJournal`, redactor (Epic 30-A) |
 | `policy.ts` | 818 | Declarative policy engine — `evaluate()`, `detectShadowing`, `checkMonotonicity` (Epic 29) |
 | `manifest.ts` | 573 | Bot-manifest protocol — schema, publish-side validation, subset check (Epic 31) |
 
@@ -29,6 +31,7 @@ Supporting modules (epic-scoped; each file header carries its `ccsc-*` bead tag)
 | `peer-bot-rate-limit.ts` | Per-(channel, bot_id) sliding-window limit breaking A→B→A runaway loops |
 | `stream-reply.ts` | Progressive Slack reply via `chat.update` |
 | `acp-adapter.ts` | Agent Client Protocol (ACP) stdio boundary adapter |
+| `slack-delivery.ts` | Thin Slack-`WebClient` adapter for the crash-safe reply-delivery outbox (ccsc-o7x): `findDelivered` / `post` with the idempotency key stamped into message metadata. Kept a sibling of `server.ts` so it can be unit-tested against a faked client without triggering server module-load side effects; the idempotent-send logic itself lives in `lib.ts` (`makeIdempotentSend`, `deliveryIdempotencyKey`). |
 
 Runtime dependencies: `@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`, `tsx`. No frameworks.
 
@@ -49,7 +52,7 @@ Slack workspace → Socket Mode WebSocket → server.ts → MCP stdio → Claude
 ```bash
 bun install                              # Install deps
 bun run typecheck                        # TypeScript strict check (tsc --noEmit)
-bun test                                 # Run test suite (bun:test) — ~986 tests
+bun test                                 # Run test suite (bun:test) — ~1,033 tests
 bun test --timeout 15000                 # Match CI's timeout
 bun test --watch                         # Watch mode
 bun test --test-name-pattern "gate"      # Run tests matching a pattern
@@ -130,7 +133,7 @@ echo '{"strict":true, "contexts":["Typecheck"]}' | gh api -X PATCH repos/jeremyl
 - `manifest.ts` — bot-manifest protocol (Epic 31): schema, `assertPublishAllowed`, `validateManifestSubset`
 
 ### Tests & acceptance contracts
-- `server.test.ts` — primary test suite covering security-critical functions (uses `bun:test`). Total across all four test files (`server.test.ts` + `features/gate-properties.test.ts` + `features/jcs-interop.test.ts` + `features/runner.test.ts`) is **~986 tests / ~6,017 expects** (a moving snapshot — exact count drifts with every feature commit; soft floor lives in coverage, not test count). Run a subset with `bun test --test-name-pattern "<pattern>"`.
+- `server.test.ts` — primary test suite covering security-critical functions (uses `bun:test`). Total across all four test files (`server.test.ts` + `features/gate-properties.test.ts` + `features/jcs-interop.test.ts` + `features/runner.test.ts`) is **~1,033 `it`/`test` blocks** (`grep -cE "^\s*(it|test)\(" server.test.ts features/*.test.ts`; `features/runner.test.ts` adds the 61 Gherkin scenarios through a hand-rolled runner rather than `it()` blocks). A moving snapshot — exact count drifts with every feature commit; the soft floor lives in coverage, not test count. Run a subset with `bun test --test-name-pattern "<pattern>"`.
 - `features/*.feature` — Wall 1 acceptance contracts (engineer-owned, pinned by `.harness-hash`); seven primitives: `inbound_gate`, `file_exfiltration_guard`, `outbound_reply_filter`, `policy_evaluation`, `audit_chain_verifier`, `admin_commands`, `tier-shadow`
 - `features/runner.ts` + `features/runner.test.ts` + `features/steps/*.ts` — hand-rolled Gherkin runner executing all 61 scenarios against the real primitives
 - `features/gate-properties.test.ts` — fast-check property-based tests for `gate()`; `features/jcs-interop.test.ts` — RFC 8785 JCS canonicalization interop for audit signing


### PR DESCRIPTION
## What

Corrects factual drift in `CLAUDE.md` against the current working tree. Doc-only — no code, no gate changes.

| Claim | Was | Now | How verified |
|---|---|---|---|
| `supervisor.ts` LoC | 980 | **1721** | `wc -l` (grew with the ccsc-o7x outbox-drain work) |
| `lib.ts` LoC | 1894 | **2369** | `wc -l` |
| `server.ts` LoC | 3250 | **3518** | `wc -l` |
| `journal.ts` LoC | 1450 | **1458** | `wc -l` |
| Production source files | ~16 | **~17** | `ls *.ts` — new `slack-delivery.ts` |
| Test blocks | ~986 | **~1,033** | `grep -cE "^\s*(it\|test)\(" server.test.ts features/*.test.ts` |

`policy.ts` (818) and `manifest.ts` (573) were still accurate and left unchanged.

## Also

- **Added `slack-delivery.ts`** to the supporting-modules table — the crash-safe reply-delivery `WebClient` adapter (ccsc-o7x); idempotent-send logic lives in `lib.ts` (`makeIdempotentSend`, `deliveryIdempotencyKey`), drained by `supervisor.ts` (`drainOutbox`).
- **Dropped the `~6,017 expects` figure** — a clean grep counts ~2,300, so the stated number was stale or counted by an unreproducible method. Replaced with the exact grep that yields the `it`/`test`-block count.
- **Noted the new top-level `AGENTS.md`** (agents.md spec) as the cross-tool sibling of `CLAUDE.md`, with a keep-in-sync requirement so the two instruction surfaces don't drift.

## Confirmed still-current (no change)

Mutation baselines (journal 85.26 / lib 85.01 / manifest 92.02 / policy 89.78 / all 86.72, post-ccsc-2et), the CI nine-gate chain, 61 scenarios across 7 `.feature` files, and the design-doc list.

- Jeremy Longshore
intentsolutions.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture and development documentation with revised component sizing metrics and test count updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->