### PR TITLE
docs(policy): record ADR-003 — thread correlation for MCP permission requests is upstream-blocked (ccsc-x0t.6)

### DIFF
--- a/000-docs/ADR-003-permission-request-thread-correlation.md
+++ b/000-docs/ADR-003-permission-request-thread-correlation.md
@@ -1,0 +1,143 @@
+# ADR-003: Thread correlation for policy evaluation of MCP permission requests
+
+## Status
+
+**ACCEPTED (operating assumption) + DEFERRED (implementation)** — `ccsc-x0t.6`,
+epic #269. The literal fix the bead asked for ("`evaluate()` receives the
+originating thread of the specific tool call, not a global") is **not achievable
+within CCSC** at the current MCP surface — the data does not exist in-band. This
+ADR records that finding, the single-active-thread operating assumption we adopt
+in the meantime, the fail-safe mitigation design to implement if evidence
+warrants, and the upstream ask that would enable the real fix.
+
+## Context
+
+The sole production caller of `policy.evaluate()` is the MCP `permission_request`
+notification handler (`server.ts`). It builds the `ToolCall` with:
+
+```ts
+const sessionThread = lastActiveThread ?? ''
+const policyCall = {
+  tool: params.tool_name,
+  sessionKey: { channel: targetChannel, thread: sessionThread },
+  actor: 'claude_process',
+  input: {}, inputAvailable: false,   // see ADR / policy-evaluation-flow.md § Input-unavailable fail-safe (ccsc-x0t.5)
+}
+```
+
+`lastActiveThread` (and `lastActiveChannel` / `targetChannel`) are **module-level
+globals reassigned on every inbound Slack message** — they hold the *most-recent
+inbound* thread, not the thread that owns *this* tool call. Under interleaved
+multi-thread activity, a `permission_request` can be attributed to the wrong
+thread:
+
+- A `{ auto_approve, thread_ts: A }` rule can fire for a tool call that
+  originated in thread B (over-grant).
+- A `{ deny, thread_ts: Q }` quarantine can silently fail to fire when
+  `lastActiveThread` has moved off Q (under-enforcement).
+
+`ccsc-x0t` (#264) *narrowed* the prior global-match hole (thread_ts is now
+enforced in `matchApplies`), which paradoxically makes the racy global
+**load-bearing**: a thread-scoped rule now depends on `lastActiveThread` pointing
+at the right thread.
+
+## The feasibility finding (why the literal fix is blocked)
+
+The originating thread of a specific tool call is **not transmitted to the
+bridge**. Concretely:
+
+1. **The notification carries no correlation.** The `permission_request`
+   notification schema (`server.ts`) is exactly
+   `{ request_id, tool_name, description, input_preview }` — no thread, no
+   channel, no session id.
+2. **`pendingPermissions` is keyed by the same racy global.** It is keyed via
+   `permissionPairingKey(lastActiveThread, request_id)`, so it provides no
+   *independent* thread correlation — it is built from the global we are trying
+   to replace.
+3. **There is no prior `request_id → thread` map.** The `permission_request` is
+   the first time the bridge sees that `request_id`; the causal link between
+   "Claude decided to call a tool" and "which Slack thread prompted it" lives
+   only inside Claude Code's process context, which the bridge cannot read.
+
+So there is no in-band signal from which `evaluate()` could recover the tool
+call's true origin thread. The same limitation applies to the *channel*
+(`targetChannel` derives from the same global). This is an **architectural
+constraint of the current MCP permission surface**, not an oversight in CCSC.
+
+## Options considered
+
+**A. Single-active-thread operating assumption (accept + document).**
+Treat the bridge as correct *only* when at most one thread is actively driving
+tool calls at a time — the overwhelmingly common case for a single-operator
+channel. Document the limitation in the threat model. Zero code, zero new
+mechanism. Risk: silent misattribution under genuine concurrent multi-thread
+tool-calling.
+
+**B. Upstream notification-shape change (the real fix).**
+Ask Anthropic to include a session/thread correlation token in the
+`permission_request` notification (or a stable `request_id → session` mapping the
+bridge can observe *before* the permission request). Then `evaluate()` receives
+the true origin. This is the only path to precise per-thread governance under
+concurrency — but it is **out of CCSC's control** (a Claude Code change).
+
+**C. Multi-thread-ambiguity fail-safe (the mitigation).**
+Track threads that produced inbound activity within the permission window. When
+**more than one** thread is active and a matched rule is *thread-scoped*, the
+attribution is unreliable → treat the thread predicate as **indeterminate** and
+**fail safe to a human** (route to approval), reusing the exact machinery from
+`ccsc-x0t.5` (the input-unavailable fail-safe). Channel-scoped and tool-scoped
+rules are unaffected. Cost: added runtime state (a short-window active-thread
+set) and possible extra HITL prompts during legitimate bursts of multi-thread
+activity.
+
+## Decision
+
+1. **Adopt Option A as the operating assumption now**, documented here and as a
+   named limitation in `THREAT-MODEL.md`. CCSC's per-thread governance is precise
+   under single-active-thread operation (the common case) and is honest that it
+   degrades under concurrent multi-thread tool-calling.
+2. **Specify Option C as the chosen mitigation** (design above) and **defer its
+   implementation** until there is evidence of real concurrent multi-thread
+   misattribution, OR Option B does not materialize. We deliberately do **not**
+   ship speculative runtime state + extra HITL prompts to guard a case we have no
+   evidence occurs in practice — kernel-smallness beats a mechanism that adds
+   footguns for partial protection. If/when implemented, it composes with the
+   existing `indeterminate` decision path (no new decision kind).
+3. **File Option B upstream** as the durable fix — the ask is a
+   session/thread correlation field on the `permission_request` notification.
+   (Left to the maintainer to file on `anthropics/claude-code` — a public
+   feature request on Anthropic's repo is an outward action to author
+   deliberately, not automate.)
+
+**Chose "document + defer the mitigation" over "implement Option C now"** because
+the mitigation trades real UX cost (false HITL prompts on legitimate bursts) for
+protection against a failure mode we have not observed, and the *complete* fix is
+upstream regardless. Documenting the boundary honestly is the higher-integrity
+move than a heuristic that papers over it.
+
+## Consequences
+
+- **Residual risk (accepted, documented):** under genuine concurrent
+  multi-thread tool-calling, a thread-scoped `auto_approve` may fire for the
+  wrong thread (over-grant) or a thread-scoped `deny`/`require` may miss
+  (under-enforcement). Channel-, tool-, actor-, and arg-scoped rules are
+  unaffected; the human approver still sees every `require`/Block-Kit prompt in
+  *some* thread and can refuse. The signed journal records the (possibly-wrong)
+  `sessionKey` faithfully, so misattribution is *auditable after the fact*.
+- **When the assumption holds** (single active thread — the common single-
+  operator case), per-thread governance is precise.
+- **Trigger to implement Option C:** a reproduced case of concurrent
+  multi-thread misattribution, or a decision that Option B will not land.
+- **Trigger to implement Option B's consumption:** the notification gains a
+  correlation field; then `sessionThread`/`targetChannel` are read from the
+  notification and this whole class closes.
+
+## Related
+
+- `000-docs/policy-evaluation-flow.md` § Input-unavailable fail-safe — the
+  `indeterminate` machinery Option C reuses.
+- `000-docs/THREAT-MODEL.md` — the thread-attribution limitation (added with
+  this ADR).
+- `ccsc-x0t.5` — the fail-safe pattern; `ccsc-x0t.1` — thread_ts in the subset
+  linters.
+- Bead `ccsc-x0t.6` (this ADR) under epic #269.

