### PR TITLE
feat(reliability): reconnect/startup catch-up for messages missed while disconnected

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -2171,6 +2171,124 @@ export function isDuplicateEvent(
 }
 
 // ---------------------------------------------------------------------------
+// Reconnect / startup catch-up watermarks (ccsc-reconnect-catchup)
+// ---------------------------------------------------------------------------
+//
+// Slack Socket Mode does NOT redeliver events that were sent while the app
+// was disconnected (host asleep / rebooted / crashed). The bridge therefore
+// persists a per-channel high-water mark — the `ts` of the last message it
+// finished processing in each channel — to STATE_DIR/watermarks.json. On
+// (re)connect it pulls conversations.history for everything newer than the
+// mark and replays it through the SAME gate()/handleMessage path, so nothing
+// the operator sent during the gap is silently lost. These helpers are the
+// pure, side-effect-free core (parse / advance / select); the disk I/O and
+// the conversations.history call live in server.ts.
+
+/** Per-channel high-water mark: `channel_id` → the Slack `ts` string of the
+ *  last message the bridge finished processing in that channel. Slack `ts`
+ *  is `"SSSSSSSSSS.mmmmmm"` (Unix seconds, dot, 6-digit intra-second
+ *  counter) and is globally monotonic per channel. */
+export type Watermarks = Record<string, string>
+
+/** Compare two Slack `ts` strings. Returns <0 when `a` is older than `b`,
+ *  0 when equal, >0 when `a` is newer.
+ *
+ *  `parseFloat` would lose precision at the 16th significant digit (a full
+ *  `ts` carries 16), so the two halves are compared as integers instead —
+ *  exact across the whole `ts` space. A missing or non-numeric half sorts as
+ *  0 for that component, so a malformed `ts` can't throw or sort wildly. */
+export function compareSlackTs(a: string, b: string): number {
+  const dotA = a.indexOf('.')
+  const dotB = b.indexOf('.')
+  const secA = dotA >= 0 ? a.slice(0, dotA) : a
+  const secB = dotB >= 0 ? b.slice(0, dotB) : b
+  const subA = dotA >= 0 ? a.slice(dotA + 1) : ''
+  const subB = dotB >= 0 ? b.slice(dotB + 1) : ''
+
+  const toInt = (s: string): number => {
+    const n = Number.parseInt(s, 10)
+    return Number.isFinite(n) ? n : 0
+  }
+
+  const secDiff = toInt(secA) - toInt(secB)
+  if (secDiff !== 0) return secDiff < 0 ? -1 : 1
+  // Right-pad the fractional counter to 6 digits so "5" and "500000"
+  // compare the way Slack means them (it always emits 6, but be defensive).
+  const subDiff = toInt(subA.padEnd(6, '0')) - toInt(subB.padEnd(6, '0'))
+  if (subDiff !== 0) return subDiff < 0 ? -1 : 1
+  return 0
+}
+
+/** Parse the persisted watermarks file. Tolerant by design: `undefined`,
+ *  empty, non-JSON, or a non-object JSON value all yield `{}`. Only
+ *  non-empty `string` → non-empty `string` entries survive, so a
+ *  hand-edited or half-written file cannot inject a junk channel id (which
+ *  would then be fed to conversations.history) or a non-string watermark
+ *  (which would break `compareSlackTs`). */
+export function parseWatermarks(raw: string | undefined | null): Watermarks {
+  if (typeof raw !== 'string' || raw.trim() === '') return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+  const out: Watermarks = {}
+  for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+    if (key.length > 0 && typeof val === 'string' && val.length > 0) {
+      out[key] = val
+    }
+  }
+  return out
+}
+
+/** Return the watermark map with `channel`'s mark advanced to `ts`, but only
+ *  when `ts` is strictly newer than the stored mark — a watermark never
+ *  regresses (monotonic). Returns the SAME object reference when nothing
+ *  changed, so the caller can skip a disk write. A `channel` or `ts` that
+ *  isn't a non-empty string is ignored (input returned unchanged). */
+export function advanceWatermark(current: Watermarks, channel: string, ts: string): Watermarks {
+  if (typeof channel !== 'string' || channel.length === 0) return current
+  if (typeof ts !== 'string' || ts.length === 0) return current
+  const existing = current[channel]
+  if (existing !== undefined && compareSlackTs(ts, existing) <= 0) return current
+  return { ...current, [channel]: ts }
+}
+
+/** From one channel's conversations.history batch, select the messages that
+ *  must be replayed after a (re)connect: strictly newer than `watermarkTs`,
+ *  deduped by `ts` (first occurrence wins), returned oldest → newest so the
+ *  replay preserves conversation order.
+ *
+ *  A message without a non-empty string `ts` is dropped — it can't be
+ *  ordered, deduped, or advance the watermark. When `watermarkTs` is
+ *  `undefined` every well-formed message qualifies, but in practice the
+ *  caller only runs catch-up for channels that already have a watermark.
+ *
+ *  Note the strict `> watermarkTs` filter here is the authoritative dedup
+ *  against the boundary message: Slack's `oldest` history parameter can be
+ *  inclusive of the exact-match `ts`, and that boundary message is the one
+ *  already processed — this drops it regardless of Slack's inclusive flag. */
+export function selectCatchupMessages<T extends { ts?: unknown }>(
+  messages: readonly T[],
+  watermarkTs: string | undefined,
+): T[] {
+  const seen = new Set<string>()
+  const selected: T[] = []
+  for (const m of messages) {
+    const ts = m.ts
+    if (typeof ts !== 'string' || ts.length === 0) continue
+    if (watermarkTs !== undefined && compareSlackTs(ts, watermarkTs) <= 0) continue
+    if (seen.has(ts)) continue
+    seen.add(ts)
+    selected.push(m)
+  }
+  selected.sort((x, y) => compareSlackTs(x.ts as string, y.ts as string))
+  return selected
+}
+
+// ---------------------------------------------------------------------------
 // Audit journal path resolution (ccsc-5pi.6)
 // ---------------------------------------------------------------------------
 

