### PR TITLE
docs: record post-release maintenance in v0.12.0 AAR

### DIFF
--- a/000-docs/v0.12.0-release-aar.md
+++ b/000-docs/v0.12.0-release-aar.md
@@ -54,6 +54,22 @@ Greptile (the intended AI reviewer) ran out of quota mid-session and stopped eng
 - Durable AI-reviewer decision (see reviewer note).
 - File-upload dedup residual: Slack file shares carry no app metadata, so dedup is a `(filename, size)` window scan — one narrow double-*deliver* window (never a loss or gate bypass), documented in the ADR-002 addendum.
 
+## Post-release maintenance (2026-07-01)
+
+A `/repo-sweep` → `/release` pass one week out. **No new release cut** — the window held docs + chores only, no code.
+
+**Docs PRs merged this window** (documentation/content, zero code change):
+
+| PR | What |
+|---|---|
+| `#257` | Trued up CLAUDE.md + README + CHANGELOG to the current codebase — test count `~1,251` (authoritative `bun test`), refreshed module LoC table, relabeled `slack-delivery.ts`; reconciled CLAUDE.md ↔ README ↔ AGENTS.md |
+| `#258` | Committed the "Claude for Slack" competitive content deliverables + tracking beads (epic `ccsc-bqw`) under `deliverables/claude-for-slack-compare/` |
+| `#259` | The rendered infographic preview PNG |
+
+**Sweep:** deleted 7 already-merged local branches (`#244`–`#251`, squash-merged 2026-06-23); local + origin left with `main` + `beads-backup` only. Working tree clean, 0 open PRs, all scaffolding present.
+
+**Release decision — NONE.** Since v0.12.0: **0 feat / 0 fix / 0 breaking** (5 docs + 3 chore/ci), 6 days out. Per the ceremony's own rule (docs/chore/ci-only → no release), no version bump — `v0.12.0` remains the head release. The audit confirmed version consistency, secrets-clean (the lone AWS-key-shaped grep hit is the allowlisted journal-redactor test fixture), branch protection, and doc currency all green. The `[Unreleased] → ### Changed → **Docs**` CHANGELOG entry stays queued for the next release that ships code.
+
 ## Rollback
 
 ```bash


### PR DESCRIPTION
Appends a **Post-release maintenance (2026-07-01)** section to the v0.12.0 AAR capturing the `/repo-sweep` + `/release` pass:

- **Sweep:** 7 already-merged local branches deleted; tree clean, 0 open PRs.
- **Docs PRs this window:** #257 (CLAUDE.md/README/CHANGELOG true-up), #258 (content deliverables + beads), #259 (infographic PNG).
- **Release decision: NONE** — 0 feat/fix/breaking since v0.12.0 (docs + chores only), so no version bump. `v0.12.0` stays head; the `[Unreleased]` docs entry stays queued for the next code release.

Docs-only.

- Jeremy Longshore
intentsolutions.io