--- a/000-docs/THREAT-MODEL.md
+++ b/000-docs/THREAT-MODEL.md
@@ -576,6 +576,23 @@ Catalogued here so they appear in every later design review:
   must be added to the *Outbound primitives* table above in the same PR,
   with its `assertOutboundAllowed` / `assertSendable` call sites shown in
   the diff.
+- **R7. Thread misattribution under concurrent multi-thread tool-calling**
+  (`ccsc-x0t.6`, [`ADR-003`](ADR-003-permission-request-thread-correlation.md)).
+  The MCP `permission_request` notification carries no thread/session
+  correlation, so `evaluate()` reads the tool call's `(channel, thread)` from
+  the module-global `lastActiveThread`/`targetChannel` (the most-recent inbound
+  message), not the call's true origin. Under genuinely concurrent multi-thread
+  tool-calling this can misattribute a call: a thread-scoped `auto_approve` may
+  fire for the wrong thread (over-grant) or a thread-scoped `deny`/`require` may
+  miss (under-enforcement). Channel-, tool-, actor-, and arg-scoped rules are
+  unaffected, and the human still sees every `require` prompt in *some* thread.
+  **Accepted operating assumption:** single-active-thread (precise for the common
+  single-operator case); the signed journal records the (possibly-wrong)
+  `sessionKey` faithfully so misattribution is auditable. The precise fix needs
+  an upstream notification-shape change (a correlation field); the interim
+  mitigation (fail-safe thread-scoped rules to a human when >1 thread is active,
+  reusing the `ccsc-x0t.5` `indeterminate` path) is designed and deferred pending
+  evidence. Full analysis + decision: ADR-003.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- **ADR-003 — thread correlation for policy evaluation of MCP permission requests** (cold-contributor review follow-up `ccsc-x0t.6`, epic #269). The bead asked to propagate the tool call's *own* thread into `evaluate()` instead of the racy `lastActiveThread` global. Investigation found this is **not achievable within CCSC** at the current MCP surface: the `permission_request` notification carries no thread/session correlation, `pendingPermissions` is keyed by the same global, and there is no prior `request_id → thread` map — the causal link lives only in Claude Code's process context. ADR-003 records that finding, **accepts the single-active-thread operating assumption** (precise for the common single-operator case), **specifies the fail-safe mitigation** (route thread-scoped rules to a human when >1 thread is active, reusing the `ccsc-x0t.5` `indeterminate` path) and defers it pending evidence, and names the **upstream ask** (a correlation field on the notification) as the durable fix. Chose "document + defer" over shipping a speculative heuristic that trades false HITL prompts for protection against an unobserved failure mode. Added as residual risk **R7** in `THREAT-MODEL.md`.
+
 ### Changed
 
 - **Docs**: True up `CLAUDE.md` + `README.md` to the current codebase — test count `~1,033`/`1,237` → `~1,251` (authoritative `bun test` count; noted the `it`/`test` grep undercounts at ~1,120 because it misses `test.each` expansions and the Gherkin runner), refreshed the module LoC table (`server.ts` 3820 / `lib.ts` 2552 / `supervisor.ts` 1810 / `journal.ts` 1461), and dropped the stale "thin adapter" label on `slack-delivery.ts` (738 LoC). Reconciles `CLAUDE.md` ↔ `README.md` ↔ `AGENTS.md`. (#257)


### PR DESCRIPTION
## What

The last open child of epic #269 (`ccsc-x0t.6`) asked to propagate a tool call's *own* thread into `evaluate()` instead of the racy `lastActiveThread` global. Investigation proved the literal fix is **not achievable within CCSC**: the MCP `permission_request` notification carries no thread/session correlation, `pendingPermissions` is keyed by the same global, and there is no prior `request_id → thread` map — the causal link lives only in Claude Code's process context.

## Why

When a bead's premise mismatches reality, the honest resolution is a **decision record**, not forced code. **Chose "document the operating assumption + specify the mitigation + name the upstream ask" over shipping a speculative multi-thread heuristic**, because the heuristic trades real UX cost (false HITL prompts) for protection against an unobserved failure mode, and the complete fix is upstream regardless.

## What's in it

- **`ADR-003`** — the feasibility finding; the **single-active-thread operating assumption** (ACCEPTED, precise for the common single-operator case); the **fail-safe mitigation** (DEFERRED — route thread-scoped rules to a human when >1 thread is active, reusing the `ccsc-x0t.5` `indeterminate` path); and the **upstream ask** (a correlation field on the notification) left for the maintainer to file deliberately on `anthropics/claude-code`.
- **`THREAT-MODEL.md`** — new residual risk **R7** pointing at ADR-003.
- **CHANGELOG** — `[Unreleased]` Docs entry.

## Verification

Docs-only — typecheck clean; no code or test changes.

## Risk

None (documentation). The residual risk R7 it documents was already present in the code; this makes it explicit, auditable, and records the decision trail. Implementation of the mitigation is deferred pending evidence of real concurrent multi-thread misattribution, or the upstream fix.

## Governance links

- [`000-docs/ADR-003-permission-request-thread-correlation.md`](000-docs/ADR-003-permission-request-thread-correlation.md)
- [`000-docs/THREAT-MODEL.md`](000-docs/THREAT-MODEL.md) R7
- Related: `ccsc-x0t.5` (the `indeterminate` machinery the mitigation reuses)

Refs #269