### PR TITLE
docs: true up CLAUDE.md + README + CHANGELOG to current codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Docs**: True up `CLAUDE.md` + `README.md` to the current codebase — test count `~1,033`/`1,237` → `~1,251` (authoritative `bun test` count; noted the `it`/`test` grep undercounts at ~1,120 because it misses `test.each` expansions and the Gherkin runner), refreshed the module LoC table (`server.ts` 3820 / `lib.ts` 2552 / `supervisor.ts` 1810 / `journal.ts` 1461), and dropped the stale "thin adapter" label on `slack-delivery.ts` (738 LoC). Reconciles `CLAUDE.md` ↔ `README.md` ↔ `AGENTS.md`. (#257)
+
 ## [0.12.0] - 2026-06-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,10 @@ Bun/TypeScript, strict mode. ~17 production source files (LoC drifts every commi
 
 | File | ~LoC | Purpose |
 |---|---|---|
-| `server.ts` | 3518 | Stateful runtime — Slack client bootstrap, MCP server, event handlers, file I/O |
-| `lib.ts` | 2369 | Pure functions — `gate()`, `assertSendable()`, `assertOutboundAllowed()`, session types, audit-receipt + idempotent-send helpers |
-| `supervisor.ts` | 1721 | `SessionSupervisor` — activate / deactivate / quiesce, idle reaper, quarantine (Epic 32), outbox drain (`drainOutbox`, ccsc-o7x) |
-| `journal.ts` | 1458 | Hash-chained audit log — `JournalWriter`, `verifyJournal`, redactor (Epic 30-A) |
+| `server.ts` | 3820 | Stateful runtime — Slack client bootstrap, MCP server, event handlers, file I/O |
+| `lib.ts` | 2552 | Pure functions — `gate()`, `assertSendable()`, `assertOutboundAllowed()`, session types, audit-receipt + idempotent-send helpers |
+| `supervisor.ts` | 1810 | `SessionSupervisor` — activate / deactivate / quiesce, idle reaper, quarantine (Epic 32), outbox drain (`drainOutbox`, ccsc-o7x) |
+| `journal.ts` | 1461 | Hash-chained audit log — `JournalWriter`, `verifyJournal`, redactor (Epic 30-A) |
 | `policy.ts` | 818 | Declarative policy engine — `evaluate()`, `detectShadowing`, `checkMonotonicity` (Epic 29) |
 | `manifest.ts` | 573 | Bot-manifest protocol — schema, publish-side validation, subset check (Epic 31) |
 
@@ -31,7 +31,7 @@ Supporting modules (epic-scoped; each file header carries its `ccsc-*` bead tag)
 | `peer-bot-rate-limit.ts` | Per-(channel, bot_id) sliding-window limit breaking A→B→A runaway loops |
 | `stream-reply.ts` | Progressive Slack reply via `chat.update` |
 | `acp-adapter.ts` | Agent Client Protocol (ACP) stdio boundary adapter |
-| `slack-delivery.ts` | Thin Slack-`WebClient` adapter for the crash-safe reply-delivery outbox (ccsc-o7x): `findDelivered` / `post` with the idempotency key stamped into message metadata. Kept a sibling of `server.ts` so it can be unit-tested against a faked client without triggering server module-load side effects; the idempotent-send logic itself lives in `lib.ts` (`makeIdempotentSend`, `deliveryIdempotencyKey`). |
+| `slack-delivery.ts` | Slack-`WebClient` adapter (~738 LoC) for the crash-safe reply-delivery outbox (ccsc-o7x): `findDelivered` / `post` with the idempotency key stamped into message metadata. Kept a sibling of `server.ts` so it can be unit-tested against a faked client without triggering server module-load side effects; the idempotent-send logic itself lives in `lib.ts` (`makeIdempotentSend`, `deliveryIdempotencyKey`). |
 
 Runtime dependencies: `@modelcontextprotocol/sdk`, `@slack/web-api`, `@slack/socket-mode`, `zod`, `tsx`. No frameworks.
 
@@ -52,7 +52,7 @@ Slack workspace → Socket Mode WebSocket → server.ts → MCP stdio → Claude
 ```bash
 bun install                              # Install deps
 bun run typecheck                        # TypeScript strict check (tsc --noEmit)
-bun test                                 # Run test suite (bun:test) — ~1,033 tests
+bun test                                 # Run test suite (bun:test) — ~1,251 tests
 bun test --timeout 15000                 # Match CI's timeout
 bun test --watch                         # Watch mode
 bun test --test-name-pattern "gate"      # Run tests matching a pattern
@@ -133,7 +133,7 @@ echo '{"strict":true, "contexts":["Typecheck"]}' | gh api -X PATCH repos/jeremyl
 - `manifest.ts` — bot-manifest protocol (Epic 31): schema, `assertPublishAllowed`, `validateManifestSubset`
 
 ### Tests & acceptance contracts
-- `server.test.ts` — primary test suite covering security-critical functions (uses `bun:test`). Total across all four test files (`server.test.ts` + `features/gate-properties.test.ts` + `features/jcs-interop.test.ts` + `features/runner.test.ts`) is **~1,033 `it`/`test` blocks** (`grep -cE "^\s*(it|test)\(" server.test.ts features/*.test.ts`; `features/runner.test.ts` adds the 61 Gherkin scenarios through a hand-rolled runner rather than `it()` blocks). A moving snapshot — exact count drifts with every feature commit; the soft floor lives in coverage, not test count. Run a subset with `bun test --test-name-pattern "<pattern>"`.
+- `server.test.ts` — primary test suite covering security-critical functions (uses `bun:test`). `bun test` reports **~1,251 tests** across the four test files (`server.test.ts` + `features/gate-properties.test.ts` + `features/jcs-interop.test.ts` + `features/runner.test.ts`), where `features/runner.test.ts` runs the 61 Gherkin scenarios through a hand-rolled runner. (A raw `grep -cE "^\s*(it|test)\(" server.test.ts features/*.test.ts` undercounts at ~1,120 — it misses `test.each` expansions and the Gherkin scenarios.) A moving snapshot — exact count drifts with every feature commit; the soft floor lives in coverage, not test count. Run a subset with `bun test --test-name-pattern "<pattern>"`.
 - `features/*.feature` — Wall 1 acceptance contracts (engineer-owned, pinned by `.harness-hash`); seven primitives: `inbound_gate`, `file_exfiltration_guard`, `outbound_reply_filter`, `policy_evaluation`, `audit_chain_verifier`, `admin_commands`, `tier-shadow`
 - `features/runner.ts` + `features/runner.test.ts` + `features/steps/*.ts` — hand-rolled Gherkin runner executing all 61 scenarios against the real primitives
 - `features/gate-properties.test.ts` — fast-check property-based tests for `gate()`; `features/jcs-interop.test.ts` — RFC 8785 JCS canonicalization interop for audit signing

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Security-critical code earns a hard gate. `ci.yml` runs nine checks in sequence 
 |---|---|
 | `bun run typecheck` | TypeScript strict, no `any` escape hatches |
 | Biome lint | curated rule set |
-| `bun test` | **1,237 tests / 6,760 assertions** across unit + property + Gherkin suites |
+| `bun test` | **1,251 tests / 6,782 assertions** across unit + property + Gherkin suites |
 | coverage floor | **≥ 95%** line + function (`scripts/coverage-floor.sh`) |
 | dependency-cruiser | architecture invariants (e.g. `policy.ts` may never import `manifest.ts`) |
 | Gherkin lint | acceptance-feature style, `--strict` |


### PR DESCRIPTION
## What

`/init` + `/claude-md-improver` audit found the repo docs had drifted on a few moving-target numbers. This trues them up. **Docs-only** — no code, no behavior change.

### Fixed drift
- **Test count**: `CLAUDE.md` said `~1,033`, `README` said `1,237` — the authoritative `bun test` count is **`~1,251`** (1251 pass / 6782 assertions). Reconciled all three (CLAUDE.md ↔ README ↔ AGENTS.md). Also noted the `it`/`test` grep undercounts at ~1,120 because it misses `test.each` expansions and the Gherkin runner.
- **Module LoC table**: `server.ts` 3518→3820, `lib.ts` 2369→2552, `supervisor.ts` 1721→1810, `journal.ts` 1458→1461.
- **`slack-delivery.ts`**: dropped the stale "thin adapter" label — it's 738 LoC after the durable file/streaming reply work.
- **CHANGELOG**: added an `[Unreleased]` → `### Changed` → `**Docs**` entry per the every-PR-lands-an-entry convention.

### Verified accurate (no change needed)
All 13 referenced scripts/configs exist · the 9 CI gates match `ci.yml` exactly · all 11 design docs resolve · mutation numbers are a labeled point-in-time snapshot · `AGENTS.md` pins no drift-prone counts.

- Jeremy Longshore
intentsolutions.io