### PR TITLE
docs(claude-md): note the deliverables/ content dir (non-code)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ Layout spec + lifecycle state machine + supervisor contract: [`000-docs/session-
 - Issues → 2–5 themed epics (A/B split + sub-epics when >5 children). Don't ship one flat epic with 10 children.
 - Branch naming: `feat/<description>-bz-<bead-id>` (multiple beads: chain `-bz-<bead>` per bead, e.g. `feat/security-scanners-bz-bsz-bz-8g6`). Docs-only: `docs/<description>`. Bug fixes: `fix/<description>-bz-<bead-id>`.
 - Client floor: Channels require Claude Code v2.1.80+ with `claude.ai` login (Research Preview constraint — see README).
+- `deliverables/` (top-level, tracked) holds **draft content, not code** — competitive one-pagers, social/blog drafts, and the standalone HTML infographic under `deliverables/claude-for-slack-compare/`. It's outside the runtime, the tests, and the CI gates; ignore it for codebase work (it's not architecture or spec).
 
 ## Issue tracking (bd) — readable-trail rule
 


### PR DESCRIPTION
Ran `claude-md-improver` — CLAUDE.md verified **fully current** (no code/scripts/CI/deps changed since the #257 true-up; all LoC/test-count/architecture facts still exact). The only delta was the new tracked `deliverables/` dir (added in #258) going undocumented.

Adds one Conventions bullet clarifying `deliverables/` is draft content, not code — outside the runtime/tests/gates — so a future session doesn't treat it as architecture or spec.

- Jeremy Longshore
intentsolutions.io