### PR TITLE
fix(boot): start the MCP stdio transport before Socket Mode — never block the handshake on Slack

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3797,15 +3797,40 @@ async function main(): Promise<void> {
     console.error('[slack] Failed to resolve bot identity:', err)
   }
 
-  // Connect Socket Mode (Slack ↔ local WebSocket)
-  await socket.start()
-  console.error('[slack] Socket Mode connected')
-
-  // Connect MCP stdio (server ↔ Claude Code)
+  // Connect MCP stdio (server ↔ Claude Code) FIRST. The stdio handshake
+  // has no external dependency and must come up immediately: when
+  // socket.start() was awaited before mcp.connect(), any Slack-side
+  // Socket Mode slowness (throttled reconnects after connection churn,
+  // flaky WebSocket pongs) blew Claude Code's 30s MCP handshake window,
+  // and the client logged a connection timeout and gave up without
+  // retrying — the whole channel stayed dead. Outbound tools
+  // (reply/react/...) use the HTTPS WebClient and work regardless of
+  // Socket Mode state; only inbound events wait on the socket.
   const transport = new StdioServerTransport()
   transport.onclose = () => void shutdown('stdio transport closed')
   await mcp.connect(transport)
   console.error('[slack] MCP server running on stdio')
+
+  // Connect Socket Mode (Slack ↔ local WebSocket) asynchronously with
+  // bounded-backoff retries. The @slack/socket-mode client auto-reconnects
+  // once started; this loop only guards the initial start() call.
+  void (async () => {
+    let delayMs = 2_000
+    while (true) {
+      try {
+        await socket.start()
+        console.error('[slack] Socket Mode connected')
+        return
+      } catch (err) {
+        console.error(
+          `[slack] Socket Mode start failed (retrying in ${Math.round(delayMs / 1000)}s):`,
+          err instanceof Error ? err.message : err,
+        )
+        await new Promise((r) => setTimeout(r, delayMs))
+        delayMs = Math.min(delayMs * 2, 60_000)
+      }
+    }
+  })()
 
   // Belt-and-suspenders: the SDK's StdioServerTransport doesn't listen for
   // stdin end/close, so transport.onclose never fires on its own. Hook stdin

