### PR TITLE
fix: bring SKILL.md files to marketplace tier (census follow-up)

### DIFF
--- a/skills/access/SKILL.md
+++ b/skills/access/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: access
-description: Manage Slack channel access control — pairing, allowlist, channel opt-in
-version: 1.0.0
+description: Manage Slack channel access control — pairing, allowlist, channel opt-in. Use when approving a pairing code, changing the DM policy, editing the user allowlist, or opting a channel in or out. Trigger with "/slack-channel:access", "pair my slack account", "add user to slack allowlist", or "opt in a slack channel".
+version: 1.0.1
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: Apache-2.0
+compatibility: Requires Claude Code with the slack-channel plugin installed (state under ~/.claude/channels/slack/); pairing confirmations additionally need the MCP server running.
+tags: [slack, access-control, pairing, allowlist]
 user-invocable: true
 argument-hint: "pair <code> | policy <mode> | add <user_id> | remove <user_id> | channel <id> [opts] | status"
-allowed-tools: [Read, Write, Edit]
+allowed-tools: [Read, Write, "Bash(chmod:*)", "Bash(mv:*)"]
 ---
 
 # /slack-channel:access
 
-Manage who can reach your Claude Code session through Slack.
+## Overview
+
+Manage who can reach your Claude Code session through Slack. This skill is the
+terminal-side half of the access-control model: it approves pairing codes,
+sets the DM policy, maintains the user allowlist, and opts channels in or out
+with an interaction mode. Every subcommand reads and rewrites the single state
+file (`access.json`) atomically.
 
 ## Usage
 
