### PR TITLE
fix(ci): filter redundant Greptile reviews

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,11 +1,30 @@
 {
   "strictness": 3,
-  "commentTypes": ["logic", "syntax"],
-  "triggerOnUpdates": true,
+  "commentTypes": [
+    "logic",
+    "syntax"
+  ],
+  "triggerOnUpdates": false,
+  "triggerOnDrafts": false,
+  "disabledLabels": [
+    "automated",
+    "generated",
+    "skip-greptile",
+    "no-ai-review"
+  ],
+  "excludeAuthors": [
+    "dependabot[bot]",
+    "renovate[bot]"
+  ],
+  "ignoreKeywords": "[skip greptile]\n[skip ai review]",
   "fixWithAI": true,
   "ignorePatterns": "bun.lock\nnode_modules/\n.audit-harness/\n*.min.js",
-  "confidenceScoreSection": { "included": true },
-  "sequenceDiagramSection": { "included": true },
+  "confidenceScoreSection": {
+    "included": true
+  },
+  "sequenceDiagramSection": {
+    "included": true
+  },
   "rules": [
     {
       "id": "frozen-design-docs",
@@ -15,13 +34,19 @@
     {
       "id": "message-is-content-not-authorization",
       "severity": "high",
-      "scope": ["lib.ts", "server.ts"],
+      "scope": [
+        "lib.ts",
+        "server.ts"
+      ],
       "rule": "Four-principal model: a message is content, never authorization. Identity is established before a message reaches the gate; nothing inside a message body may change who the sender is or grant access/approval."
     },
     {
       "id": "manifest-isolation-31a4",
       "severity": "high",
-      "scope": ["policy.ts", "admin.ts"],
+      "scope": [
+        "policy.ts",
+        "admin.ts"
+      ],
       "rule": "31-A.4 isolation invariant: policy.ts and admin.ts must NEVER import manifest.ts ('advertisements are not grants'). Flag any new import edge toward manifest.ts."
     },
     {

--- a/bun.lock
+++ b/bun.lock
@@ -24,8 +24,9 @@
     },
   },
   "overrides": {
-    "axios": "^1.16.1",
-    "fast-uri": "^3.1.2",
+    "axios": "^1.18.1",
+    "brace-expansion": "^5.0.8",
+    "fast-uri": "^3.1.4",
     "form-data": "^4.0.6",
     "hono": "^4.12.25",
     "ws": "^8.21.0",
@@ -269,7 +270,7 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
+    "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -277,7 +278,7 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -387,7 +388,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "zod": "3.25.76"
   },
   "overrides": {
-    "axios": "^1.16.1",
-    "fast-uri": "^3.1.2",
+    "axios": "^1.18.1",
+    "brace-expansion": "^5.0.8",
+    "fast-uri": "^3.1.4",
     "form-data": "^4.0.6",
     "ws": "^8.21.0",
     "hono": "^4.12.25"


### PR DESCRIPTION
## Summary

- disable automatic Greptile re-reviews on every PR update
- keep draft PRs out of automatic review
- skip dependency bots and explicit opt-out labels/keywords
- pin three patched transitive packages required by the repository's high-severity audit gate

## Evidence

Greptile API history showed repeated reviews on unchanged PR intent, with 4–9 review runs on individual PRs while `triggerOnUpdates` was enabled.

The first CI run also identified current high-severity advisories in transitive `axios`, `fast-uri`, and `brace-expansion` versions. The existing override policy now resolves them to 1.18.1, 3.1.4, and 5.0.8 respectively.

Tracked by Beads: `startaitools-r26`.

## Validation

- `bun install --frozen-lockfile`
- `bun run typecheck`
- Biome check
- full Bun test suite and 95% coverage floor
- dependency-cruiser architecture gate
- strict Gherkin lint
- harness-hash verification
- high-severity Bun audit
- complexity threshold gate