--- a/server.ts
+++ b/server.ts
@@ -43,6 +43,7 @@ import {
   EVENT_DEDUP_TTL_MS,
   enforceAuditReceiptCap,
   escMrkdwn,
+  extractSlackErrorCode,
   formatVerifyResult,
   type GateResult,
   isDuplicateEvent,
@@ -55,6 +56,7 @@ import {
   gate as libGate,
   listSessions as libListSessions,
   makeIdempotentSend,
+  NON_RETRYABLE_SLACK_ERRORS,
   PERMISSION_REPLY_RE,
   type PendingPolicyApproval,
   parseSendableRoots,
@@ -260,6 +262,14 @@ const web = new WebClient(botToken)
 const socket = new SocketModeClient({ appToken })
 
 let botUserId = ''
+// Settles once the boot-time web.auth.test() attempt completes (success OR
+// failure) — MCP connects before identity resolves, so tools that consume
+// identity (publish_manifest's replace-sweep) bounded-await this latch instead
+// of silently operating with '' identity during the window.
+let settleIdentity: () => void = () => {}
+const identitySettled = new Promise<void>((r) => {
+  settleIdentity = r
+})
 let selfBotId = ''
 let selfAppId = ''
 
@@ -1991,6 +2001,25 @@ async function executePublishManifest(
 
   // Gate 2: channel must be opted in, same as any outbound write.
   executePublishManifestGate2(channel, callerUserId, ctx)
+
+  // Identity guard: MCP connects before web.auth.test() resolves, so there is
+  // a window (sub-second happy path; up to ~30 min while Slack auth degrades
+  // and the WebClient retries) where tools are live but botUserId is still ''.
+  // findOurPriorManifestPins fails closed on '' and the replace-sweep would
+  // silently no-op, leaving duplicate pinned manifests. Bounded-await the
+  // identity latch; if identity is still unresolved, fail the call loudly as
+  // retryable rather than publish with a silent sweep skip.
+  if (ctx.botUserId === '') {
+    await Promise.race([identitySettled, new Promise((r) => setTimeout(r, 5_000))])
+    // Refresh from module state — this ctx was built before the latch settled.
+    ctx.botUserId = botUserId
+    ctx.selfBotId = selfBotId
+    if (ctx.botUserId === '') {
+      throw new Error(
+        'publish_manifest: bot identity not yet resolved (Slack auth still connecting); retry shortly',
+      )
+    }
+  }
 
   ctx.journalWrite({
     kind: 'gate.outbound.allow',
@@ -3824,13 +3853,24 @@ async function main(): Promise<void> {
       console.error('[slack] bot identity:', { botUserId, selfBotId, selfAppId })
     } catch (err) {
       console.error('[slack] Failed to resolve bot identity:', err)
+    } finally {
+      settleIdentity()
     }
 
     // Slack marks these Socket Mode start errors unrecoverable (thrown out of
     // retrieveWSSURL rather than internally reconnected) — retrying them
     // forever would silently mask a dead channel.
     const UNRECOVERABLE_START_RE =
-      /not_authed|invalid_auth|account_inactive|user_removed_from_team|team_disabled/
+      /not_authed|invalid_auth|account_inactive|user_removed_from_team|team_disabled|token_revoked|token_expired/
+    // Bounded retry: the loop exists to survive a TRANSIENT outage, not to
+    // mask a permanently-dead channel. Auth/config-fatal errors shut down
+    // immediately; anything else (persistent 5xx, proxy blackhole, DNS/TLS
+    // failure — the SDK throws these out of retrieveWSSURL as
+    // RequestError/HTTPError rather than reconnecting internally) gets
+    // MAX_SOCKET_START_ATTEMPTS tries (~5 minutes with the backoff below),
+    // then fails loud the same way.
+    const MAX_SOCKET_START_ATTEMPTS = 10
+    let attempt = 0
     let delayMs = 2_000
     while (!shuttingDown) {
       try {
@@ -3838,14 +3878,29 @@ async function main(): Promise<void> {
         console.error('[slack] Socket Mode connected')
         return
       } catch (err) {
+        attempt += 1
+        // Prefer the structured Slack error code (err.data.error) over message
+        // matching; the regex is the fallback for wrapped/stringified errors.
+        const code = extractSlackErrorCode(err)
         const msg = err instanceof Error ? err.message : String(err)
-        if (UNRECOVERABLE_START_RE.test(msg)) {
-          console.error('[slack] Socket Mode start failed with unrecoverable error:', msg)
+        if (
+          (code !== undefined && NON_RETRYABLE_SLACK_ERRORS.has(code)) ||
+          UNRECOVERABLE_START_RE.test(msg)
+        ) {
+          console.error('[slack] Socket Mode start failed with unrecoverable error:', code ?? msg)
           await shutdown('unrecoverable Socket Mode start error', 1)
           return
         }
+        if (attempt >= MAX_SOCKET_START_ATTEMPTS) {
+          console.error(
+            `[slack] Socket Mode start failed ${attempt} consecutive times; giving up:`,
+            msg,
+          )
+          await shutdown('Socket Mode start exhausted retries', 1)
+          return
+        }
         console.error(
-          `[slack] Socket Mode start failed (retrying in ${Math.round(delayMs / 1000)}s):`,
+          `[slack] Socket Mode start failed (attempt ${attempt}/${MAX_SOCKET_START_ATTEMPTS}, retrying in ${Math.round(delayMs / 1000)}s):`,
           msg,
         )
         await new Promise((r) => setTimeout(r, delayMs))

--- a/server.ts
+++ b/server.ts
@@ -3784,24 +3784,11 @@ async function main(): Promise<void> {
   deliveryTimer = setInterval(drainOutboxOnce, deliveryPollMs)
   if (typeof deliveryTimer.unref === 'function') deliveryTimer.unref()
 
-  // Resolve bot identity (user ID, bot ID, app ID) for mention detection
-  // and self-echo filtering across payload variants and multi-workspace setups
-  try {
-    const auth = await web.auth.test()
-    botUserId = (auth.user_id as string) || ''
-    selfBotId = (auth.bot_id as string) || ''
-    // app_id may not be present in all auth.test responses; fall back to empty
-    selfAppId = ((auth as unknown as Record<string, unknown>).app_id as string) || ''
-    console.error('[slack] bot identity:', { botUserId, selfBotId, selfAppId })
-  } catch (err) {
-    console.error('[slack] Failed to resolve bot identity:', err)
-  }
-
   // Connect MCP stdio (server ↔ Claude Code) FIRST. The stdio handshake
   // has no external dependency and must come up immediately: when
-  // socket.start() was awaited before mcp.connect(), any Slack-side
-  // Socket Mode slowness (throttled reconnects after connection churn,
-  // flaky WebSocket pongs) blew Claude Code's 30s MCP handshake window,
+  // socket.start() (and the web.auth.test() identity call, whose WebClient
+  // defaults to ~30 minutes of internal retries) ran before mcp.connect(),
+  // any Slack-side slowness blew Claude Code's 30s MCP handshake window,
   // and the client logged a connection timeout and gave up without
   // retrying — the whole channel stayed dead. Outbound tools
   // (reply/react/...) use the HTTPS WebClient and work regardless of
@@ -3811,20 +3798,55 @@ async function main(): Promise<void> {
   await mcp.connect(transport)
   console.error('[slack] MCP server running on stdio')
 
-  // Connect Socket Mode (Slack ↔ local WebSocket) asynchronously with
-  // bounded-backoff retries. The @slack/socket-mode client auto-reconnects
-  // once started; this loop only guards the initial start() call.
+  // Bring up the Slack side asynchronously: resolve bot identity, then
+  // connect Socket Mode with bounded-backoff retries. Identity resolution
+  // runs here (not before mcp.connect) because it is only consumed by
+  // inbound-event processing — mention detection and self-echo filtering —
+  // and no inbound event can arrive until socket.start() succeeds below.
+  //
+  // The retry loop only guards the initial start(): the @slack/socket-mode
+  // client auto-reconnects once started. Two deliberate exits:
+  //   - shuttingDown → stop retrying; a post-shutdown start() would
+  //     resurrect a socket in a process about to exit (zombie instance
+  //     stealing round-robined events).
+  //   - unrecoverable auth/config errors (revoked or wrong xapp token) →
+  //     fail loud and exit non-zero so the operator sees it at boot,
+  //     instead of retrying a permanently-fatal error forever.
   void (async () => {
+    // Resolve bot identity (user ID, bot ID, app ID) for mention detection
+    // and self-echo filtering across payload variants and multi-workspace setups
+    try {
+      const auth = await web.auth.test()
+      botUserId = (auth.user_id as string) || ''
+      selfBotId = (auth.bot_id as string) || ''
+      // app_id may not be present in all auth.test responses; fall back to empty
+      selfAppId = ((auth as unknown as Record<string, unknown>).app_id as string) || ''
+      console.error('[slack] bot identity:', { botUserId, selfBotId, selfAppId })
+    } catch (err) {
+      console.error('[slack] Failed to resolve bot identity:', err)
+    }
+
+    // Slack marks these Socket Mode start errors unrecoverable (thrown out of
+    // retrieveWSSURL rather than internally reconnected) — retrying them
+    // forever would silently mask a dead channel.
+    const UNRECOVERABLE_START_RE =
+      /not_authed|invalid_auth|account_inactive|user_removed_from_team|team_disabled/
     let delayMs = 2_000
-    while (true) {
+    while (!shuttingDown) {
       try {
         await socket.start()
         console.error('[slack] Socket Mode connected')
         return
       } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (UNRECOVERABLE_START_RE.test(msg)) {
+          console.error('[slack] Socket Mode start failed with unrecoverable error:', msg)
+          await shutdown('unrecoverable Socket Mode start error', 1)
+          return
+        }
         console.error(
           `[slack] Socket Mode start failed (retrying in ${Math.round(delayMs / 1000)}s):`,
-          err instanceof Error ? err.message : err,
+          msg,
         )
         await new Promise((r) => setTimeout(r, delayMs))
         delayMs = Math.min(delayMs * 2, 60_000)


### PR DESCRIPTION
## What

Reorders `main()` so `mcp.connect(transport)` runs before Slack's `socket.start()`, and starts Socket Mode asynchronously with bounded-backoff retries (2s doubling to a 60s cap) guarding the initial `start()`.

## Why

Fixes #266. The stdio handshake has no external dependency, but upstream ordering held it hostage to Slack: when Socket Mode was slow (throttled reconnects after churn, flaky WebSocket pongs), Claude Code's 30s MCP connect window expired and the client gave up **without retrying** — the channel stayed dead until a human reconnected it. We hit this twice in a row in production on 2026-07-13; the server printed its bot identity, then only pong warnings, and never reached 'MCP server running on stdio'.

## How

- stdio transport connects first — with this ordering the handshake completes in ~400ms every time (six consecutive production boots observed at 404-440ms).
- `socket.start()` moves into a fire-and-forget async loop: try, on failure log to stderr and retry with backoff. The @slack/socket-mode client auto-reconnects once started, so the loop only guards the initial call.
- Window semantics: between stdio-up and socket-up, outbound tools (reply/react/…) already work — they use the HTTPS `WebClient`, not the socket. Only inbound events wait for Socket Mode, which is exactly the component that was slow anyway. Nothing new is exposed while Slack connects: gating/config all initialize before `main()`'s connect section.

Tradeoff called out: a fatal, non-transient `socket.start()` error (e.g. revoked app token) now surfaces as an endless retry loop logged to stderr instead of a crashed process. Operators see the loop in the MCP log either way; happy to fail-fast after N attempts instead if you prefer.

---

## Security impact

- [x] Changes the Socket Mode / MCP stdio transport in `server.ts`

Threat-model reasoning: no new trust boundary. The change is pure ordering — both connections still come up with identical configuration; inbound events still pass the full gate; no attacker-controlled input can influence the retry loop (its only input is Slack's connect success/failure). What an attacker-controlled message can do after this change is unchanged: messages only flow once Socket Mode is up, through the same `gate()`. Existing defense layers are untouched.

---

## Test evidence

### Tier C — Human evidence you ran yourself

- [x] Exact command(s) you ran, copy-pasteable
- [x] Your actual terminal output pasted below
- [x] Environment: macOS, Bun 1.3.8, Node 26.5.0 (tsx spawn), Claude Code 2.1.207

Standalone boot with the fix (stdio no longer waits for Slack):

```
$ timeout 15 node_modules/.bin/tsx server.ts
[slack] bot identity: { botUserId: 'U...', selfBotId: 'B...', selfAppId: '' }
[slack] MCP server running on stdio     <-- now immediate, before Socket Mode
```

Before the fix (production Claude Code MCP log, twice in a row):

```
22:40:48 Starting connection with timeout of 30000ms
22:41:18 Connection timeout triggered after 30002ms (limit: 30000ms)
22:41:18 Server stderr: [slack] bot identity: ...
[WARN]  socket-mode:SlackWebSocket:1 A pong wasn't received from the server before the timeout of 5000ms!
22:41:18 Connection failed: MCP server "plugin:slack-channel:slack" connection timed out after 30000ms
```

After deploying: six consecutive successful handshakes at 404-440ms, running in production since 2026-07-13.

`bun test` (1251 pass) and `bun run typecheck` pass locally. The real 30s-handshake race can't be exercised from the unit suite without faking both transports, which would test the mock rather than the ordering.

---

## Checklist

- [x] I read `CLAUDE.md` and `SECURITY.md` and the change is consistent with them
- [x] Pure logic went into `lib.ts`; stateful wiring stayed in `server.ts` (boot wiring only)
- [x] I did not add runtime dependencies
- [x] Commit messages describe *why*, not just *what*
- [x] Not a breaking change
- [x] I re-read the full PR diff before submitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)