--- a/server.test.ts
+++ b/server.test.ts
@@ -21,6 +21,7 @@ import {
   AUDIT_RECEIPTS_MAX,
   type AuditReceiptPostArgs,
   type AuditReceiptPostError,
+  advanceWatermark,
   allowedSinkFor,
   assertNoSecretValues,
   assertOutboundAllowed,
@@ -32,6 +33,7 @@ import {
   type ChannelPolicy,
   chunkText,
   classifyDeliveryError,
+  compareSlackTs,
   computeBackoffMs,
   DELIVERY_METADATA_EVENT_TYPE,
   type DeliveryObligation,
@@ -63,6 +65,7 @@ import {
   PAIRING_EXPIRY_MS,
   PERMISSION_REPLY_RE,
   parseSendableRoots,
+  parseWatermarks,
   pruneExpired,
   redactSecretValues,
   resolveJournalPath,
@@ -76,9 +79,11 @@ import {
   saveSession,
   secretNameFromPlaceholder,
   secretPlaceholder,
+  selectCatchupMessages,
   sessionPath,
   shouldPostAuditReceipt,
   validateSendableRoots,
+  type Watermarks,
 } from './lib.ts'
 import {
   beginDurableStream,
@@ -2360,6 +2365,205 @@ describe('isDuplicateEvent', () => {
     expect(isDuplicateEvent(event, seen, 1000, 60000)).toBe(false)
     // `app_mention` subscription fires shortly after with the same event
     expect(isDuplicateEvent(event, seen, 1050, 60000)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Reconnect / startup catch-up watermarks (ccsc-reconnect-catchup)
+// ---------------------------------------------------------------------------
+
+describe('compareSlackTs', () => {
+  test('orders by the integer (seconds) part first', () => {
+    expect(compareSlackTs('1700000001.000000', '1700000000.999999')).toBeGreaterThan(0)
+    expect(compareSlackTs('1700000000.000000', '1700000001.000000')).toBeLessThan(0)
+  })
+
+  test('orders by the fractional counter when seconds are equal', () => {
+    expect(compareSlackTs('1700000000.000200', '1700000000.000100')).toBeGreaterThan(0)
+    expect(compareSlackTs('1700000000.000100', '1700000000.000200')).toBeLessThan(0)
+  })
+
+  test('returns 0 for identical timestamps', () => {
+    expect(compareSlackTs('1700000000.000100', '1700000000.000100')).toBe(0)
+  })
+
+  test('distinguishes ts that differ only in the last microsecond digit', () => {
+    // parseFloat would collapse these (16 significant digits); the
+    // integer-halves comparison keeps them distinct.
+    expect(compareSlackTs('1700000000.000001', '1700000000.000002')).toBeLessThan(0)
+  })
+
+  test('right-pads a short fractional part before comparing', () => {
+    // "5" means .500000, which is newer than .000100
+    expect(compareSlackTs('1700000000.5', '1700000000.000100')).toBeGreaterThan(0)
+  })
+
+  test('treats a ts with no dot as a whole-seconds value', () => {
+    expect(compareSlackTs('1700000001', '1700000000.999999')).toBeGreaterThan(0)
+    expect(compareSlackTs('1700000000', '1700000000.000001')).toBeLessThan(0)
+  })
+
+  test('a malformed half sorts as 0 rather than throwing', () => {
+    expect(compareSlackTs('abc.def', 'abc.def')).toBe(0)
+    expect(compareSlackTs('1700000000.xyz', '1700000000.000000')).toBe(0)
+    expect(() => compareSlackTs('', '')).not.toThrow()
+    expect(compareSlackTs('', '')).toBe(0)
+  })
+})
+
+describe('parseWatermarks', () => {
+  test('parses a well-formed channel→ts object', () => {
+    const raw = JSON.stringify({ C1: '1700000000.000100', C2: '1700000001.000200' })
+    expect(parseWatermarks(raw)).toEqual({
+      C1: '1700000000.000100',
+      C2: '1700000001.000200',
+    })
+  })
+
+  test('returns {} for undefined / null / empty / whitespace', () => {
+    expect(parseWatermarks(undefined)).toEqual({})
+    expect(parseWatermarks(null)).toEqual({})
+    expect(parseWatermarks('')).toEqual({})
+    expect(parseWatermarks('   ')).toEqual({})
+  })
+
+  test('returns {} on invalid JSON', () => {
+    expect(parseWatermarks('{ not json')).toEqual({})
+  })
+
+  test('returns {} for a JSON value that is not a plain object', () => {
+    expect(parseWatermarks('[]')).toEqual({})
+    expect(parseWatermarks('"C1"')).toEqual({})
+    expect(parseWatermarks('42')).toEqual({})
+    expect(parseWatermarks('null')).toEqual({})
+  })
+
+  test('drops entries whose value is not a non-empty string', () => {
+    const raw = JSON.stringify({
+      C1: '1700000000.000100',
+      C2: 12345,
+      C3: null,
+      C4: '',
+      C5: { nested: true },
+    })
+    expect(parseWatermarks(raw)).toEqual({ C1: '1700000000.000100' })
+  })
+
+  test('drops an empty-string key', () => {
+    const raw = JSON.stringify({ '': '1700000000.000100', C1: '1700000000.000200' })
+    expect(parseWatermarks(raw)).toEqual({ C1: '1700000000.000200' })
+  })
+})
+
+describe('advanceWatermark', () => {
+  test('advances a channel to a strictly newer ts', () => {
+    const cur: Watermarks = { C1: '1700000000.000100' }
+    const next = advanceWatermark(cur, 'C1', '1700000000.000200')
+    expect(next).toEqual({ C1: '1700000000.000200' })
+    expect(next).not.toBe(cur) // new reference when it changes
+  })
+
+  test('adds a brand-new channel', () => {
+    const cur: Watermarks = { C1: '1700000000.000100' }
+    const next = advanceWatermark(cur, 'C2', '1700000000.000050')
+    expect(next).toEqual({ C1: '1700000000.000100', C2: '1700000000.000050' })
+    expect(next).not.toBe(cur)
+  })
+
+  test('never regresses: an older ts returns the same reference', () => {
+    const cur: Watermarks = { C1: '1700000000.000200' }
+    const next = advanceWatermark(cur, 'C1', '1700000000.000100')
+    expect(next).toBe(cur)
+  })
+
+  test('an equal ts returns the same reference (idempotent)', () => {
+    const cur: Watermarks = { C1: '1700000000.000200' }
+    const next = advanceWatermark(cur, 'C1', '1700000000.000200')
+    expect(next).toBe(cur)
+  })
+
+  test('ignores an empty channel or empty ts (same reference)', () => {
+    const cur: Watermarks = { C1: '1700000000.000200' }
+    expect(advanceWatermark(cur, '', '1700000000.000300')).toBe(cur)
+    expect(advanceWatermark(cur, 'C1', '')).toBe(cur)
+  })
+
+  test('does not mutate the input map', () => {
+    const cur: Watermarks = { C1: '1700000000.000100' }
+    advanceWatermark(cur, 'C1', '1700000000.000200')
+    expect(cur).toEqual({ C1: '1700000000.000100' })
+  })
+})
+
+describe('selectCatchupMessages', () => {
+  test('keeps only messages strictly newer than the watermark', () => {
+    const msgs = [
+      { ts: '1700000000.000100', text: 'at-watermark' },
+      { ts: '1700000000.000050', text: 'older' },
+      { ts: '1700000000.000200', text: 'newer' },
+      { ts: '1700000000.000300', text: 'newest' },
+    ]
+    const out = selectCatchupMessages(msgs, '1700000000.000100')
+    expect(out.map((m) => m.text)).toEqual(['newer', 'newest'])
+  })
+
+  test('returns messages oldest → newest regardless of input order', () => {
+    const msgs = [
+      { ts: '1700000000.000300', text: 'c' },
+      { ts: '1700000000.000100', text: 'a' },
+      { ts: '1700000000.000200', text: 'b' },
+    ]
+    const out = selectCatchupMessages(msgs, '1700000000.000000')
+    expect(out.map((m) => m.text)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('dedups by ts (first occurrence wins)', () => {
+    const msgs = [
+      { ts: '1700000000.000200', text: 'first' },
+      { ts: '1700000000.000200', text: 'dup' },
+      { ts: '1700000000.000300', text: 'other' },
+    ]
+    const out = selectCatchupMessages(msgs, '1700000000.000100')
+    expect(out.map((m) => m.text)).toEqual(['first', 'other'])
+  })
+
+  test('drops messages without a usable string ts', () => {
+    const msgs = [
+      { ts: '1700000000.000200', text: 'ok' },
+      { ts: 12345, text: 'numeric-ts' },
+      { text: 'no-ts' },
+      { ts: '', text: 'empty-ts' },
+    ] as Array<{ ts?: unknown; text: string }>
+    const out = selectCatchupMessages(msgs, '1700000000.000100')
+    expect(out.map((m) => m.text)).toEqual(['ok'])
+  })
+
+  test('returns [] when nothing is newer than the watermark', () => {
+    const msgs = [
+      { ts: '1700000000.000050', text: 'a' },
+      { ts: '1700000000.000100', text: 'b' },
+    ]
+    expect(selectCatchupMessages(msgs, '1700000000.000100')).toEqual([])
+  })
+
+  test('returns [] for an empty batch', () => {
+    expect(selectCatchupMessages([], '1700000000.000100')).toEqual([])
+  })
+
+  test('an undefined watermark keeps every well-formed message', () => {
+    const msgs = [
+      { ts: '1700000000.000200', text: 'b' },
+      { ts: '1700000000.000100', text: 'a' },
+    ]
+    const out = selectCatchupMessages(msgs, undefined)
+    expect(out.map((m) => m.text)).toEqual(['a', 'b'])
+  })
+
+  test('drops the exact-watermark boundary message (Slack oldest inclusivity)', () => {
+    // Slack's `oldest` history param can echo back the boundary message;
+    // it is the one already processed, so strict filtering must drop it.
+    const msgs = [{ ts: '1700000000.000100', text: 'boundary' }]
+    expect(selectCatchupMessages(msgs, '1700000000.000100')).toEqual([])
   })
 })
 

--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,7 @@ import { createBootAnchor, JournalWriter, verifyJournal } from './journal.ts'
 import {
   type Access,
   AUDIT_RECEIPTS_MAX,
+  advanceWatermark,
   assertManifestIdentityResolved,
   assertPublishAllowed,
   buildAndPostAuditReceipt,
@@ -67,6 +68,7 @@ import {
   parseSendableRoots,
   parseV2FloorSeqArg,
   parseVerifyArg,
+  parseWatermarks,
   permissionPairingKey as permKey,
   pruneExpired,
   recordApprovalVote,
@@ -74,8 +76,10 @@ import {
   resolveJournalPath,
   sanitizeDisplayName,
   sanitizeFilename,
+  selectCatchupMessages,
   stripBotMention,
   validateSendableRoots,
+  type Watermarks,
 } from './lib.ts'
 import {
   assertPublishSizeAndSerialize,
@@ -192,6 +196,8 @@ const STATE_DIR = process.env.SLACK_STATE_DIR || join(homedir(), '.claude', 'cha
 const ENV_FILE = join(STATE_DIR, '.env')
 const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const INBOX_DIR = join(STATE_DIR, 'inbox')
+// Per-channel reconnect/startup catch-up watermarks (ccsc-reconnect-catchup).
+const WATERMARK_FILE = join(STATE_DIR, 'watermarks.json')
 const DEFAULT_CHUNK_LIMIT = 4000
 
 // File-exfil allowlist: additional roots beyond INBOX_DIR from which the
@@ -328,6 +334,38 @@ function saveAccess(access: Access): void {
   writeFileSync(tmp, JSON.stringify(access, null, 2), { mode: 0o600, flag: 'w' })
   renameSync(tmp, ACCESS_FILE)
 }
+
+// ---------------------------------------------------------------------------
+// Reconnect catch-up watermarks — load / save (ccsc-reconnect-catchup)
+// ---------------------------------------------------------------------------
+//
+// See lib.ts "Reconnect / startup catch-up watermarks" for the rationale.
+// Persistence mirrors saveAccess exactly: pid-qualified tmp file, mode 0o600
+// passed to writeFileSync so the file is never momentarily world-readable,
+// then an atomic rename. The in-memory `watermarks` map is the source of
+// truth at runtime; the file is only read at boot and after a corrupt-parse
+// it degrades to `{}` (catch-up simply finds no channels — fail-open toward
+// "no replay", never a crash).
+
+function loadWatermarks(): Watermarks {
+  if (!existsSync(WATERMARK_FILE)) return {}
+  try {
+    return parseWatermarks(readFileSync(WATERMARK_FILE, 'utf-8'))
+  } catch {
+    return {}
+  }
+}
+
+function saveWatermarks(wm: Watermarks): void {
+  const tmp = `${WATERMARK_FILE}.tmp.${process.pid}`
+  writeFileSync(tmp, JSON.stringify(wm, null, 2), { mode: 0o600, flag: 'w' })
+  renameSync(tmp, WATERMARK_FILE)
+}
+
+/** In-memory per-channel watermark map. Loaded once at boot, advanced by
+ *  handleMessage after each message is fully handled, and consulted by the
+ *  reconnect catch-up. */
+let watermarks: Watermarks = loadWatermarks()
 
 // ---------------------------------------------------------------------------
 // Static mode
@@ -3292,7 +3330,7 @@ async function handleMessage(event: unknown): Promise<void> {
         },
         ...(result.dropReason !== undefined ? { reason: result.dropReason } : {}),
       })
-      return
+      break
     }
 
     case 'pair': {
@@ -3317,18 +3355,46 @@ async function handleMessage(event: unknown): Promise<void> {
         unfurl_links: false,
         unfurl_media: false,
       })
-      return
+      break
     }
 
     case 'deliver': {
       // ccsc-0jj — admin verb detection BEFORE delivering to Claude.
       // If the message is an admin verb (!clear / !restart / !mute /
-      // !unmute), dispatch it through admin.ts and return WITHOUT
-      // also delivering to Claude (Claude shouldn't see operator
-      // verbs as chat content).
+      // !unmute), dispatch it through admin.ts and do NOT also deliver
+      // to Claude (Claude shouldn't see operator verbs as chat content).
       const handled = await tryDispatchAdminVerb(ev, result.access!)
-      if (handled) return
-      await deliverEvent(ev, result.access!)
+      if (!handled) await deliverEvent(ev, result.access!)
+      break
+    }
+  }
+
+  // Advance the per-channel catch-up watermark now that this message has been
+  // fully handled (whatever the gate decided — deliver / drop / pair). On the
+  // next startup (or a mid-session reconnect) the catch-up pulls
+  // conversations.history for everything newer than this mark and replays it
+  // through gate(), so a host that was asleep/rebooted doesn't silently lose
+  // the messages Slack didn't redeliver. We advance on drops too, so a
+  // self-echo or peer-bot message the gate rejected isn't needlessly
+  // re-fetched and re-dropped every reconnect. Reached only on a clean
+  // return from the switch — if gate() threw, the message is NOT marked
+  // processed and will be picked up by the next catch-up. Persisted
+  // atomically; the write is skipped when the mark didn't move, and a write
+  // failure is logged but never breaks message handling.
+  const wmChannel = ev.channel
+  const wmTs = ev.ts
+  if (typeof wmChannel === 'string' && typeof wmTs === 'string') {
+    const next = advanceWatermark(watermarks, wmChannel, wmTs)
+    if (next !== watermarks) {
+      watermarks = next
+      try {
+        saveWatermarks(watermarks)
+      } catch (err) {
+        console.error(
+          '[slack] failed to persist catch-up watermark:',
+          err instanceof Error ? err.message : err,
+        )
+      }
     }
   }
 }
@@ -3526,6 +3592,110 @@ socket.on('app_mention', async ({ event, ack }) => {
   } catch (err) {
     console.error('[slack] Error handling mention:', err)
   }
+})
+
+// ---------------------------------------------------------------------------
+// Reconnect / startup catch-up (ccsc-reconnect-catchup)
+// ---------------------------------------------------------------------------
+//
+// Socket Mode does NOT redeliver events sent while the app was disconnected.
+// When the host sleeps, reboots, or crashes — or the socket briefly drops
+// mid-session — every message the operator sent in the gap is lost, because
+// the bridge never asked Slack for history on (re)connect. This closes that
+// hole: for each channel with a persisted watermark, pull
+// conversations.history since the mark and replay the missed messages
+// through the EXACT SAME handleMessage() path the live socket uses.
+//
+// SECURITY: replay MUST go through handleMessage → gate(). Nothing here
+// short-circuits the inbound gate, the self-echo triple-check, the
+// allowlist, the peer-bot filter, or admin-verb handling. A message
+// recovered from history is treated identically to one that arrived live —
+// including being dropped if the gate says so. Dedup is layered: (1)
+// selectCatchupMessages drops anything at-or-before the watermark and any
+// duplicate ts within the batch, and (2) handleMessage's isDuplicateEvent
+// guard drops anything already processed live within the dedup TTL, so a
+// message that arrived live during the catch-up window is never
+// double-handled.
+
+/** Serializes catch-up runs so the initial-connect pass and a fast
+ *  reconnect can't overlap and double-fetch. */
+let catchupInFlight = false
+/** The socket-mode client emits 'connected' on the FIRST connect as well as
+ *  on every auto-reconnect. The first 'connected' is handled by the explicit
+ *  call in main() after socket.start() resolves; this flag lets the listener
+ *  skip that first event so the initial connect doesn't run catch-up twice. */
+let sawInitialConnect = false
+
+async function runReconnectCatchup(trigger: 'startup' | 'reconnect'): Promise<void> {
+  if (catchupInFlight) {
+    console.error(`[slack] catch-up already running; skipping ${trigger} trigger`)
+    return
+  }
+  catchupInFlight = true
+  try {
+    // Snapshot the channel set up front. handleMessage mutates `watermarks`
+    // as it replays, but we always query with the pre-replay mark per
+    // channel, and selectCatchupMessages re-filters, so the live mutation
+    // can't skip or duplicate a message.
+    const channels = Object.keys(watermarks)
+    if (channels.length === 0) return
+    console.error(
+      `[slack] reconnect catch-up (${trigger}): checking ${channels.length} channel(s) for messages missed while disconnected`,
+    )
+    for (const channel of channels) {
+      const watermarkTs = watermarks[channel]
+      if (watermarkTs === undefined) continue
+      try {
+        // `oldest` bounds the fetch; selectCatchupMessages is the
+        // authoritative strictly-newer-than filter (Slack's `oldest` can be
+        // inclusive of the boundary message, which is the one we already
+        // processed).
+        const res = await web.conversations.history({ channel, oldest: watermarkTs })
+        const raw = (res.messages ?? []) as Array<Record<string, unknown>>
+        const missed = selectCatchupMessages(raw, watermarkTs)
+        if (missed.length === 0) continue
+        console.error(
+          `[slack] reconnect catch-up: replaying ${missed.length} missed message(s) in ${channel}`,
+        )
+        for (const m of missed) {
+          // conversations.history omits the channel id (it was the query
+          // param); inject it so gate()/handleMessage see the same shape a
+          // live socket event carries. Replay one at a time, oldest→newest,
+          // through the full gate path.
+          try {
+            await handleMessage({ ...m, channel })
+          } catch (err) {
+            console.error(
+              `[slack] reconnect catch-up: error replaying message in ${channel}:`,
+              err instanceof Error ? err.message : err,
+            )
+          }
+        }
+      } catch (err) {
+        // Best-effort per channel: a history error (rate limit,
+        // not_in_channel, revoked scope, transient 5xx) must never crash
+        // startup or abort catch-up for the other channels.
+        console.error(
+          `[slack] reconnect catch-up failed for ${channel}:`,
+          err instanceof Error ? err.message : err,
+        )
+      }
+    }
+  } finally {
+    catchupInFlight = false
+  }
+}
+
+// Mid-session reconnect: the client re-emits 'connected' after an
+// auto-reconnect. Skip the very first (initial) connect — that one is
+// covered by the explicit startup catch-up in main() — and run catch-up on
+// every subsequent reconnect so a brief socket drop still recovers its gap.
+socket.on('connected', () => {
+  if (!sawInitialConnect) {
+    sawInitialConnect = true
+    return
+  }
+  void runReconnectCatchup('reconnect')
 })
 
 // ---------------------------------------------------------------------------
@@ -3925,6 +4095,13 @@ async function main(): Promise<void> {
       try {
         await socket.start()
         console.error('[slack] Socket Mode connected')
+        // One-time startup catch-up: recover the messages Slack didn't
+        // redeliver while this host was down. Fire-and-forget so it never
+        // delays boot; it replays through gate() and swallows per-channel
+        // errors internally. The 'connected' listener above skips the
+        // initial connect, so this is the only catch-up for the first
+        // connection (no double-run).
+        void runReconnectCatchup('startup')
         return
       } catch (err) {
         attempt += 1


### PR DESCRIPTION
Slack Socket Mode does **not** redeliver events sent while the app was disconnected, so any message the operator sent during a host sleep/reboot/crash — or a brief mid-session socket drop — was silently lost: the bridge never pulled `conversations.history` on (re)connect.

## What this adds

A per-channel **high-water mark** (`STATE_DIR/watermarks.json`, atomic `0o600` write mirroring `saveAccess`) recording the `ts` of the last message `handleMessage()` finished processing. On startup after `socket.start()` and on every subsequent `'connected'` reconnect, a one-time catch-up pulls `conversations.history` since the mark for each watermarked channel and replays missed messages through the **exact same** `handleMessage()` → `gate()` path the live socket uses.

## Security

Replay never bypasses the inbound gate, self-echo triple-check, allowlist, peer-bot filter, or admin-verb handling — a recovered message is treated identically to a live one (dropped if the gate says so). Dedup is layered: `selectCatchupMessages` drops anything at-or-before the watermark + duplicate `ts` within a batch; `handleMessage`'s `isDuplicateEvent` guard drops anything already processed live, so a message arriving live during the catch-up window is never double-handled. Per-channel history errors are swallowed and logged — catch-up is best-effort and never crashes startup.

## Structure

Pure core in `lib.ts` (`parseWatermarks` / `advanceWatermark` [monotonic] / `selectCatchupMessages` [strict > watermark, dedup, oldest→newest] / `compareSlackTs` [integer-halves compare, precision-exact]) with 27 new `bun:test` unit tests. Wiring stays in `server.ts`. Initial-connect double-run guarded (the `'connected'` listener skips the first event; a `catchupInFlight` flag serializes overlapping runs).

## Verification

- `bun run typecheck` clean
- `bun test` — **1331 pass / 0 fail**

> Note: complements the operator's separate goal of a reboot autostart — this ensures that once the bridge *is* back up, messages sent while it was down get replayed rather than lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)