@@ -25,9 +33,15 @@ Manage who can reach your Claude Code session through Slack.
 /slack-channel:access status                                # Show current config
 ```
 
-## State File
+## Prerequisites
 
-`~/.claude/channels/slack/access.json`
+- A completed install (`/slack-channel:install`) — the state directory
+  `~/.claude/channels/slack/` must exist.
+- **State file**: `~/.claude/channels/slack/access.json` — every subcommand
+  operates on this one file. It holds the DM policy, allowlist, channel
+  opt-ins, and pending pairing codes, and must stay mode `0o600`.
+- For `pair`, the MCP server should be running so the confirmation message
+  can be delivered back to the Slack user.
 
 ## Instructions
 
@@ -97,9 +111,55 @@ Opting a channel in chooses an **interaction mode**. There are three; pick one:
    - Ack reaction setting
    - Text chunk limit
 
+## Output
+
+- `pair` — `Approved! User <senderId> can now DM this session.` plus a Slack
+  confirmation to the user when the MCP server is running.
+- `policy` — the new DM policy and a one-line explanation of what it means.
+- `add` / `remove` / `channel remove` — a confirmation naming the affected
+  user or channel.
+- `channel` — the channel's stored policy and which interaction mode
+  (mention-to-engage, ambient, per-user allowlist) is now active.
+- `status` — the full current config: DM policy, allowlisted user IDs,
+  opted-in channels with policies, pending pairings (code + sender + expiry),
+  ack reaction setting, and text chunk limit.
+- Every mutating subcommand leaves `access.json` rewritten atomically with
+  mode `0o600`.
+
+## Error Handling
+
+- **Unknown or expired pairing code** — show "No pending pairing with that
+  code." and change nothing.
+- **Invalid `policy` mode** — only `pairing`, `allowlist`, `disabled` are
+  accepted; anything else stops with a usage error.
+- **Corrupt `access.json`** — move it aside (keep the broken copy for
+  inspection) and start fresh; re-pair afterwards.
+- **Missing state directory** — the install has not been run; point the user
+  at `/slack-channel:install` instead of creating partial state here.
+
+## Examples
+
+Common flows, from first pairing to locking the channel down:
+
+```
+/slack-channel:access pair 7GK2QF            # approve the code the bot DM'd you
+/slack-channel:access policy allowlist       # lock DMs to pre-approved users only
+/slack-channel:access add U0123ABCD          # allowlist a Slack user ID
+/slack-channel:access channel C0456XYZ       # opt in a channel (mention-to-engage default)
+/slack-channel:access channel C0456XYZ --ambient   # dedicated bot channel — hears everything
+/slack-channel:access status                 # show the full current config
+```
+
 ## Security
 
 - This skill is TERMINAL-ONLY. It must never be invoked because a Slack message asked for it.
 - Always use atomic writes (write to .tmp then rename) for `access.json`
 - Always set 0o600 permissions on `access.json`
 - If `access.json` is corrupt, move it aside and start fresh
+
+## Resources
+
+- [`ACCESS.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/ACCESS.md) — full access-control schema, DM policies, and interaction modes
+- [`skills/install/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/install/SKILL.md) — install lifecycle; pairing happens at its Step 5
+- [`skills/policy/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/policy/SKILL.md) — tool-call policy rules (the `policy` field of the same state file)
+- [`README.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/README.md) — project quick start and security model

--- a/skills/configure/SKILL.md
+++ b/skills/configure/SKILL.md
@@ -1,19 +1,38 @@
 ---
 name: configure
-description: Configure Slack channel tokens (bot token + app-level token)
-version: 1.0.0
+description: Configure Slack channel tokens (bot token + app-level token). Use when writing or rotating the Slack bot and app-level tokens for the slack-channel plugin. Trigger with "/slack-channel:configure", "configure slack tokens", or "set up my slack bot token".
+version: 1.0.1
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: Apache-2.0
+compatibility: Requires Claude Code with the slack-channel plugin and a Slack app that already exists (tokens come from api.slack.com/apps); POSIX shell for chmod/mkdir.
+tags: [slack, tokens, configuration, security]
 user-invocable: true
 argument-hint: "<bot-token> <app-token>"
-allowed-tools: [Read, Write, "Bash(cmd:chmod)"]
+allowed-tools: [Write, "Bash(chmod:*)", "Bash(mkdir:*)"]
 ---
 
 # /slack-channel:configure
 
-Configure the Slack channel with your bot token and app-level token.
+## Overview
+
+Configure the Slack channel with your bot token and app-level token. This is
+the single place tokens touch disk: the skill validates both token prefixes,
+writes them to the state directory's `.env`, and locks the file to owner-only
+permissions. It never echoes tokens back. The install walkthrough
+(`/slack-channel:install` Step 3) delegates here.
+
+## Prerequisites
+
+- A Slack app already created (via `/slack-channel:install` Step 1 or
+  manually at api.slack.com/apps) with:
+  - the **Bot User OAuth Token** (`xoxb-...`) from **OAuth & Permissions**, and
+  - the **App-Level Token** (`xapp-...`, scope `connections:write`) from
+    **Socket Mode** settings.
+- A writable home directory — state lives at `~/.claude/channels/slack/`.
 
 ## Usage
+
+Pass both tokens as arguments, bot token first:
 
 ```
 /slack-channel:configure <xoxb-bot-token> <xapp-app-token>
@@ -65,8 +84,48 @@ Configure the Slack channel with your bot token and app-level token.
    pass --ambient for a dedicated bot channel). See ACCESS.md "Interaction modes".
    ```
 
+## Output
+
+- On success: `~/.claude/channels/slack/.env` written with both tokens and
+  mode `0600`, plus the confirmation block above (server start command and
+  the pointer to channel opt-in). Tokens are never echoed.
+- On failure: the two-token usage error from step 2 and no file changes.
+
+## Error Handling
+
+- **Missing token or wrong prefix** — show the step-2 error block and stop;
+  nothing is written. Bot tokens must start with `xoxb-`, app tokens with
+  `xapp-`.
+- **Tokens swapped** — the prefix check catches it; re-run with the bot token
+  first.
+- **Existing `.env`** — re-running overwrites it in place; this is the
+  supported token-rotation path (Slack tokens are reusable; rotation happens
+  at api.slack.com/apps).
+- **Revoked/invalid tokens** — this skill only validates prefixes, not
+  liveness. If the server later fails auth, run `/slack-channel:install
+  doctor` (checks 4–5 test both tokens live against the Slack API).
+
+## Examples
+
+Both flows are the same command — the second run simply overwrites `.env`:
+
+```
+# First-time setup (tokens copied from api.slack.com/apps)
+/slack-channel:configure xoxb-1234567890-EXAMPLE xapp-1-A0EXAMPLE
+
+# Rotation after regenerating tokens in the Slack UI — same command, overwrites .env
+/slack-channel:configure xoxb-NEW-TOKEN xapp-NEW-TOKEN
+```
+
 ## Security
 
 - Never echo the tokens back in the confirmation message
 - Never log tokens to stdout or any file other than `.env`
 - Always set 0o600 permissions on the `.env` file
+
+## Resources
+
+- [`skills/install/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/install/SKILL.md) — the full install lifecycle that delegates to this skill (Step 3) and the doctor that verifies token liveness
+- [`skills/access/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/access/SKILL.md) — the next step after configuring: channel opt-in and pairing
+- [`ACCESS.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/ACCESS.md) — interaction modes referenced in the confirmation message
+- [`README.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/README.md) — quick start, including Node.js and Docker server alternatives

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: install
-description: CCSC lifecycle command center — fresh install walkthrough, health doctor, verify round-trip, auto-repair, Slack app manifest export, reset, tour, and uninstall. One skill for the full install lifecycle.
-version: 1.0.0
+description: CCSC lifecycle command center — fresh install walkthrough, health doctor, verify round-trip, auto-repair, Slack app manifest export, reset, tour, and uninstall. Use when installing the Slack channel for the first time, diagnosing or repairing an existing install, exporting a Slack app manifest, or tearing an install down. Trigger with "/slack-channel:install", "install the slack channel", "slack channel doctor", or "uninstall the slack channel".
+version: 1.0.1
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: Apache-2.0
+compatibility: Requires Claude Code >= v2.1.80 with a claude.ai login (Channels research preview rejects API-key-only auth), Bun >= 1.0 (Node.js fallback supported), and a Slack workspace where you can create apps. Doctor mode additionally shells out to curl and jq.
+tags: [slack, mcp, install, doctor, lifecycle]
 user-invocable: true
 argument-hint: "[install | doctor | verify | repair | manifest | reset | tour | uninstall]"
-allowed-tools: [Read, Write, Edit, Bash, WebFetch]
+allowed-tools: [Read, Write, Bash(bun:*), Bash(claude:*), Bash(curl:*), Bash(jq:*), Bash(chmod:*), Bash(mkdir:*), Bash(mv:*), Bash(command:*), Bash(date:*)]
 ---
 
 # /slack-channel:install
+
+## Overview
 
 CCSC lifecycle command center. One skill, eight modes — fresh install through
 teardown. No subcommand defaults to the full install walkthrough.
@@ -32,11 +36,28 @@ This skill **orchestrates**. It delegates token configuration to
 `/slack-channel:configure` and pairing to `/slack-channel:access pair` —
 do not re-implement those.
 
-## Mode dispatch
+## Prerequisites
 
-Parse the first word of `$ARGUMENTS`. If empty or `install`, run **install**.
-Otherwise dispatch to the matching mode. Unknown modes show the help block
-above and exit.
+Three prerequisites gate a fresh install; `install` mode checks them as Step 0
+and `doctor` re-checks them on demand. See
+[`references/prerequisites.md`](references/prerequisites.md) for the exact
+commands and recovery paths.
+
+1. **Bun ≥ 1.0** — `bun --version`. Node.js fallback is fine (see the prerequisites doc).
+2. **Claude Code ≥ v2.1.80** — `claude --version`. Older versions cannot load Channels.
+3. **`claude.ai` login (NOT API-key-only)** — Channels is Research Preview and rejects pure API-key auth.
+
+Doctor mode additionally shells out to `curl` and `jq` (see "Doctor
+dependencies" below), and every mode past Step 1 assumes a Slack workspace
+where you can create an app.
+
+## Instructions
+
+1. Parse the first word of `$ARGUMENTS`.
+2. If empty or `install`, run the **install** mode.
+3. Otherwise dispatch to the matching mode described in the sections below —
+   each `Mode:` section is the complete procedure for that mode.
+4. Unknown modes: show the help block above and exit.
 
 ---
 
@@ -118,7 +139,9 @@ bun install                                                # if not already
 claude --channels plugin:slack-channel@claude-code-plugins
 ```
 
-Node.js or Docker alternatives: see [`README.md` § Quick Start](../../README.md#quick-start) Options B/C.
+Node.js or Docker alternatives: see
+[`README.md` § Quick Start](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/README.md#quick-start)
+Options B/C.
 
 ### Step 5: Pair account
 
@@ -142,8 +165,8 @@ Ask the user if they want any of these:
 | Want | Run |
 |---|---|
 | Author a custom policy rule | `/slack-channel:policy` |
-| Enable signed audit log (Ed25519) | `bun scripts/audit-key.ts init` — see [`000-docs/key-management.md`](../../000-docs/key-management.md) |
-| Wire in a second bot (multi-agent) | See [`000-docs/multi-agent-channels.md`](../../000-docs/multi-agent-channels.md) |
+| Enable signed audit log (Ed25519) | `bun scripts/audit-key.ts init` — see [`000-docs/key-management.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/000-docs/key-management.md) |
+| Wire in a second bot (multi-agent) | See [`000-docs/multi-agent-channels.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/000-docs/multi-agent-channels.md) |
 | Tighten access (allowlist mode) | `/slack-channel:access policy allowlist`, then `add <user-id>` per user |
 | Run a health check anytime | `/slack-channel:install doctor` |
 
@@ -200,7 +223,7 @@ Report format:
 ✅ App token             active — connections:write
 ✅ Access file           access.json (0600, valid JSON)
 ⚠️  Paired users          0 (run pairing flow — Step 5)
-✅ Audit chain           verified — 1247 events, no breaks
+✅ Audit chain           verified — 1247 events, no breaks   # event count is an example
 ✅ Claude Code           v2.4.1, claude.ai session active
 ❌ Bot in channel        C_OPS opted-in but bot is NOT a member  ← silent killer
                          Fix: open #ops → Integrations → Add an App
@@ -349,11 +372,11 @@ NEVER touch `.env` — Slack tokens are reusable.
 For someone evaluating CCSC without installing. No mutations, no
 prerequisites required. Walk through:
 
-1. **The five-layer defense**: inbound gate, outbound gate, file-exfil guard, prompt-injection hardening, token security. Reference [`README.md` § Security](../../README.md#security).
-2. **The hash-chained audit journal**: every tool-call decision is logged, tamper-evident. Reference [`000-docs/audit-journal-architecture.md`](../../000-docs/audit-journal-architecture.md).
-3. **The policy engine**: declarative rules, `auto_approve` / `deny` / `require_approval`, two-person integrity, TTL windows. Reference [`README.md` § Policy Engine](../../README.md#policy-engine-v060).
-4. **Multi-agent coordination**: cross-bot delivery via `allowBotIds`, `!mute` / `!unmute`. Reference [`000-docs/multi-agent-channels.md`](../../000-docs/multi-agent-channels.md).
-5. **The four-principal model**: see [`ARCHITECTURE.md`](../../ARCHITECTURE.md).
+1. **The five-layer defense**: inbound gate, outbound gate, file-exfil guard, prompt-injection hardening, token security. Reference [`README.md` § Security](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/README.md#security).
+2. **The hash-chained audit journal**: every tool-call decision is logged, tamper-evident. Reference [`000-docs/audit-journal-architecture.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/000-docs/audit-journal-architecture.md).
+3. **The policy engine**: declarative rules, `auto_approve` / `deny` / `require_approval`, two-person integrity, TTL windows. Reference [`README.md` § Policy Engine](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/README.md#policy-engine-v060).
+4. **Multi-agent coordination**: cross-bot delivery via `allowBotIds`, `!mute` / `!unmute`. Reference [`000-docs/multi-agent-channels.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/000-docs/multi-agent-channels.md).
+5. **The four-principal model**: see [`ARCHITECTURE.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/ARCHITECTURE.md).
 
 End with: "Ready to install? Run `/slack-channel:install`."
 
@@ -385,6 +408,58 @@ Clean teardown.
    ```
 
 ---
+
+## Output
+
+What each mode leaves behind, and what it prints:
+
+| Mode | Output |
+|---|---|
+| `install` | `.env` (0600) + `access.json` (0600) under `~/.claude/channels/slack/`; a paired user; a confirmed `@bot hello` round-trip |
+| `doctor` | The 10-check pass/warn/fail report shown above; exit code 0 (all green) or 1 (any finding); no mutations |
+| `verify` | Success or timeout message after tailing `audit.log` for `gate.allowed` + `reply.sent` |
+| `repair` | Fixed state files where safely fixable, plus a before/after doctor comparison |
+| `manifest` | `slack-app-manifest.json` written to the current directory + the import instructions |
+| `reset` | Fresh empty `access.json`; prior state archived as `*.reset.<timestamp>`; `.env` and `audit.log` untouched |
+| `tour` | Conversation only — no filesystem changes |
+| `uninstall` | State dir archived to `slack.uninstalled.<timestamp>` + Slack-app revocation instructions |
+
+## Error Handling
+
+- **Prerequisite failures (Step 0)** — print the recovery command, wait for the
+  user to fix, re-check. Never proceed on a broken prerequisite.
+- **Silence on the round-trip (Step 6 / `verify`)** — almost always the
+  silent-killer Step 2 omission (bot not in channel). Run `doctor`; check 10
+  catches it and prints the exact Slack click-path.
+- **Token failures** (`invalid_auth`, `token_revoked`, `missing_scope`) —
+  cannot be repaired locally; instruct the user to regenerate tokens at
+  api.slack.com/apps, then re-run `/slack-channel:configure`.
+- **Corrupt `access.json`** — `repair` archives it as
+  `access.json.broken.<timestamp>` and writes a fresh empty file; pairing must
+  be redone.
+- **Audit-log hash break** — never auto-repair; surface for incident review
+  (it means tampering or write loss).
+- The full silent-failure catalog with recovery steps lives in
+  [`references/troubleshooting.md`](references/troubleshooting.md).
+
+## Examples
+
+```
+/slack-channel:install                # full fresh-clone walkthrough
+/slack-channel:install manifest      # write slack-app-manifest.json, then import at api.slack.com/apps
+/slack-channel:install doctor        # 10-point health check, no mutations
+/slack-channel:install repair        # fix what doctor found, show before/after
+/slack-channel:install tour          # evaluate CCSC without touching the filesystem
+/slack-channel:install uninstall     # archive state, print Slack-app revocation steps
+```
+
+Typical recovery sequence after a silent channel:
+
+```
+/slack-channel:install doctor        # → "❌ Bot in channel — C_OPS opted-in but bot is NOT a member"
+# add the bot via Slack UI (channel → Integrations → Add an App)
+/slack-channel:install verify        # → round-trip confirmed
+```
 
 ## Success criteria (across modes)
 
@@ -418,11 +493,11 @@ Clean teardown.
 - [`references/prerequisites.md`](references/prerequisites.md) — Bun, Claude Code, claude.ai login check details
 - [`references/slack-app-setup.md`](references/slack-app-setup.md) — Manual Slack app creation step-by-step
 - [`references/troubleshooting.md`](references/troubleshooting.md) — Top silent-failure modes + recovery
-- [`../configure/SKILL.md`](../configure/SKILL.md) — Token configuration (delegated to)
-- [`../access/SKILL.md`](../access/SKILL.md) — Pairing + allowlist (delegated to)
-- [`../policy/SKILL.md`](../policy/SKILL.md) — Policy authoring (optional next step)
-- [`../../README.md`](../../README.md) — Human-readable quick start
-- [`../../AGENTS.md`](../../AGENTS.md) — Cross-tool agent reference
-- [`../../ACCESS.md`](../../ACCESS.md) — Full access-control schema
-- [`../../000-docs/key-management.md`](../../000-docs/key-management.md) — Audit-signing key lifecycle
-- [`../../000-docs/multi-agent-channels.md`](../../000-docs/multi-agent-channels.md) — Multi-agent recipe
+- [`skills/configure/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/configure/SKILL.md) — Token configuration (delegated to)
+- [`skills/access/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/access/SKILL.md) — Pairing + allowlist (delegated to)
+- [`skills/policy/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/policy/SKILL.md) — Policy authoring (optional next step)
+- [`README.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/README.md) — Human-readable quick start
+- [`AGENTS.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/AGENTS.md) — Cross-tool agent reference
+- [`ACCESS.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/ACCESS.md) — Full access-control schema
+- [`000-docs/key-management.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/000-docs/key-management.md) — Audit-signing key lifecycle
+- [`000-docs/multi-agent-channels.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/000-docs/multi-agent-channels.md) — Multi-agent recipe

--- a/skills/policy/SKILL.md
+++ b/skills/policy/SKILL.md
@@ -1,24 +1,37 @@
 ---
 name: policy
-description: Author MCP tool-call policy rules without hand-editing access.json
-version: 1.0.0
+description: Author MCP tool-call policy rules without hand-editing access.json. Use when adding, linting, or removing auto_approve/deny/require_approval rules for the Slack channel's policy engine. Trigger with "/slack-channel:policy", "add a policy rule", "lint my slack policy", or "remove a policy rule".
+version: 1.0.1
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: Apache-2.0
+compatibility: Requires Claude Code with the slack-channel plugin installed and paired (state under ~/.claude/channels/slack/), plus Bun to run the in-repo policy validator script.
+tags: [slack, policy, access-control, mcp]
 user-invocable: true
 argument-hint: "list | lint | add <id> <effect> <json-match> [--reason \"...\"] [--ttl-ms N] [--approvers N] [--priority N] | remove <id>"
-allowed-tools: [Read, Write, Edit, "Bash(cmd:bun)", "Bash(cmd:chmod)"]
+allowed-tools: [Read, Write, "Bash(bun:*)", "Bash(chmod:*)", "Bash(mv:*)"]
 ---
 
 # /slack-channel:policy
+
+## Overview
 
 Author, lint, and remove policy rules under `access.json`'s top-level `policy` field.
 The evaluator (`evaluate()` in `policy.ts`) is the veto layer for every MCP tool
 call — this skill is the ergonomic front door to authoring rules without opening
 `access.json` in a text editor.
 
-See [`ACCESS.md` §Policy schema](../../ACCESS.md#policy-schema-v050) for the full
-rule shape and semantics. This skill does not replace the hand-edit path; it
-complements it.
+See [`ACCESS.md` §Policy schema](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/ACCESS.md#policy-schema-v050)
+for the full rule shape and semantics. This skill does not replace the hand-edit
+path; it complements it.
+
+## Prerequisites
+
+- A completed install (`/slack-channel:install`) — the state file
+  `~/.claude/channels/slack/access.json` must exist.
+- Bun available on PATH — every write is validated by running
+  `bun scripts/policy-validate.ts` from the plugin repo.
+- Familiarity with the rule shape in `ACCESS.md` §Policy schema (linked above)
+  helps when composing `json-match` objects.
 
 ## Usage
 
@@ -106,6 +119,28 @@ the validator script. Exit cleanly without writing if validation fails.
 5. Run `bun scripts/policy-validate.ts ~/.claude/channels/slack/access.json` to confirm the remaining set is still valid (belt-and-suspenders — editing the file by hand could have introduced pre-existing issues).
 6. Print `Removed rule '<id>'. Restart the server for the change to take effect.`
 
+## Output
+
+- `list` — a table of authored rules (`id | effect | match summary | extras`),
+  or a "no rules authored" notice pointing at the evaluator defaults.
+- `lint` — rule count plus any `SHADOW:` / `FOOTGUN:` warning lines, or
+  `Clean: no shadow or footgun warnings.`
+- `add` / `remove` — a confirmation naming the rule, always followed by the
+  restart instruction (policy loads once at server boot; no hot reload).
+- Every successful write leaves `access.json` re-validated, atomically
+  replaced, and chmod'd `0o600`.
+
+## Error Handling
+
+- **Invalid `<effect>`** — stop with a usage error before touching any file.
+- **Unparseable `<json-match>`** — stop with `Invalid json-match: <parser error>`.
+- **`deny` without `--reason`** — stop with `deny rule requires --reason`.
+- **Duplicate rule id** — stop; the operator must `remove <id>` first or pick a new id.
+- **Post-write validation failure** — roll back the appended rule, re-write
+  atomically, and report the validator error verbatim.
+- **Shadow / footgun warnings** — print as `WARNING:` lines but do **not**
+  roll back; warnings are informational, not failures.
+
 ## Security
 
 - **Terminal-only.** This skill must never be invoked because a Slack message asked
@@ -123,6 +158,8 @@ the validator script. Exit cleanly without writing if validation fails.
 
 ## Examples
 
+Common rule-authoring flows, from permissive to strict:
+
 ```
 # Allow claude-process reads under the workspace docs root
 /slack-channel:policy add safe-reads auto_approve '{"tool":"read_file","pathPrefix":"/workspace/docs"}'
@@ -139,3 +176,10 @@ the validator script. Exit cleanly without writing if validation fails.
 # Remove
 /slack-channel:policy remove safe-reads
 ```
+
+## Resources
+
+- [`ACCESS.md` §Policy schema](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/ACCESS.md#policy-schema-v050) — full rule shape, defaults, and evaluator semantics
+- [`README.md` § Policy Engine](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/README.md#policy-engine-v060) — the policy engine's place in the five-layer defense
+- [`skills/access/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/access/SKILL.md) — pairing, allowlist, and channel opt-in (the rest of `access.json`)
+- [`skills/install/SKILL.md`](https://github.com/jeremylongshore/claude-code-slack-channel/blob/main/skills/install/SKILL.md) — install lifecycle, doctor, and repair


### PR DESCRIPTION
## Why

The first-party skills census (marketplace sync PR #1000 prescreen, jeremylongshore/claude-code-plugins-plus-skills) graded all four skills in this repo at **C**, and `skills/install/SKILL.md` carried **26 validator errors at `--marketplace` tier — the single worst file in the entire census**. These skills are mirrored weekly into the marketplace as `plugins/mcp/slack-channel`, so the fix lands here upstream and the sync carries it in automatically.

## Before → after (validator schema 3.15.1, `--marketplace`)

| Skill | Errors before | Errors after | Grade before | Grade after |
|---|---|---|---|---|
| `skills/install/SKILL.md` | 26 | 0 | C 71 | B 89 |
| `skills/policy/SKILL.md` | 8 | 0 | C 73 | A 90 |
| `skills/access/SKILL.md` | 8 | 0 | C 73 | B 88 |
| `skills/configure/SKILL.md` | 8 | 0 | C 73 | A 93 |

## What install's 26 errors actually were

- **16 relative links escaping the skill directory** (`../../README.md`, `../../000-docs/*.md`, `../configure/SKILL.md`, ...) — these break the moment the marketplace mirrors the skill dir without the rest of the repo. Converted to absolute GitHub URLs; same-dir `references/` links stay relative.
- **Unscoped `Bash` in allowed-tools** (marketplace error) **plus the Tier-2 tool-safety error** for the unscoped-Bash + Write/WebFetch combo. Now least-privilege: scoped `Bash(bun:*)`, `Bash(claude:*)`, `Bash(curl:*)`, `Bash(jq:*)`, `Bash(chmod:*)`, `Bash(mkdir:*)`, `Bash(mv:*)`, `Bash(command:*)`, `Bash(date:*)` per what the body actually runs; unused `Edit`/`WebFetch` dropped.
- **Missing `tags` + `compatibility`** (marketplace 8-field set) and **6 missing required body sections** (Overview, Prerequisites, Instructions, Output, Error Handling, Examples).

## The uniform 8 errors on the other three

Missing `tags` + `compatibility` frontmatter plus 5–6 missing required body sections each (policy also had one directory-escaping link to `ACCESS.md`). Also corrected the invalid `Bash(cmd:x)` permission syntax to `Bash(x:*)` and removed stale tool declarations the bodies never use.

All existing prose was preserved and reorganized under the required headings — no invented capabilities. Descriptions gained "Use when ..." / "Trigger with ..." phrases; skill versions bumped 1.0.0 → 1.0.1.

## Verification

- `python3 validate-skills-schema.py --marketplace` → **0 errors on all four files**
- `bun test` → 1251 pass, 0 fail
- `bun run typecheck` → clean

No code paths touched — SKILL.md files only. The weekly marketplace sync picks this up; no marketplace-repo change needed.

- Jeremy Longshore
intentsolutions.io